### PR TITLE
Update URL for f-dqc-thebusofprincegeorgescounty

### DIFF
--- a/feeds/mobilityeqity.github.com.dmfr.json
+++ b/feeds/mobilityeqity.github.com.dmfr.json
@@ -329,15 +329,11 @@
         "static_current": "https://www.princegeorgescountymd.gov/DocumentCenter/View/35935/TheBUS_GTFS_v05_2021"
       },
       "license": {
-        "url": "https://github.com/mobilityequity/maryland-local-gtfs/blob/master/README.md",
-        "use_without_attribution": "no",
-        "attribution_instructions": "when using MTI data or software in projects, maps, etc.; you agree to acknowledge MTI as a data source (https://mti.umd.edu/).",
-        "create_derived_product": "yes",
-        "redistribute": "yes",
-        "commercial_use_allowed": "yes",
-        "share_alike_optional": "yes"
+        "url": "https://www.princegeorgescountymd.gov/1122/Routes-Schedules"
       },
-      "feed_namespace_id": "o-dqc-thebusofprincegeorgescounty",
+      "tags": {
+        "unstable_url": "true"
+      },
       "operators": [
         {
           "onestop_id": "o-dqc-thebusofprincegeorgescounty",
@@ -348,7 +344,7 @@
           },
           "name": "Prince George's County",
           "short_name": "The Bus",
-          "website": "http://www.princegeorgescountymd.gov/sites/PublicWorks/Transit/TheBus/Pages/default.aspx",
+          "website": "https://www.princegeorgescountymd.gov/1120/Countys-TheBus",
           "associated_feeds": [
             {
               "gtfs_agency_id": "4"

--- a/feeds/mobilityeqity.github.com.dmfr.json
+++ b/feeds/mobilityeqity.github.com.dmfr.json
@@ -326,7 +326,7 @@
       "spec": "gtfs",
       "id": "f-dqc-thebusofprincegeorgescounty",
       "urls": {
-        "static_current": "https://github.com/mobilityequity/maryland-local-gtfs/raw/master/PG_GTFS.zip"
+        "static_current": "https://www.princegeorgescountymd.gov/DocumentCenter/View/35935/TheBUS_GTFS_v05_2021"
       },
       "license": {
         "url": "https://github.com/mobilityequity/maryland-local-gtfs/blob/master/README.md",


### PR DESCRIPTION
See the link on this page: https://www.princegeorgescountymd.gov/1122/Routes-Schedules

Unfortunately this URL will eventually change again, and also there are some inadequacies in the stop_times, at least as far as OpenTripPlanner is concerned.