### PR TITLE
Update gitlab.com.dmfr.json

### DIFF
--- a/feeds/gitlab.com.dmfr.json
+++ b/feeds/gitlab.com.dmfr.json
@@ -67,13 +67,6 @@
     },
     {
       "spec": "gtfs",
-      "id": "f-lynwood~trolley",
-      "urls": {
-        "static_current": "https://gitlab.com/LACMTA/gtfs_lax/-/archive/master/gtfs_lax-master.zip?path=lynwood_trolley#lynwood_trolley"
-      }
-    },
-    {
-      "spec": "gtfs",
       "id": "f-santa~clarita",
       "urls": {
         "static_current": "https://gitlab.com/LACMTA/gtfs_lax/-/archive/master/gtfs_lax-master.zip?path=santa_clarita#santa_clarita"


### PR DESCRIPTION
Moving Lynwood Trolley GTFS feed URL to `trilliumtransit.com.dmfr.json`