### PR TITLE
Update the URL for BATA_GTFS.zip

### DIFF
--- a/feeds/nationalrtap.org.dmfr.json
+++ b/feeds/nationalrtap.org.dmfr.json
@@ -59,7 +59,7 @@
       "spec": "gtfs",
       "id": "f-bay~area~transportation~authority~mi",
       "urls": {
-        "static_current": "http://rapid.nationalrtap.org/GTFSFileManagement/UserUploadFiles/5109/BATA_GTFS.zip"
+        "static_current": "http://rapid.nationalrtap.org/GTFSFileManagement/UserUploadFiles/7480/BATA_GTFS.zip"
       },
       "license": {
         "url": "https://www.bata.net/customer-service/gtfs-data.html"


### PR DESCRIPTION
One of BATA's transportation planners provided this slightly modified link.