### PR TITLE
Add Swiftly's GTFS-rt feeds for RTA Maryland

### DIFF
--- a/feeds/api.goswift.ly.dmfr.json
+++ b/feeds/api.goswift.ly.dmfr.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.3.0.json",
+  "feeds": [
+    {
+      "spec": "gtfs-rt",
+      "id": "f-dqcq-regionaltransportationagencyofcentralmaryland~rt",
+      "associated_feeds": [
+        "f-dqcq-regionaltransportationagencyofcentralmaryland"
+      ],
+      "urls": {
+        "realtime_alerts": "https://api.goswift.ly/real-time/rtamaryland/gtfs-rt-alerts",
+        "realtime_trip_updates": "https://api.goswift.ly/real-time/rtamaryland/gtfs-rt-trip-updates",
+        "realtime_vehicle_positions": "https://api.goswift.ly/real-time/rtamaryland/gtfs-rt-vehicle-positions"
+      },
+      "license": {
+        "url": "https://www.goswift.ly/api-license",
+      },
+      "authorization": {
+        "type": "header",
+        "param_name": "Authorization",
+      }
+    }
+  ],
+  "license_spdx_identifier": "CDLA-Permissive-1.0"
+}


### PR DESCRIPTION
Alternative PR to #61 using a separate DMFR.json file instead of the agency-specific one 