### PR TITLE
Update adelaidemetro.com.au.dmfr.json

### DIFF
--- a/feeds/adelaidemetro.com.au.dmfr.json
+++ b/feeds/adelaidemetro.com.au.dmfr.json
@@ -5,7 +5,7 @@
       "spec": "gtfs",
       "id": "f-r1f-adelaidemetrocomau",
       "urls": {
-        "static_current": "http://adelaidemetro.com.au/GTFS/google_transit.zip"
+        "static_current": "https://gtfs.adelaidemetro.com.au/v1/static/latest/google_transit.zip"
       },
       "license": {
         "url": "http://creativecommons.org/licenses/by/4.0",


### PR DESCRIPTION
Changed URL to https://gtfs.adelaidemetro.com.au/v1/static/latest/google_transit.zip

This is where Adelaide Metro's feed is now available