### PR TITLE
SEPTA operator

### DIFF
--- a/operators/o-dr4-septa.json
+++ b/operators/o-dr4-septa.json
@@ -10,7 +10,7 @@
   "associated_feeds": [
     {
       "feed_onestop_id": "f-dr4-septa~rail",
-      "gtfs_agency_id": ""
+      "gtfs_agency_id": "SEPTA"
     },
     {
       "feed_onestop_id": "f-dr4-septa~bus",


### PR DESCRIPTION
one feed does have `agency_id` (the other does not)