### PR TITLE
Add feed_namespace_ids to Swiftly feeds

### DIFF
--- a/feeds/api.goswift.ly.dmfr.json
+++ b/feeds/api.goswift.ly.dmfr.json
@@ -4,6 +4,7 @@
     {
       "spec": "gtfs-rt",
       "id": "f-9xj5s-viamobilityservices~rt",
+      "feed_namespace_id": "o-9xj5s-viamobilityservices",
       "associated_feeds": [
         "f-9xj5s-viamobilityservices~co~us"
       ],
@@ -24,6 +25,7 @@
     {
       "spec": "gtfs-rt",
       "id": "f-dqcq-regionaltransportationagencyofcentralmaryland~rt",
+      "feed_namespace_id": "o-dqcq-regionaltransportationagencyofcentralmaryland",
       "associated_feeds": [
         "f-dqcq-regionaltransportationagencyofcentralmaryland"
       ],


### PR DESCRIPTION
### Problem
GTFS-realtime feeds are not showing up in Transitland V2 pages:
- https://www.transit.land/operators/o-9xj5s-viamobilityservices
- https://www.transit.land/operators/o-dqcq-regionaltransportationagencyofcentralmaryland

### Solution
I believe the issue is because `feed_namespace_id` is not set. `associated_feeds` is set, but appears insufficient.

This PR sets those values for the feeds