### PR TITLE
Add GTFS feed for Icelandic bus company Strætó

### DIFF
--- a/feeds/opendata.straeto.is.dmfr.json
+++ b/feeds/opendata.straeto.is.dmfr.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.4.0.json",
+  "feeds": [
+    {
+      "spec": "gtfs",
+      "id": "f-ge2kx-straeto",
+      "urls": {
+        "static_current": "http://opendata.straeto.is/data/gtfs/gtfs.zip"
+      },
+      "languages": ["is"],
+      "license": {
+        "spdx_identifier": "OGL-UK-3.0",
+        "url": "https://www.straeto.is/uploads/files/134-ed60c2c158.docx",
+        "use_without_attribution": "no",
+        "create_derived_product": "yes",
+        "redistribute": "yes"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-ge2kx-straeto",
+          "tags": {
+            "wikidata_id": "Q966621",
+            "twitter_general": "straetobs"
+          },
+          "name": "Strætó bs",
+          "website": "https://www.straeto.is/",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Source data and licence doc available from <https://www.straeto.is/is/um-straeto/leidakerfi/opin-rafraen-gogn>.

Strætó is the publicly-owned company that operates buses within Reykjavík and its surrounding towns, along with a few other routes around the country.