### PR TITLE
Adds `ZSSK` via ZSR

### DIFF
--- a/feeds/zsr.sk.dmfr.json
+++ b/feeds/zsr.sk.dmfr.json
@@ -10,12 +10,8 @@
       "operators": [
         {
           "onestop_id": "o-eo0-zssk",
-          "name": "ZSSK via ZSR",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "ZelezniceSlovenskejRepubliky"
-            }
-          ]
+          "name": "Železničná spoločnosť Slovensko",
+          "short_name": "ZSSK"
         }
       ]
     }

--- a/feeds/zsr.sk.dmfr.json
+++ b/feeds/zsr.sk.dmfr.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.4.0.json",
+  "feeds": [
+    {
+      "spec": "gtfs",
+      "id": "f-eo0-zssk",
+      "urls": {
+        "static_current": "https://www.zsr.sk/files/pre-cestujucich/cestovny-poriadok/gtfs/gtfs.zip"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-eo0-zssk",
+          "name": "ZSSK via ZSR",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "ZelezniceSlovenskejRepubliky"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "license_spdx_identifier": "cc-zero"
+}

--- a/feeds/zsr.sk.dmfr.json
+++ b/feeds/zsr.sk.dmfr.json
@@ -11,7 +11,7 @@
         {
           "onestop_id": "o-eo0-zssk",
           "name": "Železničná spoločnosť Slovensko",
-          "short_name": "ZSSK"
+          "short_name": "ZSSK via ZSR"
         }
       ]
     }


### PR DESCRIPTION
ZSR and ZSSK are under one corporate umbrella, ZSR regulates Railway tracks in Slovakia, whilst ZSSK is major Rail Service Provider here. Taken from Slovakia Open Data Portal (https://data.gov.sk/dataset/https-www-zsr-sk-files-pre-cestujucich-cestovny-poriadok-gtfs-gtfs-zip)