### PR TITLE
ZTM Warszawa requires OSM attribution

### DIFF
--- a/feeds/mkuran.pl.dmfr.json
+++ b/feeds/mkuran.pl.dmfr.json
@@ -75,9 +75,10 @@
       },
       "license": {
         "url": "http://www.ztm.waw.pl/?c=628&l=1",
-        "use_without_attribution": "unknown",
+        "use_without_attribution": "no",
         "create_derived_product": "yes",
-        "redistribute": "yes"
+        "redistribute": "yes",
+        "attribution_text": "Bus shapes based on data by: © OpenStreetMap contributors"
       },
       "operators": [
         {


### PR DESCRIPTION
the feed contains an `attributions.txt` file