### PR TITLE
Update ressources.data.sncf.com.dmfr.json

### DIFF
--- a/feeds/ressources.data.sncf.com.dmfr.json
+++ b/feeds/ressources.data.sncf.com.dmfr.json
@@ -3,9 +3,9 @@
   "feeds": [
     {
       "spec": "gtfs",
-      "id": "f-u0-sncf~tram~train~ter",
+      "id": "f-u0-sncf~ter",
       "urls": {
-        "static_current": "https://ressources.data.sncf.com/explore/dataset/sncf-tram-train-ter-pdl-gtfs/files/f517d7646d71f8ad65f496835bd569c8/download/"
+        "static_current": "https://data.sncf.com/explore/dataset/sncf-ter-gtfs/files/24e02fa969496e2caa5863a365c66ec2/download"
       },
       "license": {
         "url": "http://data.sncf.com/licence"


### PR DESCRIPTION
Replace SNCF regional feed by SNCF national feed (previous feed was for trains in region "Pays de la loire" only, new feed is for all TER trains in France)