### PR TITLE
Update rtd-denver.com.dmfr.json

### DIFF
--- a/feeds/rtd-denver.com.dmfr.json
+++ b/feeds/rtd-denver.com.dmfr.json
@@ -5,7 +5,7 @@
       "spec": "gtfs",
       "id": "f-9xj-rtd",
       "urls": {
-        "static_current": "http://www.rtd-denver.com/GoogleFeeder/google_transit.zip"
+        "static_current": "https://www.rtd-denver.com/files/gtfs/google_transit.zip"
       },
       "license": {
         "url": "https://www.rtd-denver.com/business-center/open-spatial-data/gtfs-license-agreement",
@@ -19,19 +19,16 @@
       "spec": "gtfs-rt",
       "id": "f-rtddenver~rt",
       "urls": {
-        "realtime_trip_updates": "http://www.rtd-denver.com/google_sync/TripUpdate.pb",
-        "realtime_vehicle_positions": "http://www.rtd-denver.com/google_sync/VehiclePosition.pb"
+        "realtime_alerts": "https://www.rtd-denver.com/files/gtfs-rt/Alerts.pb",
+        "realtime_trip_updates": "https://www.rtd-denver.com/files/gtfs-rt/TripUpdate.pb",
+        "realtime_vehicle_positions": "https://www.rtd-denver.com/files/gtfs-rt/VehiclePosition.pb"
       },
       "feed_namespace_id": "o-9xj-regionaltransportationdistrict",
       "associated_feeds": [
         "f-9xj-rtd"
       ],
       "license": {
-        "url": "https://www.rtd-denver.com/business-center/open-data/gtfs-developer-guide"
-      },
-      "authorization": {
-        "type": "basic_auth",
-        "info_url": "https://www.rtd-denver.com/business-center/open-data/gtfs-developer-guide"
+        "url": "https://www.rtd-denver.com/business-center/open-spatial-data/gtfs-realtime-license-agreement"
       }
     }
   ],


### PR DESCRIPTION
On Tuesday, December 1, RTD updated the locations of its GTFS and GTFS-RT files. It also removed the Basic Auth requirement for its GTFS-RT feeds. This PR reflects those changes.

Changes:
- Update URL for current static feed
- Update URL for realtime trip updates
- Update URL for realtime vehicle positions
- Update URL for GTFS-RT license agreement
- Add URL for realtime alerts
- Remove authorization for GTFS-RT spec