### PR TITLE
Update URL for dartfirststate

### DIFF
--- a/feeds/dartfirststate.com.dmfr.json
+++ b/feeds/dartfirststate.com.dmfr.json
@@ -5,7 +5,7 @@
       "spec": "gtfs",
       "id": "f-dr4-dartfirststate",
       "urls": {
-        "static_current": "http://dartfirststate.com/information/routes/gtfs_data/dartfirststate_de_us.zip"
+        "static_current": "https://dartfirststate.com/RiderInfo/Routes/gtfs_data/dartfirststate_de_us.zip"
       },
       "feed_namespace_id": "o-dr4-dartfirststate",
       "operators": [


### PR DESCRIPTION
DART has changed the URL where GTFS can be found.