### PR TITLE
Link to real (and updated) GTFS for RIOC

### DIFF
--- a/feeds/github.com.dmfr.json
+++ b/feeds/github.com.dmfr.json
@@ -562,7 +562,7 @@
       "spec": "gtfs",
       "id": "f-rioc~nyc",
       "urls": {
-        "static_current": "https://github.com/laidig/rioc-gtfs/raw/master/rioc_gtfs.zip"
+        "static_current": "http://rapid.nationalrtap.org/GTFSFileManagement/UserUploadFiles/7707/gtfs.zip"
       },
       "operators": [
         {


### PR DESCRIPTION
I run the GTFS feed for RIOC - we store the feed at the National RTAP link above. This is the link referenced by Google et. al.

The one currently in there appears to be wrong and has not been updated in a number of years.