### PR TITLE
Update daten.transparenz.hamburg.de.dmfr.json

### DIFF
--- a/feeds/daten.transparenz.hamburg.de.dmfr.json
+++ b/feeds/daten.transparenz.hamburg.de.dmfr.json
@@ -5,14 +5,14 @@
       "spec": "gtfs",
       "id": "f-u1-hamburgerverkehrsverbundhvv~hamburgerverkehrsverbundhvv~ham",
       "urls": {
-        "static_current": "http://daten.transparenz.hamburg.de/Dataport.HmbTG.ZS.Webservice.GetRessource100/GetRessource100.svc/1fd45eb0-1f44-4f4d-82b4-26a9c3f49255/Upload__HVV_Rohdaten_GTFS_Fpl_20170907.zip"
+        "static_current": "http://daten.transparenz.hamburg.de/Dataport.HmbTG.ZS.Webservice.GetRessource100/GetRessource100.svc/b5f71a77-e622-4b34-82d4-c921a9c71be5/Upload__HVV_Rohdaten_GTFS_Fpl_20200211.zip"
       },
       "license": {
         "url": "https://www.govdata.de/dl-de/by-2-0",
         "use_without_attribution": "no",
         "create_derived_product": "yes",
         "redistribute": "yes",
-        "attribution_text": "Hamburger Verkehrsverbund GmbH, dl-de/by-2-0 (www.govdata.de/dl-de/by-2-0), http://suche.transparenz.hamburg.de/dataset/hvv-fahrplandaten-gtfs-september-2017-bis-dezember-2017"
+        "attribution_text": "Hamburger Verkehrsverbund GmbH, dl-de/by-2-0 (www.govdata.de/dl-de/by-2-0), https://suche.transparenz.hamburg.de/dataset/hvv-fahrplandaten-gtfs-februar-2020-bis-dezember-2020"
       },
       "feed_namespace_id": "o-u1x-hamburgerverkehrsverbundhvv"
     }


### PR DESCRIPTION
A new version of this feed for Hamburg, Germany and nearby cities was available.

Previous version published at: 08.09.2017 
New version published at: 11.02.2020

Source (German): https://suche.transparenz.hamburg.de/dataset/hvv-fahrplandaten-gtfs-februar-2020-bis-dezember-2020
Previous Version: http://suche.transparenz.hamburg.de/dataset/hvv-fahrplandaten-gtfs-september-2017-bis-dezember-2017