### PR TITLE
Associate TCAT realtime feed with operator

### DIFF
--- a/feeds/tcatbus.com.dmfr.json
+++ b/feeds/tcatbus.com.dmfr.json
@@ -7,20 +7,7 @@
       "urls": {
         "static_current": "https://s3.amazonaws.com/tcat-gtfs/tcat-ny-us.zip"
       },
-      "feed_namespace_id": "o-dr997-tompkinsconsolidatedareatransit",
-      "operators": [
-        {
-          "onestop_id": "o-dr997-tompkinsconsolidatedareatransit",
-          "tags": {
-            "us_ntd_id": "20145",
-            "wikidata_id": "Q7820360",
-            "twitter_general": "tcatrides"
-          },
-          "name": "Tompkins Consolidated Area Transit",
-          "short_name": "TCAT",
-          "website": "https://tcatbus.com/"
-        }
-      ]
+      "feed_namespace_id": "o-dr997-tompkinsconsolidatedareatransit"
     },
     {
       "spec": "gtfs-rt",
@@ -29,8 +16,33 @@
         "realtime_trip_updates": "https://realtimetcatbus.availtec.com/InfoPoint/GTFS-Realtime.ashx?&Type=TripUpdate",
         "realtime_vehicle_positions": "https://realtimetcatbus.availtec.com/InfoPoint/GTFS-Realtime.ashx?&Type=VehiclePosition&serverid=0",
         "realtime_alerts": "https://realtimetcatbus.availtec.com/InfoPoint/GTFS-Realtime.ashx?&Type=Alert"
-      }
+      },
+      "feed_namespace_id": "o-dr997-tompkinsconsolidatedareatransit",
+      "associated_feeds": [
+        "f-dr997-tompkinsconsolidatedareatransit"
+      ]
     }
   ],
-  "license_spdx_identifier": "CDLA-Permissive-1.0"
+  "license_spdx_identifier": "CDLA-Permissive-1.0",
+  "operators": [
+    {
+      "onestop_id": "o-dr997-tompkinsconsolidatedareatransit",
+      "tags": {
+        "us_ntd_id": "20145",
+        "wikidata_id": "Q7820360",
+        "twitter_general": "tcatrides"
+      },
+      "name": "Tompkins Consolidated Area Transit",
+      "short_name": "TCAT",
+      "website": "https://tcatbus.com/",
+      "associated_feeds": [
+        {
+          "feed_onestop_id": "f-tompkinsconsolidatedareatransit~rt"
+        },
+        {
+          "feed_onestop_id": "f-dr997-tompkinsconsolidatedareatransit"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
TCAT has a realtime feed defined but it isn't correctly associated with it on the website. I followed the BART DMFR JSON as a guide to attempt to fix this.