### PR TITLE
MARTA

### DIFF
--- a/feeds/itsmarta.com.dmfr.json
+++ b/feeds/itsmarta.com.dmfr.json
@@ -5,7 +5,7 @@
       "spec": "gtfs",
       "id": "f-dnh-marta",
       "urls": {
-        "static_current": "https://www.itsmarta.com/google_transit_feed/google_transit.zip#GTFS-10222020"
+        "static_current": "https://www.itsmarta.com/google_transit_feed/google_transit.zip"
       },
       "feed_namespace_id": "o-dnh-metropolitanatlantarapidtransitauthority"
     }


### PR DESCRIPTION
MARTA changed the name of the directory within the zip where it nests its GTFS files.

We can now auto-detect the directory testing: https://github.com/interline-io/transitland-lib/pull/105