### PR TITLE
SF Bay Area Regional GTFS Feed

### DIFF
--- a/feeds/511.org.dmfr.json
+++ b/feeds/511.org.dmfr.json
@@ -3,10 +3,32 @@
   "feeds": [
     {
       "spec": "gtfs",
+      "id": "f-sf~bay~area~rg",
+      "urls": {
+        "static_current": "http://api.511.org/transit/datafeeds?operator_id=RG"
+      },
+      "license": {
+        "url": "http://assets.511.org/pdf/nextgen/developers/511_Data_Agreement_Final.pdf",
+        "use_without_attribution": "no",
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "commercial_use_allowed": "yes",
+        "share_alike_optional": "yes",
+        "attribution_text": "data provided by 511.org",
+        "attribution_instructions": "MUST acknowledge the source of the Provided Data with the tag line \"powered by 511.org,\" or \"data provided by 511.org,\" or a variant approved in writing by MTC, and a link to http://www.511.org.  The acknowledgement must be in visual proximity to the user's access to the Provided Data.  If space allows, Registered Data Disseminators are encouraged to provide the MTC 511 + Design logo with the link to 511.org."
+      },
+      "tags": {
+        "managed_by": "mtc-ca",
+        "manual_import": "true"
+      }
+    },
+    {
+      "spec": "gtfs",
       "id": "f-9q8zm-blue~goldfleet",
       "urls": {
         "static_historic": ["http://api.511.org/transit/datafeeds?operator_id=BG"]
       },
+      
       "authorization": {
         "type": "query_param",
         "info_url": "https://511.org/open-data/token",


### PR DESCRIPTION
will be marked for manual import, until we are ready to excluse other agency-level feeds from global search