### PR TITLE
Baden-Württemberg feeds

### DIFF
--- a/feeds/nvbw.de.dmfr.json
+++ b/feeds/nvbw.de.dmfr.json
@@ -1,0 +1,282 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.3.0.json",
+  "feeds": [
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~bodo",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/bodo.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~ding",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/ding.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~filsland",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/filsland.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~hnv",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/hnv.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~ding",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/ding.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~kvsh",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/kvsh.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~naldo",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/naldo.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~oam",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/oam.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~rab",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/rab.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~rbs",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_ohne_liniennetz/rbs.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~rxr",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/rxr.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~rvs",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/rvs.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~sbg",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/sbg.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~sweg",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/sweg.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~swhn",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/swhn.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~tgo",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/tgo.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~tuticket",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/tuticket.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~vgc",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/vgc.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~vgf",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/vgf.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~vhb",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/vhb.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~vpe",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/vpe.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~bwspnv",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/bwspnv.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    },
+    { 
+      "spec": "gtfs",
+      "id": "f-nvbw~bwsbahnubahn",
+      "urls": {
+        "current_static": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/bwsbahnubahn.zip"
+      },
+      "license": {
+        "url": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz",
+        "attribution_text": "NVBW GmbH data record and © OpenStreetMap",
+        "use_without_attribution": "no"
+      }
+    }
+  ],
+  "license_spdx_identifier": "CDLA-Permissive-1.0"
+}


### PR DESCRIPTION
extracted from https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz using

```
http https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz | pup 'a attr{href}' | rg '.zip'
```

closes #118