### PR TITLE
added f-9r0-trinity~ca~us 

### DIFF
--- a/feeds/data.trilliumtransit.com.dmfr.json
+++ b/feeds/data.trilliumtransit.com.dmfr.json
@@ -2051,6 +2051,14 @@
       "urls": {
         "static_current": "http://data.trilliumtransit.com/gtfs/maderactc-ca-us/maderactc-ca-us.zip"
       }
+    },
+        {
+      "spec": "gtfs",
+      "id": "f-9r0-trinity~ca~us",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/weaverville-ca-us/weaverville-ca-us.zip"
+      },
+      "feed_namespace_id": "o-9r0-trinitytransit"
     }
   ],
   "license_spdx_identifier": "CDLA-Permissive-1.0"


### PR DESCRIPTION
static_current is incorrect on website, but trinity isn't in the other dmfr.json files