### PR TITLE
latest SEPTA feed versions

### DIFF
--- a/feeds/github.com.dmfr.json
+++ b/feeds/github.com.dmfr.json
@@ -38,7 +38,7 @@
       "spec": "gtfs",
       "id": "f-dr4-septa~rail",
       "urls": {
-        "static_current": "https://github.com/septadev/GTFS/releases/download/v201912150/gtfs_public.zip#google_rail.zip"
+        "static_current": "https://github.com/septadev/GTFS/releases/download/v202003220/gtfs_public.zip#google_rail.zip"
       },
       "license": {
         "url": "http://www3.septa.org/developer/",
@@ -52,7 +52,7 @@
       "spec": "gtfs",
       "id": "f-dr4-septa~bus",
       "urls": {
-        "static_current": "https://github.com/septadev/GTFS/releases/download/v201912150/gtfs_public.zip#google_bus.zip"
+        "static_current": "https://github.com/septadev/GTFS/releases/download/v202003220/gtfs_public.zip#google_bus.zip"
       },
       "license": {
         "url": "http://www3.septa.org/developer/"


### PR DESCRIPTION

https://github.com/septadev/GTFS/releases/tag/v202003220