### PR TITLE
format the Trillium file using the new `transitland dmfr format --save` command

### DIFF
--- a/feeds/trilliumtransit.com.dmfr.json
+++ b/feeds/trilliumtransit.com.dmfr.json
@@ -2,287 +2,106 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.4.0.json",
   "feeds": [
     {
-      "spec": "gtfs",
-      "id": "f-9vfu-dentoncountytransportationauthority",
-      "urls": {
-        "static_current": "http://trilliumtransit.com/transit_feeds/dentoncounty-tx-us/dentoncounty-tx-us.zip",
-        "static_historic": ["https://www.dcta.net/images/uploads/content_files/resource_center/DCTA_GTFS.zip"]
-      },
-      "license": {
-        "url": "https://www.dcta.net/resources/open-data"
-      },
+      "id": "f-9mgve-avalon~ca~us",
       "operators": [
         {
-          "onestop_id": "o-9vfu-dentoncountytransportationauthority",
-          "tags": {
-            "us_ntd_id": "60101",
-            "wikidata_id": "Q5259601",
-            "twitter_general": "RideDCTA"
-          },
-          "name": "Denton County Transportation Authority",
-          "short_name": "DCTA",
           "associated_feeds": [
             {
-              "feed_onestop_id": "f-dentoncountytransportationauthority~rt"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qf-laketahoe~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/laketahoe-ca-us/laketahoe-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qfx-tahoetruckeearearegionaltransit",
-          "supersedes_ids": ["o-9qfx-tahoeareametroaltransit"],
-          "website": "https://tahoetruckeetransit.com/",
-          "name": "Tahoe Truckee Area Regional Transit",
-          "short_name": "TART",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "904"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "9R02-91101",
-            "twitter_general": "areatahoe"
-          }
-        },
-        {
-          "onestop_id": "o-9qfx-northlaketahoeexpress~24houradvancereservationsrequired",
-          "name": "North Lake Tahoe Express",
-          "website": "https://www.northlaketahoeexpress.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "16"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9q8zr-tidelinewatertaxi~ca~us",
-      "urls": {
-        "static_current": "http://trilliumtransit.com/transit_feeds/tidelinewatertaxi-ca-us/tidelinewatertaxi-ca-us.zip"
-      },
-      "tags": {
-        "feed_id": "tidelinewatertaxi-ca-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q8zr-tidelinewatertaxi",
-          "tags": {
-            "omd_provider_id": "tideline-water-taxi",
-            "twitter_general": "tidelinesf"
-          },
-          "name": "Tideline Water Taxi",
-          "website": "https://tidelinetickets.com",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "513"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-c263-selah~wa~us",
-      "urls": {
-        "static_current": "http://trilliumtransit.com/transit_feeds/selah-wa-us/selah-wa-us.zip"
-      },
-      "tags": {
-        "feed_id": "selah-wa-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-c263-selahtransit",
-          "name": "Selah Transit",
-          "website": "https://selahwa.gov/transit/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "868"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drvc-rtp~me~us",
-      "urls": {
-        "static_current": "http://trilliumtransit.com/transit_feeds/rtp-me-us/rtp-me-us.zip"
-      },
-      "tags": {
-        "feed_id": "rtp-me-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drvc-lakesregionexplorer",
-          "name": "Lakes Region Explorer",
-          "website": "http://rtprides.org/lake-region-bus/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "522"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-iowa~city~transit",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/iowacitytransit-ia-us/iowacitytransit-ia-us.zip"
-      },
-      "license": {
-        "url": "https://iowa-gtfs.com/"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9zqu-iowacitytransitsystem",
-          "name": "Iowa City Transit System",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "796"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "70018",
-            "twitter_general": "CityOfIowaCity"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qc-placercountytransit",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/placercounty-ca-us/placercounty-ca-us.zip",
-        "static_historic": [
-          "http://iportal.sacrt.com/gtfs/PCT/20080914/google_transit.zip"
-        ]
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qc-placercountytransit",
-          "tags": {
-            "us_ntd_id": "90196",
-            "wikidata_id": "Q7200309",
-            "twitter_general": "pctpa"
-          },
-          "name": "Placer County Transit"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-banning~pass~transit",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/banning-ca-us/banning-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qhb-cityofbanningtransit",
-          "name": "City of Banning Transit",
-          "associated_feeds": [
-            {
-              "onestop_id": "f-banning~pass~transit~rt"
+              "gtfs_agency_id": "622"
             },
             {
-              "onestop_id": "f-banning~pass~transit~rt~alerts"
+              "feed_onestop_id": "f-avalon~ca~rt"
             }
-          ]
+          ],
+          "name": "Avalon Transit",
+          "onestop_id": "o-9mgve-avalontransit",
+          "tags": {
+            "twitter_general": "avalongov",
+            "us_ntd_id": "90249"
+          },
+          "website": "http://www.cityofavalon.com/transit"
         }
-      ]
-    },
-    {
-      "spec": "gtfs-rt",
-      "id": "f-banning~pass~transit~rt~alerts",
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "avalon-ca-us"
+      },
       "urls": {
-        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/banning-ca-us/service_alerts.proto"
+        "static_current": "http://data.trilliumtransit.com/gtfs/avalon-ca-us/avalon-ca-us.zip"
       }
     },
     {
-      "spec": "gtfs",
-      "id": "f-9r88-rogue~valley~transportation~district",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/rvtd-or-us/rvtd-or-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9r88-rogue~valley~transportation~district",
-          "tags": {
-            "us_ntd_id": "00034",
-            "wikidata_id": "Q7359553",
-            "twitter_general": "ridervtd"
-          },
-          "name": "Rogue Valley Transportation District",
-          "short_name": "RVTD"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dr5r-path~nj~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/path-nj-us/path-nj-us.zip"
-      },
+      "id": "f-9muq-lagunabeach~ca~us",
       "license": {
-        "url": "http://www.panynj.gov/path/developers.html",
-        "use_without_attribution": "yes",
         "create_derived_product": "yes",
-        "redistribute": "unknown"
-      },
-      "tags": {
-        "feed_id": "path-nj-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "path"
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
       },
       "operators": [
         {
-          "onestop_id": "o-dr5r-path",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "126"
+            }
+          ],
+          "name": "Laguna Beach Transit",
+          "onestop_id": "o-9muq-lagunabeachtransit",
           "tags": {
-            "us_ntd_id": "20098",
-            "wikidata_id": "Q1055811",
-            "twitter_general": "PATHTrain"
+            "twitter_general": "lagunabeachgov",
+            "us_ntd_id": "90119"
           },
-          "name": "Port Authority Trans-Hudson",
-          "short_name": "PATH"
+          "website": "http://www.lagunabeachcity.net/cityhall/pw/transit/default.asp"
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "lagunabeach-ca-us",
+        "gtfs_data_exchange": "laguna-beach-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/lagunabeach-ca-us/lagunabeach-ca-us.zip"
+      }
     },
     {
+      "id": "f-9myr-paloverdevalley~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "75"
+            }
+          ],
+          "name": "Palo Verde Valley Transit Agency",
+          "onestop_id": "o-9myr-paloverdevalleytransitagency",
+          "short_name": "PVVTA",
+          "website": "http://pvvta.com/"
+        }
+      ],
       "spec": "gtfs",
+      "tags": {
+        "feed_id": "paloverde_valley-ca-us",
+        "gtfs_data_exchange": "palo-verde-valley-transit-agency",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/paloverde_valley-ca-us/paloverde_valley-ca-us.zip"
+      }
+    },
+    {
       "id": "f-9pp-humboldtcounty~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/humboldtcounty-ca-us/humboldtcounty-ca-us.zip"
-      },
       "license": {
-        "use_without_attribution": "yes",
         "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "humboldtcounty-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": " Arcata & Mad River Transit System"
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
       },
       "operators": [
         {
-          "onestop_id": "o-9pr8n-samoatransitsystem",
-          "name": "Samoa Transit System",
           "associated_feeds": [
             {
               "gtfs_agency_id": "1716"
@@ -294,13 +113,13 @@
               "feed_onstop_id": "f-9pp-humboldtcounty~ca~us~rt~alerts"
             }
           ],
+          "name": "Samoa Transit System",
+          "onestop_id": "o-9pr8n-samoatransitsystem",
           "tags": {
             "wikidata_id": "Q5940414"
           }
         },
         {
-          "onestop_id": "o-9prb9-bluelakerancheriatransitsystem",
-          "name": "Blue Lake Rancheria Transit System",
           "associated_feeds": [
             {
               "gtfs_agency_id": "972"
@@ -312,20 +131,14 @@
               "feed_onstop_id": "f-9pp-humboldtcounty~ca~us~rt~alerts"
             }
           ],
+          "name": "Blue Lake Rancheria Transit System",
+          "onestop_id": "o-9prb9-bluelakerancheriatransitsystem",
           "tags": {
             "us_ntd_id": "99292",
             "wikidata_id": "Q96373720"
           }
         },
         {
-          "onestop_id": "o-9prb8-arcata~madrivertransitsystem",
-          "tags": {
-            "us_ntd_id": "9R02-91018",
-            "wikidata_id": "Q4785261"
-          },
-          "name": "Arcata & Mad River Transit System",
-          "short_name": "A&MRTS",
-          "website": "http://www.arcatatransit.org/?referrer=gtfs",
           "associated_feeds": [
             {
               "gtfs_agency_id": "3"
@@ -336,17 +149,17 @@
             {
               "feed_onstop_id": "f-9pp-humboldtcounty~ca~us~rt~alerts"
             }
-          ]
+          ],
+          "name": "Arcata & Mad River Transit System",
+          "onestop_id": "o-9prb8-arcata~madrivertransitsystem",
+          "short_name": "A&MRTS",
+          "tags": {
+            "us_ntd_id": "9R02-91018",
+            "wikidata_id": "Q4785261"
+          },
+          "website": "http://www.arcatatransit.org/?referrer=gtfs"
         },
         {
-          "onestop_id": "o-9pp-redwoodtransitsystem",
-          "tags": {
-            "us_ntd_id": "9R02-91036",
-            "wikidata_id": "Q5940414"
-          },
-          "name": "Redwood Transit System",
-          "short_name": "RTS",
-          "website": "http://www.redwoodtransit.org/?referrer=gtfs",
           "associated_feeds": [
             {
               "gtfs_agency_id": "1"
@@ -357,17 +170,17 @@
             {
               "feed_onstop_id": "f-9pp-humboldtcounty~ca~us~rt~alerts"
             }
-          ]
+          ],
+          "name": "Redwood Transit System",
+          "onestop_id": "o-9pp-redwoodtransitsystem",
+          "short_name": "RTS",
+          "tags": {
+            "us_ntd_id": "9R02-91036",
+            "wikidata_id": "Q5940414"
+          },
+          "website": "http://www.redwoodtransit.org/?referrer=gtfs"
         },
         {
-          "onestop_id": "o-9pr8n-eurekatransitservice",
-          "tags": {
-            "us_ntd_id": "9R02-91093",
-            "wikidata_id": "Q5411264"
-          },
-          "name": "Eureka Transit Service",
-          "short_name": "ETS",
-          "website": "http://www.eurekatransit.org/?referrer=gtfs",
           "associated_feeds": [
             {
               "gtfs_agency_id": "2"
@@ -378,1000 +191,83 @@
             {
               "feed_onstop_id": "f-9pp-humboldtcounty~ca~us~rt~alerts"
             }
-          ]
+          ],
+          "name": "Eureka Transit Service",
+          "onestop_id": "o-9pr8n-eurekatransitservice",
+          "short_name": "ETS",
+          "tags": {
+            "us_ntd_id": "9R02-91093",
+            "wikidata_id": "Q5411264"
+          },
+          "website": "http://www.eurekatransit.org/?referrer=gtfs"
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "humboldtcounty-ca-us",
+        "gtfs_data_exchange": " Arcata & Mad River Transit System",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/humboldtcounty-ca-us/humboldtcounty-ca-us.zip"
+      }
     },
     {
-      "spec": "gtfs-rt",
       "id": "f-9pp-humboldtcounty~ca~us~rt~alerts",
+      "spec": "gtfs-rt",
       "urls": {
         "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/humboldtcounty-ca-us/service_alerts.proto"
       }
     },
     {
-      "spec": "gtfs",
-      "id": "f-9qd-yosemite~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/yosemite-ca-us/yosemite-ca-us.zip"
-      },
-      "license": {
-        "url": "http://yarts.com/developers-gtfs-data/",
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "yosemite-ca-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qdyw-yosemitevalleyshuttlesystem",
-          "name": "Yosemite Valley Shuttle System",
-          "website": "http://www.nps.gov/yose/planyourvisit/publictransportation.htm#CP_JUMP_566977",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "216"
-            }
-          ]
-        },
-        {
-          "onestop_id": "o-9qd-yosemitearearegionaltransportationsystem",
-          "tags": {
-            "us_ntd_id": "9R02-91070",
-            "wikidata_id": "Q8055918",
-            "twitter_general": "rideyarts"
-          },
-          "name": "Yosemite Area Regional Transportation System",
-          "short_name": "YARTS",
-          "website": "http://www.yarts.com/?referrer=gtfs",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "114"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drg-addisoncounty~vt~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/addisoncounty-vt-us/addisoncounty-vt-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "addisoncounty-vt-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "addison-county-transit-resources"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drg-addisoncountytransitresources",
-          "tags": {
-            "us_ntd_id": "1R06-10143"
-          },
-          "name": "Addison County Transit Resources",
-          "website": "http://actr-vt.org/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "230"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qf-amador~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/amador-ca-us/amador-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "amador-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "amador-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qf-amadortransit",
-          "tags": {
-            "us_ntd_id": "9R02-91000",
-            "wikidata_id": "Q13429190",
-            "twitter_general": "amadortransit"
-          },
-          "name": "Amador Transit",
-          "website": "http://amadortransit.com/site/pages/schedules.cgi?referrer=gtfs",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "80"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qh0-anaheim~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/anaheim-ca-us/anaheim-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes",
-        "url": "https://rideart.org/gtfs/"
-      },
-      "tags": {
-        "feed_id": "anaheim-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "anaheim-resort-transportation"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qh0-anaheimresorttransportation",
-          "tags": {
-            "us_ntd_id": "90211",
-            "wikidata_id": "Q4750893",
-            "twitter_general": "RideARTbus"
-          },
-          "name": "Anaheim Resort Transportation",
-          "short_name": "ART",
-          "website": "http://www.rideart.org/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "248"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dnm6-asheville~nc~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/asheville-nc-us/asheville-nc-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "asheville-nc-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dnm6-ashevilleredefinestransit",
-          "tags": {
-            "us_ntd_id": "40005",
-            "wikidata_id": "Q4804926",
-            "twitter_general": "cityofasheville"
-          },
-          "name": "Asheville Redefines Transit",
-          "short_name": "ART",
-          "website": "http://www.ashevillenc.gov/Departments/Transit.aspx",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "190"
-            },
-            {
-              "onestop_id": "f-dnm6-asheville~nc~us~alerts"
-            },
-            {
-              "onestop_id": "f-dnm6-asheville~nc~us~rt"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs-rt",
-      "id": "f-dnm6-asheville~nc~us~alerts",
-      "urls": {
-        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/asheville-nc-us/service_alerts.proto"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dnm6-ashevilleredefinestransit",
-          "name": "Asheville Redefines Transit",
-          "associated_feeds": [
-            {
-              "onestop_id": "f-dnm6-asheville~nc~us"
-            },
-            {
-              "onestop_id": "f-dnm6-asheville~nc~us~rt"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drt-baystatecruisecompany~ma~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/baystatecruisecompany-ma-us/baystatecruisecompany-ma-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "baystatecruisecompany-ma-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "bay-state-cruise-company"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drt-baystatecruisecompany",
-          "name": "Bay State Cruise Company",
-          "website": "http://www.baystatecruisecompany.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "275"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qhc-beaumont~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/beaumont-ca-us/beaumont-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "beaumont-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "beaumont-pass-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qhc-beaumonttransitsystem",
-          "tags": {
-            "wikidata_id": "Q7142408"
-          },
-          "name": "Beaumont Transit System",
-          "website": "http://www.ci.beaumont.ca.us/index.aspx?NID=160",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "73"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dp89-beloittransit~wi~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/beloittransit-wi-us/beloittransit-wi-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "beloittransit-wi-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "beloit-transit-system"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dp89-beloittransitsystem",
-          "tags": {
-            "us_ntd_id": "50109"
-          },
-          "name": "Beloit Transit System"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dre-berkshire~ma~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/berkshire-ma-us/berkshire-ma-us.zip"
-      },
-      "license": {
-        "url": "https://www.massdot.state.ma.us/Portals/0/docs/developers/develop_license_agree.pdf",
-        "use_without_attribution": "no",
-        "create_derived_product": "yes",
-        "redistribute": "yes",
-        "attribution_text": "Clearly acknowledge MassDOT as the provider of the Data."
-      },
-      "tags": {
-        "feed_id": "berkshire-ma-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dre-berkshiremetroaltransitauthority",
-          "tags": {
-            "us_ntd_id": "10007",
-            "wikidata_id": "Q20708878"
-          },
-          "name": "Berkshire Regional Transit Authority",
-          "short_name": "BRTA"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qhf-bigbear~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/bigbear-ca-us/bigbear-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "bigbear-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "mountain-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qhf-mountaintransit",
-          "tags": {
-            "us_ntd_id": "9R02-91012",
-            "wikidata_id": "Q6924864"
-          },
-          "name": "Mountain Transit",
-          "website": "http://www.mountaintransit.org/?referrer=gtfs",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "44"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drmr-brockton~ma~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/brockton-ma-us/brockton-ma-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes",
-        "url": "https://www.mass.gov/doc/developers-license-agreement-11132009/download"
-      },
-      "tags": {
-        "feed_id": "brockton-ma-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "brockton-area-transit-authority"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drmr-brocktonareatransitauthority",
-          "tags": {
-            "us_ntd_id": "10004",
-            "wikidata_id": "Q4972867",
-            "twitter_general": "BrocktonBAT"
-          },
-          "name": "Brockton Area Transit Authority",
-          "short_name": "BAT"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qnx-bullheadareatransit~az~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/bullheadareatransit-az-us/bullheadareatransit-az-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "bullheadareatransit-az-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qnx-bullheadareatransitsystem",
-          "tags": {
-            "us_ntd_id": "9R01-91037",
-            "twitter_general": "bullheadinfo"
-          },
-          "name": "Bullhead Area Transit System",
-          "website": "http://www.bullheadcity.com/departments/human-services-transit/transportation",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "258"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9x-bustang~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/bustang-co-us/bustang-co-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "bustang-co-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "bustang"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9x-bustang",
-          "tags": {
-            "wikidata_id": "Q85749670",
-            "twitter_general": "RideBustang"
-          },
-          "name": "Bustang",
-          "website": "http://ridebustang.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "249"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-c2pvx-butte~mt~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/butte-mt-us/butte-mt-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "butte-mt-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "butte-silver-bow"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-c2pvx-butte~silverbow",
-          "tags": {
-            "us_ntd_id": "8R02-88296"
-          },
-          "name": "Butte-Silver Bow",
-          "website": "http://www.buttebus.org/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "150"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qf-calaveras~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/calaveras-ca-us/calaveras-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "calaveras-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "calaveras-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qf-calaverastransit",
-          "tags": {
-            "us_ntd_id": "9R02-91063"
-          },
-          "name": "Calaveras Transit",
-          "website": "http://calaverastransit.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "79"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drtd-capeann~ma~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/capeann-ma-us/capeann-ma-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "capeann-ma-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "cape-ann-transportation-authority"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drtd-capeanntransportation",
-          "tags": {
-            "us_ntd_id": "10053",
-            "wikidata_id": "Q5034570",
-            "twitter_general": "capeanntransit"
-          },
-          "name": "Cape Ann Transportation Authority",
-          "short_name": "CATA"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dq25-capital~area~transit~nc~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/capital-area-transit-nc-us/capital-area-transit-nc-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes",
-        "url": "https://goraleigh.org/developer-terms-and-conditions"
-      },
-      "tags": {
-        "feed_id": "capital-area-transit-nc-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dq25-goraleigh",
-          "tags": {
-            "us_ntd_id": "40007",
-            "wikidata_id": "Q5035469",
-            "twitter_general": "GoRaleighNC"
-          },
-          "name": "GoRaleigh"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dnrg-cary~transit~nc~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/cary-transit-nc-us/cary-transit-nc-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "cary-transit-nc-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "cary-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dnrg-carytransit",
-          "tags": {
-            "us_ntd_id": "40143",
-            "wikidata_id": "Q5005923",
-            "twitter_general": "TownofCary"
-          },
-          "name": "Cary Transit",
-          "short_name": "GoCary"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dru-chittendoncounty~vt~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/ccta-vt-us/ccta-vt-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes",
-        "url": "https://vermont-gtfs.org/"
-      },
-      "tags": {
-        "feed_id": "chittendoncounty-vt-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drg-chittendencountytransporationauthority",
-          "name": "Chittenden County Transporation Authority",
-          "website": "http://www.cctaride.org",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "460"
-            }
-          ]
-        },
-        {
-          "onestop_id": "o-dru-greenmountaintransitagency",
-          "tags": {
-            "us_ntd_id": "10066",
-            "wikidata_id": "Q28404107",
-            "twitter_general": "RideGMT"
-          },
-          "name": "Green Mountain Transit Agency",
-          "website": "http://www.gmtaride.org",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "461"
-            },
-            {
-              "feed_onestop_id": "f-chittendoncounty~rt"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dnru-chapel~hill~transit~nc~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/chapel-hill-transit-nc-us/chapel-hill-transit-nc-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "chapel-hill-transit-nc-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "chapel-hill-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dnru-chapelhilltransit",
-          "tags": {
-            "us_ntd_id": "40051",
-            "wikidata_id": "Q5073024",
-            "twitter_general": "chapelhillgov"
-          },
-          "name": "Chapel Hill Transit"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dnjj-clemson~sc~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/clemson-sc-us/clemson-sc-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "clemson-sc-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "clemson-area-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dnjj-clemsonareatransit",
-          "tags": {
-            "us_ntd_id": "40208",
-            "wikidata_id": "Q5131543",
-            "twitter_general": "catclemson"
-          },
-          "name": "Clemson Area Transit",
-          "short_name": "catbus"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qh2s-corona~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/corona-ca-us/corona-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "corona-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "corona-cruiser"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qh2s-coronacruiser",
-          "tags": {
-            "us_ntd_id": "90052"
-          },
-          "name": "Corona Cruiser"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9w0md-cottonwood~az~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/cottonwood-az-us/cottonwood-az-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "cottonwood-az-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "cottonwood-area-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9w0md-cottonwoodareatransit",
-          "tags": {
-            "us_ntd_id": "9R01-91010"
-          },
-          "name": "Cottonwood Area Transit",
-          "website": "http://cottonwoodaz.gov/cat.php",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "64"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drs-crtransit~vt~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/crtransit-vt-us/crtransit-vt-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "crtransit-vt-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "the-current"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drs-thecurrent",
-          "tags": {
-            "us_ntd_id": "1R06-10144",
-            "wikidata_id": "Q28448928"
-          },
-          "name": "The Current",
-          "website": "http://crtransit.org/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "232"
-            },
-            {
-              "feed_onestop_id": "f-crtransit~vt~rt"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drms-cuttyhunkferryco~ma~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/cuttyhunkferryco-ma-us/cuttyhunkferryco-ma-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "cuttyhunkferryco-ma-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drms-cuttyhunkferryco",
-          "name": "Cuttyhunk Ferry Co.",
-          "website": "http://www.cuttyhunkferryco.com",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "277"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
       "id": "f-9pr-delnorte~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/delnorte-ca-us/delnorte-ca-us.zip"
-      },
       "license": {
-        "use_without_attribution": "yes",
         "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "delnorte-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "redwood-coast-transit"
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
       },
       "operators": [
         {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "19"
+            }
+          ],
+          "name": "Redwood Coast Transit",
           "onestop_id": "o-9pr-redwoodcoasttransit",
           "tags": {
             "us_ntd_id": "9R02-91097",
             "wikidata_id": "Q96401429"
           },
-          "name": "Redwood Coast Transit",
-          "website": "http://www.redwoodcoasttransit.org/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "19"
-            }
-          ]
+          "website": "http://www.redwoodcoasttransit.org/"
         }
-      ]
-    },
-    {
+      ],
       "spec": "gtfs",
-      "id": "f-dnrug-duke~nc~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/duke-nc-us/duke-nc-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
       "tags": {
-        "feed_id": "duke-nc-us",
+        "feed_id": "delnorte-ca-us",
+        "gtfs_data_exchange": "redwood-coast-transit",
         "managed_by": "trillium"
       },
-      "operators": [
-        {
-          "onestop_id": "o-dnrug-duketransit",
-          "name": "Duke Transit",
-          "website": "http://parking.duke.edu/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "240"
-            }
-          ]
-        }
-      ]
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/delnorte-ca-us/delnorte-ca-us.zip"
+      }
     },
     {
-      "spec": "gtfs",
-      "id": "f-dnru-durham~area~transit~authority~nc~us",
+      "id": "f-9pz-lincolncounty~or~us~rt~alerts",
+      "spec": "gtfs-rt",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/durham-area-transit-authority-nc-us/durham-area-transit-authority-nc-us.zip"
-      },
+        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/lincolncounty-or-us/service_alerts.proto"
+      }
+    },
+    {
+      "id": "f-9q-easternsierra~ca~us",
       "license": {
-        "use_without_attribution": "yes",
         "create_derived_product": "yes",
         "redistribute": "yes",
-        "url": "https://godurhamtransit.org/developer-terms-and-conditions"
-      },
-      "tags": {
-        "feed_id": "durham-area-transit-authority-nc-us",
-        "managed_by": "trillium"
+        "use_without_attribution": "yes"
       },
       "operators": [
         {
-          "onestop_id": "o-dnru-godurham",
-          "tags": {
-            "us_ntd_id": "40087",
-            "wikidata_id": "Q5316462",
-            "twitter_general": "godurhamtransit"
-          },
-          "name": "GoDurham",
-          "associated_feeds": [
-            {
-              "onestop_id": "f-dnru-durham~area~transit~authority~nc~us~rt"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drsh-dvtamoover~vt~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/dvtamoover-vt-us/dvtamoover-vt-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "dvtamoover-vt-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drsh-moover",
-          "tags": {
-            "us_ntd_id": "1R06-10144",
-            "wikidata_id": "Q28448928"
-          },
-          "name": "MOOver!",
-          "website": "http://www.moover.com",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "218"
-            },
-            {
-              "feed_onestop_id": "f-dvtamoover~vt~rt"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9q-easternsierra~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/easternsierra-ca-us/easternsierra-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "easternsierra-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "eastern-sierra-transit-authority"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q-easternsierratransitauthority",
-          "tags": {
-            "us_ntd_id": "9R02-91062",
-            "wikidata_id": "Q5330465",
-            "twitter_general": "estabus"
-          },
-          "name": "Eastern Sierra Transit Authority",
-          "website": "http://www.estransit.com/",
           "associated_feeds": [
             {
               "gtfs_agency_id": "78"
@@ -1379,391 +275,296 @@
             {
               "onestop_id": "f-9q-easternsierra~ca~us~rt"
             }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qc-eldoradotransit~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/eldoradotransit-ca-us/eldoradotransit-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "eldoradotransit-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "el-dorado-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qc-eldoradotransit",
+          ],
+          "name": "Eastern Sierra Transit Authority",
+          "onestop_id": "o-9q-easternsierratransitauthority",
           "tags": {
-            "us_ntd_id": "90229",
-            "wikidata_id": "Q5351201",
-            "twitter_general": "eldoradotransit"
+            "twitter_general": "estabus",
+            "us_ntd_id": "9R02-91062",
+            "wikidata_id": "Q5330465"
           },
-          "name": "El Dorado Transit",
-          "website": "http://www.eldoradotransit.com/?referrer=gtfs",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "261"
-            }
-          ]
+          "website": "http://www.estransit.com/"
         }
-      ]
-    },
-    {
+      ],
       "spec": "gtfs",
-      "id": "f-9q9y-escalon~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/escalon-ca-us/escalon-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
       "tags": {
-        "feed_id": "escalon-ca-us",
+        "feed_id": "easternsierra-ca-us",
+        "gtfs_data_exchange": "eastern-sierra-transit-authority",
         "managed_by": "trillium"
       },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/easternsierra-ca-us/easternsierra-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9q4-smat~ca~us",
       "operators": [
         {
-          "onestop_id": "o-9q9y-etrans",
-          "tags": {
-            "us_ntd_id": "9R02-91078"
-          },
-          "name": "eTrans",
-          "website": "http://cityofescalon.org/departments/transit-services/",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "52"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qc-fairfield~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/fairfield-ca-us/fairfield-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "fairfield-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "fairfield-and-suisun-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qc-fairfieldandsuisuntransit",
-          "tags": {
-            "us_ntd_id": "90092",
-            "wikidata_id": "Q5430409",
-            "twitter_general": "fast_transit"
-          },
-          "name": "Fairfield and Suisun Transit",
-          "short_name": "FAST",
-          "website": "http://www.fasttransit.org/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "36"
-            },
-            {
-              "feed_onestop_id": "f-fairfield~ca~rt"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drq-freedomcruiseline~ma~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/freedomcruiseline-ma-us/freedomcruiseline-ma-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "freedomcruiseline-ma-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "freedom-cruise-line"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drq-freedomcruiseline",
-          "name": "Freedom Cruise Line",
-          "website": "http://www.nantucketislandferry.com",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "278"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qd-fresnocounty~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/fresnocounty-ca-us/fresnocounty-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "fresnocounty-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "fresno-county-rural-transit-agency"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qd-fresnocountyruraltransitagency",
-          "tags": {
-            "us_ntd_id": "9R02-91007"
-          },
-          "name": "Fresno County Rural Transit Agency",
-          "website": "http://www.ruraltransit.org/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "171"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dnxs-gltc~lynchburg~va~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/gltc-lynchburg-va-us/gltc-lynchburg-va-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "gltc-lynchburg-va-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dnxs-greaterlynchburgtransitco",
-          "tags": {
-            "us_ntd_id": "30008",
-            "wikidata_id": "Q5600625",
-            "twitter_general": "GLTCONLINE"
-          },
-          "name": "Greater Lynchburg Transit Co.",
-          "short_name": "GLTC"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dre-greenmtncn~vt~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/greenmtncn-vt-us/greenmtncn-vt-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "greenmtncn-vt-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "o-dre-greenmountaincommunitynetworkinc"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dre-greenmountaincommunitynetworkinc",
-          "tags": {
-            "us_ntd_id": "1R06-10151",
-            "wikidata_id": "Q5602891"
-          },
-          "name": "Green Mountain Community Network, Inc.",
-          "website": "http://www.greenmtncn.org/index.html",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "219"
-            },
-            {
-              "feed_onestop_id": "f-greenmtncn~vt~rt"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drq5-hylinecruises~ma~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/hylinecruises-ma-us/hylinecruises-ma-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "hylinecruises-ma-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "hy-line-cruises"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drq5-hy~linecruises",
-          "tags": {
-            "wikidata_id": "Q14715606",
-            "twitter_general": "hylinecruises"
-          },
-          "name": "Hy-Line Cruises",
-          "website": "https://www.hylinecruises.com",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "279"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9vxz-jatran~ms~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/jatran-ms-us/jatran-ms-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "jatran-ms-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "jatran"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9vxz-jatran",
-          "tags": {
-            "us_ntd_id": "50034",
-            "wikidata_id": "Q6117777"
-          },
-          "name": "JATRAN"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9yz-jeffersoncounty~mo~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/jeffersoncounty-mo-us/jeffersoncounty-mo-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "jeffersoncounty-mo-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "jeffco-express"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9yz-jeffcoexpress",
-          "name": "JeffCo Express",
-          "website": "http://www.jeffcoexpress.org/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "199"
+              "gtfs_agency_id": "475"
             }
           ],
+          "name": "Santa Maria Area Transit",
+          "onestop_id": "o-9q4-santamariaareatransit",
+          "short_name": "SMAT",
           "tags": {
-            "twitter_general": "JeffCoExpress"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dp8d-jts~wi~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/jts-wi-us/jts-wi-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "jts-wi-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "janesville-transit-system"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dp8d-janesvilletransitsystem",
-          "tags": {
-            "us_ntd_id": "50108",
-            "wikidata_id": "Q6153111",
-            "twitter_general": "City_Janesville"
+            "twitter_general": "City_SantaMaria",
+            "us_ntd_id": "90087",
+            "wikidata_id": "Q7419673"
           },
-          "name": "Janesville Transit System",
-          "website": "http://www.ci.janesville.wi.us/index.aspx?page=124",
+          "website": "http://www.cityofsantamaria.org/home/showdocument?id=6159"
+        },
+        {
           "associated_feeds": [
             {
-              "gtfs_agency_id": "254"
+              "gtfs_agency_id": "476"
             }
-          ]
+          ],
+          "name": "Guadalupe Flyer",
+          "onestop_id": "o-9q4q-guadalupeflyer",
+          "tags": {
+            "us_ntd_id": "9R02-91043"
+          },
+          "website": "http://www.cityofsantamaria.org/home/showdocument?id=11840"
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "smat-ca-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/smat-ca-us/smat-ca-us.zip"
+      }
     },
     {
+      "id": "f-9q5-airportvaletexpress~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "229"
+            }
+          ],
+          "name": "Airport Valet Express",
+          "onestop_id": "o-9q5-airportvaletexpress",
+          "short_name": "Bakersfield",
+          "website": "https://www.airportvaletexpress.com/fares/"
+        }
+      ],
       "spec": "gtfs",
-      "id": "f-9q7-kerncounty~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/kerncounty-ca-us/kerncounty-ca-us.zip"
-      },
-      "license": {
-        "url": "http://kerntransit.org/developers-gtfs/",
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
       "tags": {
-        "feed_id": "kerncounty-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "kern-regional-transit"
+        "feed_id": "airportvaletexpress-ca-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/airportvaletexpress-ca-us/airportvaletexpress-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9q5-dpwlacounty~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1466"
+            }
+          ],
+          "name": "LA Go Bus",
+          "onestop_id": "o-9q5-lagobus",
+          "tags": {
+            "twitter_general": "LACoPublicWorks",
+            "us_ntd_id": "90270,90271,90272,90273,90274,90275,90276,90278"
+          },
+          "website": "https://dpw.lacounty.gov/transit/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "dpwlacounty-ca-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/dpwlacounty-ca-us/dpwlacounty-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9q56-thousandoaks~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "526"
+            }
+          ],
+          "name": "Thousand Oaks Transit",
+          "onestop_id": "o-9q56-thousandoakstransit",
+          "tags": {
+            "twitter_general": "TOTransit",
+            "us_ntd_id": "90165",
+            "wikidata_id": "Q7797062"
+          },
+          "website": "http://www.toaks.org/government/depts/public_works/transportation/default.asp"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "thousandoaks-ca-us",
+        "gtfs_data_exchange": "thousand-oaks-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/thousandoaks-ca-us/thousandoaks-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9q5b4-pvpta~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
       },
       "operators": [
         {
-          "onestop_id": "o-9q7-kerntransit",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "134"
+            }
+          ],
+          "name": "Palos Verdes Peninsula Transit Authority",
+          "onestop_id": "o-9q5b4-palosverdespeninsulatransitauthority",
+          "short_name": "PVPTA",
           "tags": {
-            "us_ntd_id": "9R02-91059",
-            "wikidata_id": "Q6394141",
-            "twitter_general": "KernTransit"
+            "us_ntd_id": "90287",
+            "wikidata_id": "Q7128670"
           },
-          "name": "Kern Transit",
-          "website": "http://kerntransit.org/?referrer=gtfs",
+          "website": "http://www.palosverdes.com/pvtransit/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "pvpta-ca-us",
+        "gtfs_data_exchange": "palos-verdes-peninsula-transit-authority",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/pvpta-ca-us/pvpta-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9q5bf-lawndale~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1522"
+            }
+          ],
+          "name": "Lawndale Beat",
+          "onestop_id": "o-9q5bf-lawndalebeat",
+          "tags": {
+            "us_ntd_id": "90280"
+          },
+          "website": "http://www.lawndalecity.org/html/DEPTHTML/CSD/Beat.htm"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "lawndale-ca-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/cityoflawndale-ca-us/cityoflawndale-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9q5cx-montereypark~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "509"
+            }
+          ],
+          "name": "Spirit Bus",
+          "onestop_id": "o-9q5cx-spiritbus",
+          "tags": {
+            "twitter_general": "CityofMPK",
+            "us_ntd_id": "90286",
+            "wikidata_id": "Q6905333"
+          },
+          "website": "http://www.montereypark.ca.gov/549/Spirit-Bus"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "montereypark-ca-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/montereypark-ca-us/montereypark-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9q5d-707",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "729"
+            }
+          ],
+          "name": "Simi Valley Transit",
+          "onestop_id": "o-9q5d-simivalleytransit",
+          "tags": {
+            "twitter_general": "svtransit",
+            "us_ntd_id": "90050"
+          },
+          "website": "http://www.simivalley.org/departments/community-services/simi-valley-transit"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "707"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/simivalley-ca-us/simivalley-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9q6-kcapta~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "804"
+            }
+          ],
+          "name": "Kings Area Rural Transit",
+          "onestop_id": "o-9q6-kingsarearuraltransit",
+          "short_name": "KART",
+          "tags": {
+            "us_ntd_id": "90200"
+          },
+          "website": "http://mykartbus.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "kcapta-ca-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/kcapta-ca-us/kcapta-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9q7-kerncounty~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "url": "http://kerntransit.org/developers-gtfs/",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
           "associated_feeds": [
             {
               "gtfs_agency_id": "194"
@@ -1771,2192 +572,146 @@
             {
               "feed_onestop_id": "f-kerncounty~ca~rt"
             }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9muq-lagunabeach~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/lagunabeach-ca-us/lagunabeach-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "lagunabeach-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "laguna-beach-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9muq-lagunabeachtransit",
+          ],
+          "name": "Kern Transit",
+          "onestop_id": "o-9q7-kerntransit",
           "tags": {
-            "us_ntd_id": "90119",
-            "twitter_general": "lagunabeachgov"
+            "twitter_general": "KernTransit",
+            "us_ntd_id": "9R02-91059",
+            "wikidata_id": "Q6394141"
           },
-          "name": "Laguna Beach Transit",
-          "website": "http://www.lagunabeachcity.net/cityhall/pw/transit/default.asp",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "126"
-            }
-          ]
+          "website": "http://kerntransit.org/?referrer=gtfs"
         }
-      ]
-    },
-    {
+      ],
       "spec": "gtfs",
-      "id": "f-9qb-laketransit~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/laketransit-ca-us/laketransit-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
       "tags": {
-        "feed_id": "laketransit-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "lake-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qb-laketransit",
-          "tags": {
-            "us_ntd_id": "9R02-91053",
-            "wikidata_id": "Q6478146"
-          },
-          "name": "Lake Transit",
-          "website": "http://www.laketransit.org/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "7"
-            },
-            {
-              "onestop_id": "f-9qb-laketransit~ca~us~rt"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9r4-lassen~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/lassen-ca-us/lassen-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "lassen-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "lassen-rural-bus"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9r4-lassenruralbus",
-          "tags": {
-            "us_ntd_id": "9R02-91098"
-          },
-          "name": "Lassen Rural Bus",
-          "website": "http://www.lassentransportation.com/a/Lassen-Rural-Bus-LRB.php?referrer=gtfs",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "81"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-c26-linktransit~wa~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/linktransit-wa-us/linktransit-wa-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "linktransit-wa-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "link-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-c26-linktransit",
-          "tags": {
-            "us_ntd_id": "00043",
-            "wikidata_id": "Q25000891",
-            "twitter_general": "LinkTransit"
-          },
-          "name": "Link Transit"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-c22-mason~wa~us",
-      "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/mason-wa-us/mason-wa-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "mason-wa-us",
+        "feed_id": "kerncounty-ca-us",
+        "gtfs_data_exchange": "kern-regional-transit",
         "managed_by": "trillium"
       },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/kerncounty-ca-us/kerncounty-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9q7m-portervilletransit",
       "operators": [
         {
-          "onestop_id": "o-c22-masontransitauthority",
-          "tags": {
-            "us_ntd_id": "0R03-00315",
-            "wikidata_id": "Q20712385",
-            "twitter_general": "masontransit"
-          },
-          "name": "Mason Transit Authority",
-          "website": "http://www.masontransit.org",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "480"
+              "gtfs_agency_id": "Porterville"
             }
-          ]
+          ],
+          "name": "Porterville Transit",
+          "onestop_id": "o-9q7m5-portervilletransit",
+          "tags": {
+            "twitter_general": "ridept",
+            "us_ntd_id": "90198"
+          }
+        },
+        {
+          "name": "Porterville Transit",
+          "onestop_id": "o-9q7m-portervilletransit",
+          "tags": {
+            "us_ntd_id": "90198"
+          }
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/porterville-ca-us/porterville-ca-us.zip"
+      }
     },
     {
-      "spec": "gtfs",
-      "id": "f-9qb-mendocino~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/mendocino-ca-us/mendocino-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "mendocino-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "mendocino-transit-authority"
-      },
+      "id": "f-9q8yy-missionbaytma~ca~us",
       "operators": [
         {
-          "onestop_id": "o-9qb-mendocinotransitauthority",
-          "tags": {
-            "us_ntd_id": "9R02-91047",
-            "wikidata_id": "Q6816698"
-          },
-          "name": "Mendocino Transit Authority",
-          "website": "http://www.mendocinotransit.org/?referrer=gtfs",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "42"
+              "gtfs_agency_id": "671"
             }
-          ]
+          ],
+          "name": "Mission Bay TMA",
+          "onestop_id": "o-9q8yy-missionbaytma",
+          "tags": {
+            "omd_provider_id": "mission-bay-tma",
+            "twitter_general": "MissionBayTMA"
+          },
+          "website": "http://missionbaytma.org/"
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "missionbaytma-ca-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/missionbaytma-ca-us/missionbaytma-ca-us.zip"
+      }
     },
     {
-      "spec": "gtfs",
-      "id": "f-drt7-merrimackvalley~ma~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/merrimackvalley-ma-us/merrimackvalley-ma-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes",
-        "url": "https://www.mass.gov/doc/developers-license-agreement-11132009/download"
-      },
-      "tags": {
-        "feed_id": "merrimackvalley-ma-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "merrimack-valley-regional-transit-authority"
-      },
+      "id": "f-9q8zr-tidelinewatertaxi~ca~us",
       "operators": [
         {
-          "onestop_id": "o-drt7-merrimackvalleymetroaltransitauthority",
-          "tags": {
-            "us_ntd_id": "10013",
-            "wikidata_id": "Q6820290",
-            "twitter_general": "mvrta_"
-          },
-          "name": "Merrimack Valley Regional Transit Authority",
-          "short_name": "MVRTA",
-          "website": "http://www.mvrta.com",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "441"
-            },
-            {
-              "feed_onestop_id": "f-merrimackvalley~rt"
+              "gtfs_agency_id": "513"
             }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drsf-montachusett~ma~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/montachusett-ma-us/montachusett-ma-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes",
-        "url": "https://www.mass.gov/doc/developers-license-agreement-11132009/download"
-      },
-      "tags": {
-        "feed_id": "montachusett-ma-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "montachusett-regional-transit-authority"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drsf-montachusettmetroaltransitauthority",
+          ],
+          "name": "Tideline Water Taxi",
+          "onestop_id": "o-9q8zr-tidelinewatertaxi",
           "tags": {
-            "us_ntd_id": "10061",
-            "wikidata_id": "Q6903133"
+            "omd_provider_id": "tideline-water-taxi",
+            "twitter_general": "tidelinesf"
           },
-          "name": "Montachusett Regional Transit Authority",
-          "short_name": "MART"
+          "website": "https://tidelinetickets.com"
         }
-      ]
-    },
-    {
+      ],
       "spec": "gtfs",
-      "id": "f-djf8-montgomerytransit~al~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/montgomerytransit-al-us/montgomerytransit-al-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
       "tags": {
-        "feed_id": "montgomerytransit-al-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "montgomery-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-djf8-montgomerytransit",
-          "tags": {
-            "us_ntd_id": "40044",
-            "wikidata_id": "Q6905645"
-          },
-          "name": "Montgomery Transit"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dpc4-oshkosh~wi~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/oshkosh-wi-us/oshkosh-wi-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "oshkosh-wi-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "go-transit-city-of-oshkosh"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dpc4-gotransitcityofoshkosh",
-          "tags": {
-            "us_ntd_id": "50009",
-            "wikidata_id": "Q5514128",
-            "twitter_general": "Oshkosh_Transit"
-          },
-          "name": "GO Transit (City of Oshkosh)"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9myr-paloverdevalley~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/paloverde_valley-ca-us/paloverde_valley-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "paloverde_valley-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "palo-verde-valley-transit-agency"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9myr-paloverdevalleytransitagency",
-          "name": "Palo Verde Valley Transit Agency",
-          "short_name": "PVVTA",
-          "website": "http://pvvta.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "75"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drmu1-patriotpartyboats~ma~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/patriotpartyboats-ma-us/patriotpartyboats-ma-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "patriotpartyboats-ma-us",
+        "feed_id": "tidelinewatertaxi-ca-us",
         "managed_by": "trillium"
       },
-      "operators": [
-        {
-          "onestop_id": "o-drmu1-patriotpartyboats",
-          "name": "Patriot Party Boats",
-          "website": "http://www.patriotpartyboats.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "280"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qbc9-petalumatransit~petaluma~ca~us",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/petalumatransit-petaluma-ca-us/petalumatransit-petaluma-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "petalumatransit-petaluma-ca-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qbc9-petalumatransit",
-          "tags": {
-            "us_ntd_id": "90213",
-            "wikidata_id": "Q7171668",
-            "twitter_general": "petalumatransit"
-          },
-          "name": "Petaluma Transit",
-          "website": "http://cityofpetaluma.net/pubworks/transit-sub.html",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "267"
-            }
-          ]
-        }
-      ]
+        "static_current": "http://trilliumtransit.com/transit_feeds/tidelinewatertaxi-ca-us/tidelinewatertaxi-ca-us.zip"
+      }
     },
     {
-      "spec": "gtfs",
-      "id": "f-9r4-plumas~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/plumas-ca-us/plumas-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "plumas-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "plumas-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9r4-plumastransit",
-          "tags": {
-            "us_ntd_id": "9R02-91119"
-          },
-          "name": "Plumas Transit",
-          "website": "http://www.plumastransit.com",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "20"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9q5b4-pvpta~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/pvpta-ca-us/pvpta-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "pvpta-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "palos-verdes-peninsula-transit-authority"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q5b4-palosverdespeninsulatransitauthority",
-          "tags": {
-            "us_ntd_id": "90287",
-            "wikidata_id": "Q7128670"
-          },
-          "name": "Palos Verdes Peninsula Transit Authority",
-          "short_name": "PVPTA",
-          "website": "http://www.palosverdes.com/pvtransit/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "134"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9we1-redappletransit~nm~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/redappletransit-nm-us/redappletransit-nm-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "redappletransit-nm-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9we1-redappletransit",
-          "tags": {
-            "us_ntd_id": "60100"
-          },
-          "name": "Red Apple Transit",
-          "website": "http://fmtn.org/index.aspx?nid=279",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "459"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9r0-redding~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/redding-ca-us/redding-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "redding-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "redding-area-bus-authority"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9r0-reddingareabusauthority",
-          "tags": {
-            "us_ntd_id": "90093",
-            "wikidata_id": "Q7305617",
-            "twitter_general": "cityofredding"
-          },
-          "name": "Redding Area Bus Authority",
-          "short_name": "RABA",
-          "website": "http://www.rabaride.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "25"
-            },
-            {
-              "onestop_id": "f-9r0-redding~ca~us~rt"
-            },
-            {
-              "onestop_id": "f-9r0-redding~ca~us~rt~alerts"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs-rt",
-      "id": "f-9r0-redding~ca~us~rt~alerts",
-      "urls": {
-        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/redding-ca-us/service_alerts.proto"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9r0-reddingareabusauthority",
-          "tags": {
-            "us_ntd_id": "90093",
-            "wikidata_id": "Q7305617",
-            "twitter_general": "cityofredding"
-          },
-          "name": "Redding Area Bus Authority",
-          "short_name": "RABA",
-          "website": "http://www.rabaride.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "25"
-            },
-            {
-              "onestop_id": "f-9r0-redding~ca~us~rt"
-            },
-            {
-              "onestop_id": "f-9r0-redding~ca~us~rt~alerts"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-c20w-rivercitiestransit~wa~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/rivercitiestransit-wa-us/rivercitiestransit-wa-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "rivercitiestransit-wa-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "rivercities-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-c20w-rivercitiestransit",
-          "tags": {
-            "us_ntd_id": "00016",
-            "wikidata_id": "Q28451877"
-          },
-          "name": "RiverCities Transit"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dru-ruralcommunity~vt~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/ruralcommunity-vt-us/ruralcommunity-vt-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "ruralcommunity-vt-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "rural-community-transportation"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dru-ruralcommunitytransportation",
-          "tags": {
-            "us_ntd_id": "1R06-10148",
-            "wikidata_id": "Q7380490"
-          },
-          "name": "Rural Community Transportation",
-          "short_name": "RCT",
-          "website": "http://www.riderct.org/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "221"
-            },
-            {
-              "feed_onestop_id": "f-ruralcommunity~vt~rt"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
       "id": "f-9q99-sanbenito~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/sanbenitocounty-ca-us/sanbenitocounty-ca-us.zip"
-      },
       "license": {
-        "use_without_attribution": "yes",
         "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "sanbenito-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "san-benito-county-express"
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
       },
       "operators": [
         {
-          "onestop_id": "o-9q99-sanbenitocountyexpress",
-          "tags": {
-            "wikidata_id": "Q7413407",
-            "twitter_general": "CountyExpress"
-          },
-          "name": "San Benito County Express",
-          "website": "http://www.SanBenitoCountyExpress.org/",
           "associated_feeds": [
             {
               "gtfs_agency_id": "123"
             }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9zep-siouxareametro~sd~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/siouxareametro-sd-us/siouxareametro-sd-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "siouxareametro-sd-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "sioux-area-metro"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9zep-siouxareametro",
-          "tags": {
-            "us_ntd_id": "80002",
-            "wikidata_id": "Q7525432",
-            "twitter_general": "citysiouxfalls"
-          },
-          "name": "Sioux Area Metro",
-          "website": "http://www.siouxfalls.org/sam/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "217"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9r2-siskiyou~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/siskiyou-ca-us/siskiyou-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "siskiyou-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "siskiyou-transit-and-general-express"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9r2-siskiyoutransitandgeneralexpress",
-          "tags": {
-            "us_ntd_id": "9R02-91048"
-          },
-          "name": "Siskiyou Transit and General Express",
-          "website": "http://www.co.siskiyou.ca.us/GS/stage.aspx",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "24"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qc0-soltrans~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/soltrans-ca-us/soltrans-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "soltrans-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "soltrans"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qc0-soltrans",
-          "tags": {
-            "us_ntd_id": "90232",
-            "wikidata_id": "Q16984743",
-            "twitter_general": "SolTransRide"
-          },
-          "name": "Solano County Transit",
-          "short_name": "SolTrans"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qb-sonomacounty~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/sonomacounty-ca-us/sonomacounty-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "sonomacounty-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "cloverdale-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qb-sonomacountytransit",
-          "tags": {
-            "us_ntd_id": "90089",
-            "wikidata_id": "Q7562177",
-            "twitter_general": "SoCo_TPW"
-          },
-          "name": "Sonoma County Transit",
-          "website": "http://www.sctransit.com",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "175"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-djn-spacecoast~fl~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/spacecoast-fl-us/spacecoast-fl-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "spacecoast-fl-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "space-coast-area-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-djn-spacecoastareatransit",
-          "tags": {
-            "us_ntd_id": "40063",
-            "wikidata_id": "Q7572299",
-            "twitter_general": "321Transit"
-          },
-          "name": "Space Coast Area Transit",
-          "website": "http://www.ridescat.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "71"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dru-stagecoach~vt~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/stagecoach-vt-us/stagecoach-vt-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "stagecoach-vt-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "stagecoach-transportation-services"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dru-stagecoachtransportationservices",
-          "tags": {
-            "us_ntd_id": "1R06-10168"
-          },
-          "name": "Stagecoach Transportation Services",
-          "website": "http://stagecoach-rides.org",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "222"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-trivalley~vt~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/trivalleytransit-vt-us/trivalleytransit-vt-us.zip"
-      },
-      "license": {
-        "url": "http://vermont-gtfs.org/"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dru-tri~valleytransit",
-          "name": "Tri-Valley Transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "986"
-            }
           ],
+          "name": "San Benito County Express",
+          "onestop_id": "o-9q99-sanbenitocountyexpress",
           "tags": {
-            "us_ntd_id": "1R06-10143",
-            "twitter_general": "actransitvt"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qd-stanislaus~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/stanislaus-ca-us/stanislaus-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "stanislaus-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": " Ceres Area Transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qdj3-buslineserviceofturlock",
-          "name": "Bus Line Service of Turlock",
-          "website": "http://www.turlock.ca.us/citydepartments/developmentservices/transitservices/blasttransitlines/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "69"
-            }
-          ]
-        },
-        {
-          "onestop_id": "o-9q9vz-ceresareatransit",
-          "name": "Ceres Area Transit",
-          "website": "http://www.ci.ceres.ca.us/CeresAreaTransit/CAT.html",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "70"
-            }
-          ]
-        },
-        {
-          "onestop_id": "o-9q9-stanislausmetroaltransit",
-          "tags": {
-            "us_ntd_id": "90236",
-            "wikidata_id": "Q7598964",
-            "twitter_general": "RideStaRT"
+            "twitter_general": "CountyExpress",
+            "wikidata_id": "Q7413407"
           },
-          "name": "Stanislaus Regional Transit",
-          "short_name": "StaRT",
-          "website": "http://www.srt.org/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "68"
-            }
-          ]
+          "website": "http://www.SanBenitoCountyExpress.org/"
         }
-      ]
-    },
-    {
+      ],
       "spec": "gtfs",
-      "id": "f-c815-streamlinetransit~mt~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/streamlinetransit-mt-us/streamlinetransit-mt-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
       "tags": {
-        "feed_id": "streamlinetransit-mt-us",
+        "feed_id": "sanbenito-ca-us",
+        "gtfs_data_exchange": "san-benito-county-express",
         "managed_by": "trillium"
       },
-      "operators": [
-        {
-          "onestop_id": "o-c815-streamline",
-          "tags": {
-            "us_ntd_id": "8R02-80235",
-            "twitter_general": "ridestreamline"
-          },
-          "name": "Streamline",
-          "website": "http://www.streamlinebus.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "259"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9r1-tehama~ca~us",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/tehama-ca-us/tehama-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "tehama-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": " Susanville Indian Rancheria Public Transportation Program"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9r1-susanvilleindianrancheriapublictransportationprogram",
-          "tags": {
-            "us_ntd_id": "99256"
-          },
-          "name": "Susanville Indian Rancheria Public Transportation Program",
-          "website": "http://www.transitunlimited.org/Susanville_Indian_Rancheria_Public_Transportation_Program",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "62"
-            }
-          ]
-        },
-        {
-          "onestop_id": "o-9r1h-tehamaruralareaexpress",
-          "tags": {
-            "us_ntd_id": "9R02-91089"
-          },
-          "name": "Tehama Rural Area Express",
-          "short_name": "TRAX",
-          "website": "http://www.taketrax.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "21"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dp1b-terrehautetransit~in~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/terrehautetransit-in-us/terrehautetransit-in-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "terrehautetransit-in-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "terre-haute-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dp1b-terrehautetransit",
-          "tags": {
-            "us_ntd_id": "50053",
-            "wikidata_id": "Q7703361"
-          },
-          "name": "Terre Haute Transit",
-          "website": "http://terrehaute.in.gov/departments/transit-department",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "260"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drs-thebus~vt~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/thebus-vt-us/thebus-vt-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "thebus-vt-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "the-bus-marble-valley-regional-transit-district"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drs-thebusmarblevalleymetroaltransitdistrict",
-          "tags": {
-            "us_ntd_id": "1R06-10154",
-            "wikidata_id": "Q6755227"
-          },
-          "name": "The Bus (Marble Valley Regional Transit District)",
-          "short_name": "MVRTD",
-          "website": "http://www.thebus.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "220"
-            },
-            {
-              "feed_onestop_id": "f-thebus~vt~rt"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9w0q-verdelynx~az~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/verdelynx-az-us/verdelynx-az-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "verdelynx-az-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9w0q-verdelynx",
-          "tags": {
-            "omd_provider_id": "verde-lynx",
-            "us_ntd_id": "9R01-91010"
-          },
-          "name": "Verde Lynx",
-          "website": "https://cottonwoodaz.gov/166/Verde-Lynx-Public-Transportation",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "65"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qh-victorville~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/victorville-ca-us/victorville-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "victorville-ca-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qh-victorvalleytransitauthority",
-          "tags": {
-            "us_ntd_id": "90148",
-            "wikidata_id": "Q7926418",
-            "twitter_general": "VVTransit"
-          },
-          "name": "Victor Valley Transit Authority",
-          "short_name": "VVTA",
-          "website": "http://www.vvta.org",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "493"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drm-vineyardfastferry~ri~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/vineyardfastferry-ri-us/vineyardfastferry-ri-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "vineyardfastferry-ri-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drm-vineyardfastferry",
-          "tags": {
-            "wikidata_id": "https://twitter.com/RIFastFerry"
-          },
-          "name": "Vineyard Fast Ferry",
-          "website": "https://www.vineyardfastferry.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "281"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dru-vttranslines~vt~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/vttranslines-vt-us/vttranslines-vt-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "vttranslines-vt-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dru-vermonttranslines",
-          "name": "Vermont Translines",
-          "website": "https://www.vttranslines.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "228"
-            }
-          ],
-          "tags": {
-            "twitter_general": "vttranslines"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dp9k-waukeshacounty~wi~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/waukeshacounty-wi-us/waukeshacounty-wi-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "waukeshacounty-wi-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dp9k-waukeshacountytransit",
-          "tags": {
-            "us_ntd_id": "50096",
-            "wikidata_id": "Q7975163"
-          },
-          "name": "Waukesha County Transit",
-          "website": "http://www.ci.waukesha.wi.us/web/guest/waukeshametro/transit_home",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "189"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qc-westcat~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/westcat-ca-us/westcat-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "westcat-ca-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qc-westcatwesterncontracosta",
-          "tags": {
-            "us_ntd_id": "90159",
-            "wikidata_id": "Q7984179",
-            "twitter_general": "wccta"
-          },
-          "name": "WestCat (Western Contra Costa)",
-          "website": "http://www.westcat.org/index.html",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "392"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-c20-wilsonville~or~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/wilsonville-or-us/wilsonville-or-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "wilsonville-or-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "smart"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-c20-southmetroareametroaltransit",
-          "tags": {
-            "us_ntd_id": "00046",
-            "wikidata_id": "Q7567940"
-          },
-          "name": "South Metro Area Regional Transit",
-          "short_name": "SMART",
-          "website": "http://www.ridesmart.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "101"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qc-yubasutter~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/yubasutter-ca-us/yubasutter-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "tags": {
-        "feed_id": "yubasutter-ca-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qc-yuba~suttertransit",
-          "tags": {
-            "us_ntd_id": "90061",
-            "wikidata_id": "Q8060099",
-            "twitter_general": "yubacounty"
-          },
-          "name": "Yuba-Sutter Transit"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dnr-tta~regionalbus~nc~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/tta-regionalbus-nc-us/tta-regionalbus-nc-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes",
-        "url": "https://gotriangle.org/developer-terms-and-conditions"
-      },
-      "tags": {
-        "feed_id": "tta-regionalbus-nc-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dnr-gotriangle",
-          "tags": {
-            "us_ntd_id": "40108",
-            "wikidata_id": "Q7840091",
-            "twitter_general": "ocptnc"
-          },
-          "name": "GoTriangle"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drsb-wrta",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/wrta-ma-us/wrta-ma-us.zip"
-      },
-      "license": {
-        "url": "https://www.massdot.state.ma.us/Portals/0/docs/developers/develop_license_agree.pdf",
-        "use_without_attribution": "no",
-        "create_derived_product": "yes",
-        "redistribute": "yes",
-        "attribution_text": "Clearly acknowledge MassDOT as the provider of the Data."
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drsb-wrta",
-          "tags": {
-            "us_ntd_id": "10014",
-            "wikidata_id": "Q8034217",
-            "twitter_general": "therta"
-          },
-          "name": "Worcester Regional Transit Authority",
-          "short_name": "WRTA"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dnh0-gwinnettcountytransit",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/gwinnettcountytransit-ga-us/gwinnettcountytransit-ga-us.zip"
-      },
-      "license": {
-        "url": "http://atlantaregional.com/File%20Library/Transportation/Transit/Developers-Agreement-for-Web.pdf",
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "redistribute": "yes"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dnh0-gwinnettcountytransit",
-          "tags": {
-            "us_ntd_id": "40138",
-            "wikidata_id": "Q5623666",
-            "twitter_general": "gctransit"
-          },
-          "name": "Gwinnett County Transit",
-          "short_name": "GCT",
-          "website": "http://www.gctransit.com",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "GCT"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9q56-thousandoaks~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/thousandoaks-ca-us/thousandoaks-ca-us.zip"
-      },
-      "tags": {
-        "feed_id": "thousandoaks-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "thousand-oaks-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q56-thousandoakstransit",
-          "tags": {
-            "us_ntd_id": "90165",
-            "wikidata_id": "Q7797062",
-            "twitter_general": "TOTransit"
-          },
-          "name": "Thousand Oaks Transit",
-          "website": "http://www.toaks.org/government/depts/public_works/transportation/default.asp",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "526"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-djj6-thehernandoexpress~fl~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/thehernandoexpress-fl-us/thehernandoexpress-fl-us.zip"
-      },
-      "tags": {
-        "status": "outdated",
-        "feed_id": "thehernandoexpress-fl-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-djj6-hernandobus",
-          "tags": {
-            "us_ntd_id": "40146",
-            "wikidata_id": "Q7670246",
-            "twitter_general": "HernandoCoGov"
-          },
-          "name": "Hernando County Transit",
-          "short_name": "The Bus"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-djjk-citruscounty~fl~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/citruscounty-fl-us/citruscounty-fl-us.zip"
-      },
-      "tags": {
-        "feed_id": "citruscounty-fl-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-djjk-orangelinebuscitruscountytransit",
-          "tags": {
-            "wikidata_id": "Q5122888",
-            "twitter_general": "citrusbocc"
-          },
-          "name": "Citrus County Transit",
-          "short_name": "Orange Line Bus",
-          "website": "http://www.citruscountytransit.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "409"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dj3-ecat~fl~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/ecat-fl-us/ecat-fl-us.zip"
-      },
-      "tags": {
-        "feed_id": "ecat-fl-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "escambia-county-area-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dj3-escambiacountyareatransit",
-          "tags": {
-            "us_ntd_id": "40038",
-            "wikidata_id": "Q5396846",
-            "twitter_general": "rideecat"
-          },
-          "name": "Escambia County Area Transit",
-          "short_name": "ECAT",
-          "website": "https://goecat.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "413"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dj6m-okaloosacountytransit~fl~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/okaloosacountytransit-fl-us/okaloosacountytransit-fl-us.zip"
-      },
-      "tags": {
-        "status": "outdated",
-        "feed_id": "okaloosacountytransit-fl-us",
-        "gtfs_data_exchange": "emerald-coast-rider"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dj6m-emeraldcoastrider",
-          "tags": {
-            "us_ntd_id": "40128"
-          },
-          "name": "Emerald Coast Rider",
-          "short_name": "ECR",
-          "website": "http://ecrider.org/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "412"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dj75-baytowntrolley~fl~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/baytowntrolley-fl-us/baytowntrolley-fl-us.zip"
-      },
-      "tags": {
-        "feed_id": "baytowntrolley-fl-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "bay-town-trolley"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dj75-baytowntrolley",
-          "tags": {
-            "wikidata_id": "Q4874138",
-            "twitter_general": "BayTownTrolley"
-          },
-          "name": "Bay Town Trolley",
-          "website": "http://www.baytowntrolley.org",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "407"
-            },
-            {
-              "feed_onestop_id": "f-baytowntrolley~fl~rt"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drmg-marthasvineyard~ma~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/marthasvineyard-ma-us/marthasvineyard-ma-us.zip"
-      },
-      "license": {
-        "url": "https://www.massdot.state.ma.us/Portals/0/docs/developers/develop_license_agree.pdf",
-        "use_without_attribution": "no",
-        "create_derived_product": "yes",
-        "redistribute": "yes",
-        "attribution_text": "Clearly acknowledge MassDOT as the provider of the Data."
-      },
-      "tags": {
-        "feed_id": "marthasvineyard-ma-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drmg-marthasvineyardtransitauthority",
-          "tags": {
-            "us_ntd_id": "1R02-10145",
-            "wikidata_id": "Q20715059",
-            "twitter_general": "VTA_MV"
-          },
-          "name": "Martha's Vineyard Transit Authority",
-          "short_name": "VTA"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drmm-southeasternregionaltransitauthority",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/srta-ma-us/srta-ma-us.zip"
-      },
-      "tags": {
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "southeastern-regional-transit-authority"
-      },
-      "license": {
-        "url": "https://www.mass.gov/doc/developers-license-agreement-11132009/download"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drmm-southeasternregionaltransitauthority",
-          "tags": {
-            "us_ntd_id": "10006",
-            "wikidata_id": "Q7569500",
-            "twitter_general": "srtabus"
-          },
-          "name": "Southeastern Regional Transit Authority",
-          "short_name": "SRTA"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dr-peterpanbuslines",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/peterpan-ma-us/peterpan-ma-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dr-peterpanbonanzadivision",
-          "name": "Peter Pan Bonanza Division",
-          "website": "https://peterpanbus.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "642"
-            }
-          ]
-        },
-        {
-          "onestop_id": "o-dr-peterpanbuslines",
-          "tags": {
-            "us_ntd_id": "1R02-10157",
-            "wikidata_id": "Q204807",
-            "twitter_general": "PeterPanBus",
-            "twitter_service_alerts": "peterpanalerts"
-          },
-          "name": "Peter Pan Bus Lines",
-          "website": "http://peterpanbus.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "PeterPan"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drq4-thewave~nantucketregionaltransitauthority",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/nantucket-ma-us/nantucket-ma-us.zip"
-      },
-      "tags": {
-        "managed_by": "trillium"
-      },
-      "license": {
-        "url": "https://www.mass.gov/doc/developers-license-agreement-11132009/download"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drq4-thewave~nantucketregionaltransitauthority",
-          "tags": {
-            "us_ntd_id": "1R02-10162",
-            "wikidata_id": "Q6964378"
-          },
-          "name": "Nantucket Regional Transit Authority",
-          "short_name": "WAVE"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drt6-lowellregionaltransitauthority",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/lowell-ma-us/lowell-ma-us.zip"
-      },
-      "tags": {
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "lowell-regional-transit-authority"
-      },
-      "license": {
-        "url": "https://www.mass.gov/doc/developers-license-agreement-11132009/download"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drt6-lowellregionaltransitauthority",
-          "tags": {
-            "us_ntd_id": "10005",
-            "wikidata_id": "Q2078562",
-            "twitter_general": "mylrta"
-          },
-          "name": "Lowell Regional Transit Authority",
-          "short_name": "LRTA"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drm-thegreaterattleborotauntonregionaltransitauthority",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/gatra-ma-us/gatra-ma-us.zip"
-      },
-      "tags": {
-        "managed_by": "trillium"
-      },
-      "license": {
-        "url": "https://www.mass.gov/doc/developers-license-agreement-11132009/download"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drm-thegreaterattleborotauntonregionaltransitauthority",
-          "tags": {
-            "us_ntd_id": "10064",
-            "wikidata_id": "Q5600434"
-          },
-          "name": "Greater Attleboro Taunton Regional Transit Authority",
-          "short_name": "GATRA"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drq-capecodregionaltransitauthorityccrta",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/capecod-ma-us/capecod-ma-us.zip"
-      },
-      "license": {
-        "url": "https://www.massdot.state.ma.us/Portals/0/docs/developers/develop_license_agree.pdf",
-        "use_without_attribution": "no",
-        "create_derived_product": "yes",
-        "redistribute": "yes",
-        "attribution_text": "Clearly acknowledge MassDOT as the provider of the Data."
-      },
-      "tags": {
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "cape-cod-regional-transit-authority"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drq-capecodregionaltransitauthorityccrta",
-          "tags": {
-            "us_ntd_id": "10105",
-            "wikidata_id": "Q5034704",
-            "twitter_general": "CapeCodRTA"
-          },
-          "name": "Cape Cod Regional Transit Authority",
-          "short_name": "CCRTA"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9ry8-mountainridestransportationauthoritymrta",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/mountainrides-id-us/mountainrides-id-us.zip"
-      },
-      "tags": {
-        "gtfs_data_exchange": "mountain-rides-transportation-authority-mrta"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9ry8-mountainridestransportationauthoritymrta",
-          "name": "Mountain Rides Transportation Authority",
-          "short_name": "MRTA",
-          "website": "http://www.mountainrides.org/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "MRTA"
-            }
-          ],
-          "tags": {
-            "twitter_general": "mountainrides"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-c427-cityandboroughofjuneau~ak~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/cityandboroughofjuneau-ak-us/cityandboroughofjuneau-ak-us.zip"
-      },
-      "tags": {
-        "feed_id": "cityandboroughofjuneau-ak-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-c427-capitaltransit",
-          "tags": {
-            "us_ntd_id": "0R04-00391",
-            "wikidata_id": "Q5035680",
-            "twitter_general": "cbjuneau"
-          },
-          "name": "Capital Transit",
-          "website": "http://www.juneau.org/capitaltransit/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "474"
-            },
-            {
-              "feed_onestop_id": "f-cityandboroughofjuneau~rt"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qc3-datatrilliumtransitcom",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/riovista-ca-us/riovista-ca-us.zip"
-      },
-      "tags": {
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "rio-vista-delta-breeze"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qc3-riovistadeltabreeze",
-          "tags": {
-            "us_ntd_id": "9R02-91014",
-            "wikidata_id": "Q7335361",
-            "twitter_general": "cityofriovista"
-          },
-          "name": "Rio Vista Delta Breeze",
-          "website": "http://www.riovistacity.com/transit/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "RV"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-djjt-suntran~fl~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/suntran-fl-us/suntran-fl-us.zip"
-      },
-      "tags": {
-        "feed_id": "suntran-fl-us",
-        "gtfs_data_exchange": "suntran"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-djjt-suntrancityofocala",
-          "tags": {
-            "us_ntd_id": "40120",
-            "wikidata_id": "Q5123847",
-            "twitter_general": "CityofOcalaFL"
-          },
-          "name": "SunTran"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-djq-sunshinebuscompany~fl~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/sunshinebuscompany-fl-us/sunshinebuscompany-fl-us.zip"
-      },
-      "tags": {
-        "feed_id": "sunshinebuscompany-fl-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "sunshine-bus-company"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-djq-sunshinebuscompany",
-          "name": "Sunshine Bus Company",
-          "website": "http://www.sunshinebus.net/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "408"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-djz4-carta~sc~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/carta-sc-us/carta-sc-us.zip"
-      },
-      "tags": {
-        "feed_id": "carta-sc-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "charleston-area-regional-transportation-authority"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-djz4-charlestonarearegionaltransportationauthority",
-          "tags": {
-            "us_ntd_id": "40110",
-            "wikidata_id": "Q5084103",
-            "twitter_general": "ridecarta"
-          },
-          "name": "Charleston Area Regional Transportation Authority",
-          "short_name": "CARTA",
-          "website": "http://www.ridecarta.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "213"
-            },
-            {
-              "feed_onstop_id": "f-djz4-carta~sc~us~rt"
-            },
-            {
-              "feed_onstop_id": "f-djz4-carta~sc~us~alerts"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs-rt",
-      "id": "f-djz4-carta~sc~us~alerts",
-      "urls": {
-        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/carta-sc-us/service_alerts.proto"
+        "static_current": "http://data.trilliumtransit.com/gtfs/sanbenitocounty-ca-us/sanbenitocounty-ca-us.zip"
       }
     },
     {
-      "spec": "gtfs",
-      "id": "f-dpq-lakecounty~oh~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/lakecounty-oh-us/lakecounty-oh-us.zip"
-      },
-      "tags": {
-        "feed_id": "lakecounty-oh-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dpq-laketran",
-          "tags": {
-            "us_ntd_id": "50117",
-            "wikidata_id": "Q6479195",
-            "twitter_general": "laketran"
-          },
-          "name": "Laketran",
-          "website": "http://www.laketran.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "508"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drm-blockislandferry~ri~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/blockislandferry-ri-us/blockislandferry-ri-us.zip"
-      },
-      "tags": {
-        "feed_id": "blockislandferry-ri-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drm-blockislandferry",
-          "name": "Block Island Ferry",
-          "website": "http://www.blockislandferry.com",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "276"
-            }
-          ],
-          "tags": {
-            "twitter_general": "BlockIsleFerry"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dpc8-sheboygan~wi~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/sheboygan-wi-us/sheboygan-wi-us.zip"
-      },
-      "tags": {
-        "feed_id": "sheboygan-wi-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dpc8-shorelinemetro",
-          "tags": {
-            "us_ntd_id": "50088",
-            "wikidata_id": "Q7501442"
-          },
-          "name": "Shoreline Metro"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9q4-smat~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/smat-ca-us/smat-ca-us.zip"
-      },
-      "tags": {
-        "feed_id": "smat-ca-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q4-santamariaareatransit",
-          "tags": {
-            "us_ntd_id": "90087",
-            "wikidata_id": "Q7419673",
-            "twitter_general": "City_SantaMaria"
-          },
-          "name": "Santa Maria Area Transit",
-          "short_name": "SMAT",
-          "website": "http://www.cityofsantamaria.org/home/showdocument?id=6159",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "475"
-            }
-          ]
-        },
-        {
-          "onestop_id": "o-9q4q-guadalupeflyer",
-          "tags": {
-            "us_ntd_id": "9R02-91043"
-          },
-          "name": "Guadalupe Flyer",
-          "website": "http://www.cityofsantamaria.org/home/showdocument?id=11840",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "476"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9xh-ecotransit~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/ecotransit-co-us/ecotransit-co-us.zip"
-      },
-      "tags": {
-        "feed_id": "ecotransit-co-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9xh-ecotransit",
-          "name": "ECO Transit",
-          "website": "http://www.eaglecounty.us/Transit/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "536"
-            }
-          ],
-          "tags": {
-            "twitter_general": "EagleCounty"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9r4-rtcride",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/rtc-nv-us/rtc-nv-us.zip"
-      },
-      "tags": {
-        "gtfs_data_exchange": "rtc-ride"
-      },
-      "license": {
-        "url": "https://www.rtcwashoe.com/terms-of-use/"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9r4-rtcride",
-          "tags": {
-            "us_ntd_id": "90001",
-            "wikidata_id": "Q7309179",
-            "twitter_general": "rtcwashoe"
-          },
-          "name": "Regional Transportation Commission",
-          "short_name": "RTC",
-          "website": "http://www.rtcwashoe.com"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9q9p3-emerygoround",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/emerygoround-ca-us/emerygoround-ca-us.zip"
-      },
-      "tags": {
-        "feed_id": "emerygoround-ca-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q9p3-emerygo~round",
-          "tags": {
-            "wikidata_id": "Q5370986",
-            "twitter_general": "emeryvilleca"
-          },
-          "name": "Emery Go-Round",
-          "website": "http://www.emerygoround.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "573"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
       "id": "f-9q9hy-mountainview",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/mountainview-ca-us/mountainview-ca-us.zip"
-      },
-      "tags": {
-        "feed_id": "mountainview-ca-us",
-        "managed_by": "trillium"
-      },
       "operators": [
         {
-          "onestop_id": "o-9q9hy-mvgomountainview",
-          "name": "Mountain View Transportation Management Association",
-          "short_name": "MVgo",
-          "website": "http://mvgo.org",
           "associated_feeds": [
             {
               "gtfs_agency_id": "533"
@@ -3965,15 +720,27 @@
               "feed_onestop_id": "f-9q9hy-mountainview~rt"
             }
           ],
+          "name": "Mountain View Transportation Management Association",
+          "onestop_id": "o-9q9hy-mvgomountainview",
+          "short_name": "MVgo",
           "tags": {
             "twitter_general": "MvgoShuttle"
-          }
+          },
+          "website": "http://mvgo.org"
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "mountainview-ca-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/mountainview-ca-us/mountainview-ca-us.zip"
+      }
     },
     {
-      "spec": "gtfs-rt",
       "id": "f-9q9hy-mountainview~rt",
+      "spec": "gtfs-rt",
       "urls": {
         "realtime_alerts": "https://ridemvgo.org/gtfs-rt/alerts",
         "realtime_trip_updates": "https://ridemvgo.org/gtfs-rt/tripupdates",
@@ -3981,570 +748,1830 @@
       }
     },
     {
-      "spec": "gtfs",
-      "id": "f-dnq9-ckrider~nc~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/ckrider-nc-us/ckrider-nc-us.zip"
-      },
-      "tags": {
-        "feed_id": "ckrider-nc-us",
-        "managed_by": "trillium"
-      },
+      "id": "f-9q9j-commute~ca~us",
       "operators": [
         {
-          "onestop_id": "o-dnq9-concordkannapolisareatransit",
-          "tags": {
-            "us_ntd_id": "40167",
-            "wikidata_id": "Q5158814"
-          },
-          "name": "Concord Kannapolis Area Transit",
-          "website": "http://www.ckrider.com/",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "541"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qh45-duartetransit~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/duartetransit-ca-us/duartetransit-ca-us.zip"
-      },
-      "tags": {
-        "feed_id": "duartetransit-ca-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qh45-duartetransit",
-          "tags": {
-            "us_ntd_id": "90264",
-            "twitter_general": "cityofduarte"
-          },
-          "name": "Duarte Transit",
-          "website": "http://www.accessduarte.com/~accessdu/index.php?option=com_content&view=article&id=88&Itemid=131",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "484"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dps-michiganflyer~mi~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/michiganflyer-mi-us/michiganflyer-mi-us.zip"
-      },
-      "tags": {
-        "feed_id": "michiganflyer-mi-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dps-michiganflyer",
-          "tags": {
-            "wikidata_id": "Q6021774",
-            "twitter_general": "MichiganFlyer1"
-          },
-          "name": "Michigan Flyer",
-          "website": "http://www.michiganflyer.com/Home.aspx",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "535"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9q5cx-montereypark~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/montereypark-ca-us/montereypark-ca-us.zip"
-      },
-      "tags": {
-        "feed_id": "montereypark-ca-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q5cx-spiritbus",
-          "tags": {
-            "us_ntd_id": "90286",
-            "wikidata_id": "Q6905333",
-            "twitter_general": "CityofMPK"
-          },
-          "name": "Spirit Bus",
-          "website": "http://www.montereypark.ca.gov/549/Spirit-Bus",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "509"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drke-ninetown~connecticut~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/ninetown-connecticut-us/ninetown-connecticut-us.zip"
-      },
-      "tags": {
-        "feed_id": "ninetown-connecticut-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drke-9towntransit",
-          "tags": {
-            "us_ntd_id": "1R01-10140",
-            "wikidata_id": "Q5401887",
-            "twitter_general": "9towntransit"
-          },
-          "name": "9 Town Transit",
-          "website": "http://estuarytransit.org/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "539"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drt3-123bc~ma~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/route128corridor-ma-us/route128corridor-ma-us.zip"
-      },
-      "tags": {
-        "feed_id": "123bc-ma-us",
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drt3-128businesscouncil",
-          "name": "128 Business Council",
-          "website": "http://128bc.org/rev-hartwell-area-shuttle/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "466"
+              "gtfs_agency_id": "936"
             }
           ],
+          "name": "Commute.org Shuttles",
+          "onestop_id": "o-9q9j-commuteorgshuttles",
           "tags": {
-            "twitter_general": "UnlockTheGrid"
+            "twitter_general": "SMCountyCommute",
+            "wikidata_id": "Q7162971"
+          },
+          "website": "http://www.commute.org"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "commute-ca-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/commute-ca-us/commute-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9q9p3-emerygoround",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "573"
+            }
+          ],
+          "name": "Emery Go-Round",
+          "onestop_id": "o-9q9p3-emerygo~round",
+          "tags": {
+            "twitter_general": "emeryvilleca",
+            "wikidata_id": "Q5370986"
+          },
+          "website": "http://www.emerygoround.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "emerygoround-ca-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/emerygoround-ca-us/emerygoround-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9q9y-escalon~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "52"
+            }
+          ],
+          "name": "eTrans",
+          "onestop_id": "o-9q9y-etrans",
+          "tags": {
+            "us_ntd_id": "9R02-91078"
+          },
+          "website": "http://cityofescalon.org/departments/transit-services/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "escalon-ca-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/escalon-ca-us/escalon-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qb-airportexpressinc~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "953"
+            }
+          ],
+          "name": "Sonoma County Airport Express",
+          "onestop_id": "o-9qb-sonomacountyairportexpress",
+          "website": "http://airportexpressinc.com/?utm_source=google&utm_medium=transit&utm_campaign=sonoma"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "airportexpressinc-ca-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/airportexpressinc-ca-us/airportexpressinc-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qb-laketransit~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "7"
+            },
+            {
+              "onestop_id": "f-9qb-laketransit~ca~us~rt"
+            }
+          ],
+          "name": "Lake Transit",
+          "onestop_id": "o-9qb-laketransit",
+          "tags": {
+            "us_ntd_id": "9R02-91053",
+            "wikidata_id": "Q6478146"
+          },
+          "website": "http://www.laketransit.org/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "laketransit-ca-us",
+        "gtfs_data_exchange": "lake-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/laketransit-ca-us/laketransit-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qb-mendocino~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "42"
+            }
+          ],
+          "name": "Mendocino Transit Authority",
+          "onestop_id": "o-9qb-mendocinotransitauthority",
+          "tags": {
+            "us_ntd_id": "9R02-91047",
+            "wikidata_id": "Q6816698"
+          },
+          "website": "http://www.mendocinotransit.org/?referrer=gtfs"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "mendocino-ca-us",
+        "gtfs_data_exchange": "mendocino-transit-authority",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/mendocino-ca-us/mendocino-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qb-sonomacounty~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "175"
+            }
+          ],
+          "name": "Sonoma County Transit",
+          "onestop_id": "o-9qb-sonomacountytransit",
+          "tags": {
+            "twitter_general": "SoCo_TPW",
+            "us_ntd_id": "90089",
+            "wikidata_id": "Q7562177"
+          },
+          "website": "http://www.sctransit.com"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "sonomacounty-ca-us",
+        "gtfs_data_exchange": "cloverdale-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/sonomacounty-ca-us/sonomacounty-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qbc9-petalumatransit~petaluma~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "267"
+            }
+          ],
+          "name": "Petaluma Transit",
+          "onestop_id": "o-9qbc9-petalumatransit",
+          "tags": {
+            "twitter_general": "petalumatransit",
+            "us_ntd_id": "90213",
+            "wikidata_id": "Q7171668"
+          },
+          "website": "http://cityofpetaluma.net/pubworks/transit-sub.html"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "petalumatransit-petaluma-ca-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/petalumatransit-petaluma-ca-us/petalumatransit-petaluma-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qc-eldoradotransit~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "261"
+            }
+          ],
+          "name": "El Dorado Transit",
+          "onestop_id": "o-9qc-eldoradotransit",
+          "tags": {
+            "twitter_general": "eldoradotransit",
+            "us_ntd_id": "90229",
+            "wikidata_id": "Q5351201"
+          },
+          "website": "http://www.eldoradotransit.com/?referrer=gtfs"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "eldoradotransit-ca-us",
+        "gtfs_data_exchange": "el-dorado-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/eldoradotransit-ca-us/eldoradotransit-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qc-fairfield~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "36"
+            },
+            {
+              "feed_onestop_id": "f-fairfield~ca~rt"
+            }
+          ],
+          "name": "Fairfield and Suisun Transit",
+          "onestop_id": "o-9qc-fairfieldandsuisuntransit",
+          "short_name": "FAST",
+          "tags": {
+            "twitter_general": "fast_transit",
+            "us_ntd_id": "90092",
+            "wikidata_id": "Q5430409"
+          },
+          "website": "http://www.fasttransit.org/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "fairfield-ca-us",
+        "gtfs_data_exchange": "fairfield-and-suisun-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/fairfield-ca-us/fairfield-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qc-placercountytransit",
+      "operators": [
+        {
+          "name": "Placer County Transit",
+          "onestop_id": "o-9qc-placercountytransit",
+          "tags": {
+            "twitter_general": "pctpa",
+            "us_ntd_id": "90196",
+            "wikidata_id": "Q7200309"
           }
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/placercounty-ca-us/placercounty-ca-us.zip",
+        "static_historic": [
+          "http://iportal.sacrt.com/gtfs/PCT/20080914/google_transit.zip"
+        ]
+      }
     },
     {
-      "spec": "gtfs",
-      "id": "f-9vg3-startransit~tx~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/startransit-tx-us/startransit-tx-us.zip"
+      "id": "f-9qc-westcat~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
       },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "392"
+            }
+          ],
+          "name": "WestCat (Western Contra Costa)",
+          "onestop_id": "o-9qc-westcatwesterncontracosta",
+          "tags": {
+            "twitter_general": "wccta",
+            "us_ntd_id": "90159",
+            "wikidata_id": "Q7984179"
+          },
+          "website": "http://www.westcat.org/index.html"
+        }
+      ],
+      "spec": "gtfs",
       "tags": {
-        "feed_id": "startransit-tx-us",
+        "feed_id": "westcat-ca-us",
         "managed_by": "trillium"
       },
-      "operators": [
-        {
-          "onestop_id": "o-9vg3-startransit",
-          "tags": {
-            "us_ntd_id": "60114"
-          },
-          "name": "STAR Transit",
-          "website": "http://www.startransit.org/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "556"
-            }
-          ]
-        }
-      ]
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/westcat-ca-us/westcat-ca-us.zip"
+      }
     },
     {
-      "spec": "gtfs",
-      "id": "f-dq2s-tarriver~nc~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/tarriver-nc-us/tarriver-nc-us.zip"
+      "id": "f-9qc-yubasutter~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
       },
+      "operators": [
+        {
+          "name": "Yuba-Sutter Transit",
+          "onestop_id": "o-9qc-yuba~suttertransit",
+          "tags": {
+            "twitter_general": "yubacounty",
+            "us_ntd_id": "90061",
+            "wikidata_id": "Q8060099"
+          }
+        }
+      ],
+      "spec": "gtfs",
       "tags": {
-        "feed_id": "tarriver-nc-us",
+        "feed_id": "yubasutter-ca-us",
         "managed_by": "trillium"
       },
-      "operators": [
-        {
-          "onestop_id": "o-dq2s-tarrivertransit",
-          "tags": {
-            "us_ntd_id": "40096",
-            "wikidata_id": "Q7684999",
-            "twitter_general": "cityofrockymtnc"
-          },
-          "name": "Tar River Transit",
-          "website": "http://www.tarrivertransit.org",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "560"
-            }
-          ]
-        }
-      ]
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/yubasutter-ca-us/yubasutter-ca-us.zip"
+      }
     },
     {
-      "spec": "gtfs",
-      "id": "f-drs-truenorthtransit~ma~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/truenorthtransit-ma-us/truenorthtransit-ma-us.zip"
+      "id": "f-9qc0-soltrans~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
       },
+      "operators": [
+        {
+          "name": "Solano County Transit",
+          "onestop_id": "o-9qc0-soltrans",
+          "short_name": "SolTrans",
+          "tags": {
+            "twitter_general": "SolTransRide",
+            "us_ntd_id": "90232",
+            "wikidata_id": "Q16984743"
+          }
+        }
+      ],
+      "spec": "gtfs",
       "tags": {
-        "status": "unpublished",
-        "feed_id": "truenorthtransit-ma-us",
+        "feed_id": "soltrans-ca-us",
+        "gtfs_data_exchange": "soltrans",
         "managed_by": "trillium"
       },
-      "operators": [
-        {
-          "onestop_id": "o-drs-max",
-          "name": "Massachusetts Area Express",
-          "short_name": "MAX",
-          "website": "http://ridemaxbus.com",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "521"
-            }
-          ]
-        }
-      ]
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/soltrans-ca-us/soltrans-ca-us.zip"
+      }
     },
     {
+      "id": "f-9qc3-datatrilliumtransitcom",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "RV"
+            }
+          ],
+          "name": "Rio Vista Delta Breeze",
+          "onestop_id": "o-9qc3-riovistadeltabreeze",
+          "tags": {
+            "twitter_general": "cityofriovista",
+            "us_ntd_id": "9R02-91014",
+            "wikidata_id": "Q7335361"
+          },
+          "website": "http://www.riovistacity.com/transit/"
+        }
+      ],
       "spec": "gtfs",
-      "id": "f-c2qft-udash~mt~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/udash-mt-us/udash-mt-us.zip"
-      },
       "tags": {
-        "feed_id": "udash-mt-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "mountain-line-mutd"
+        "gtfs_data_exchange": "rio-vista-delta-breeze",
+        "managed_by": "trillium"
       },
-      "operators": [
-        {
-          "onestop_id": "o-c2qft-udash~universityofmontana",
-          "tags": {
-            "us_ntd_id": "80107",
-            "twitter_general": "udash"
-          },
-          "name": "University of Montana",
-          "short_name": "UDASH",
-          "website": "http://life.umt.edu/asum/asum_agencies/Transportation/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "465"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dp9e-belleurbansystem",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/racine-wi-us/racine-wi-us.zip"
+        "static_current": "http://data.trilliumtransit.com/gtfs/riovista-ca-us/riovista-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qd-fresnocounty~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
       },
       "operators": [
         {
-          "onestop_id": "o-dp9e-belleurbansystem",
-          "tags": {
-            "us_ntd_id": "50006",
-            "wikidata_id": "Q4883698",
-            "twitter_general": "CityofRacine"
-          },
-          "name": "Belle Urban System",
-          "short_name": "BUS",
-          "website": "http://www.racinetransit.com",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "629"
+              "gtfs_agency_id": "171"
             }
-          ]
+          ],
+          "name": "Fresno County Rural Transit Agency",
+          "onestop_id": "o-9qd-fresnocountyruraltransitagency",
+          "tags": {
+            "us_ntd_id": "9R02-91007"
+          },
+          "website": "http://www.ruraltransit.org/"
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "fresnocounty-ca-us",
+        "gtfs_data_exchange": "fresno-county-rural-transit-agency",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/fresnocounty-ca-us/fresnocounty-ca-us.zip"
+      }
     },
     {
+      "id": "f-9qd-stanislaus~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "69"
+            }
+          ],
+          "name": "Bus Line Service of Turlock",
+          "onestop_id": "o-9qdj3-buslineserviceofturlock",
+          "website": "http://www.turlock.ca.us/citydepartments/developmentservices/transitservices/blasttransitlines/"
+        },
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "70"
+            }
+          ],
+          "name": "Ceres Area Transit",
+          "onestop_id": "o-9q9vz-ceresareatransit",
+          "website": "http://www.ci.ceres.ca.us/CeresAreaTransit/CAT.html"
+        },
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "68"
+            }
+          ],
+          "name": "Stanislaus Regional Transit",
+          "onestop_id": "o-9q9-stanislausmetroaltransit",
+          "short_name": "StaRT",
+          "tags": {
+            "twitter_general": "RideStaRT",
+            "us_ntd_id": "90236",
+            "wikidata_id": "Q7598964"
+          },
+          "website": "http://www.srt.org/"
+        }
+      ],
       "spec": "gtfs",
+      "tags": {
+        "feed_id": "stanislaus-ca-us",
+        "gtfs_data_exchange": " Ceres Area Transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/stanislaus-ca-us/stanislaus-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qd-yosemite~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "url": "http://yarts.com/developers-gtfs-data/",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "216"
+            }
+          ],
+          "name": "Yosemite Valley Shuttle System",
+          "onestop_id": "o-9qdyw-yosemitevalleyshuttlesystem",
+          "website": "http://www.nps.gov/yose/planyourvisit/publictransportation.htm#CP_JUMP_566977"
+        },
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "114"
+            }
+          ],
+          "name": "Yosemite Area Regional Transportation System",
+          "onestop_id": "o-9qd-yosemitearearegionaltransportationsystem",
+          "short_name": "YARTS",
+          "tags": {
+            "twitter_general": "rideyarts",
+            "us_ntd_id": "9R02-91070",
+            "wikidata_id": "Q8055918"
+          },
+          "website": "http://www.yarts.com/?referrer=gtfs"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "yosemite-ca-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/yosemite-ca-us/yosemite-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qdc-clovistransit~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "971"
+            }
+          ],
+          "name": "Clovis Transit",
+          "onestop_id": "o-9qdc-clovistransit",
+          "tags": {
+            "twitter_general": "clovistransit"
+          },
+          "website": "https://cityofclovis.com/general-services/transit/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "clovistransit-ca-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/clovistransit-ca-us/clovistransit-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qdd-maderaareaexpress~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "960"
+            }
+          ],
+          "name": "Madera Area Express",
+          "onestop_id": "o-9qdd-maderaareaexpress",
+          "tags": {
+            "us_ntd_id": "90199"
+          },
+          "website": "https://www.cityofmadera.ca.gov/home/departments/transit/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "maderaareaexpress-ca-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/cityofmadera-ca-us/cityofmadera-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qf-amador~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "80"
+            }
+          ],
+          "name": "Amador Transit",
+          "onestop_id": "o-9qf-amadortransit",
+          "tags": {
+            "twitter_general": "amadortransit",
+            "us_ntd_id": "9R02-91000",
+            "wikidata_id": "Q13429190"
+          },
+          "website": "http://amadortransit.com/site/pages/schedules.cgi?referrer=gtfs"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "amador-ca-us",
+        "gtfs_data_exchange": "amador-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/amador-ca-us/amador-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qf-calaveras~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "79"
+            }
+          ],
+          "name": "Calaveras Transit",
+          "onestop_id": "o-9qf-calaverastransit",
+          "tags": {
+            "us_ntd_id": "9R02-91063"
+          },
+          "website": "http://calaverastransit.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "calaveras-ca-us",
+        "gtfs_data_exchange": "calaveras-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/calaveras-ca-us/calaveras-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qf-laketahoe~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "904"
+            }
+          ],
+          "name": "Tahoe Truckee Area Regional Transit",
+          "onestop_id": "o-9qfx-tahoetruckeearearegionaltransit",
+          "short_name": "TART",
+          "supersedes_ids": ["o-9qfx-tahoeareametroaltransit"],
+          "tags": {
+            "twitter_general": "areatahoe",
+            "us_ntd_id": "9R02-91101"
+          },
+          "website": "https://tahoetruckeetransit.com/"
+        },
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "16"
+            }
+          ],
+          "name": "North Lake Tahoe Express",
+          "onestop_id": "o-9qfx-northlaketahoeexpress~24houradvancereservationsrequired",
+          "website": "https://www.northlaketahoeexpress.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/laketahoe-ca-us/laketahoe-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qh-victorville~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "493"
+            }
+          ],
+          "name": "Victor Valley Transit Authority",
+          "onestop_id": "o-9qh-victorvalleytransitauthority",
+          "short_name": "VVTA",
+          "tags": {
+            "twitter_general": "VVTransit",
+            "us_ntd_id": "90148",
+            "wikidata_id": "Q7926418"
+          },
+          "website": "http://www.vvta.org"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "victorville-ca-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/victorville-ca-us/victorville-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qh0-anaheim~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "url": "https://rideart.org/gtfs/",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "248"
+            }
+          ],
+          "name": "Anaheim Resort Transportation",
+          "onestop_id": "o-9qh0-anaheimresorttransportation",
+          "short_name": "ART",
+          "tags": {
+            "twitter_general": "RideARTbus",
+            "us_ntd_id": "90211",
+            "wikidata_id": "Q4750893"
+          },
+          "website": "http://www.rideart.org/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "anaheim-ca-us",
+        "gtfs_data_exchange": "anaheim-resort-transportation",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/anaheim-ca-us/anaheim-ca-us.zip"
+      }
+    },
+    {
       "id": "f-9qh1-norwalktransitsystem",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/nts-ca-us/nts-ca-us.zip"
-      },
       "operators": [
         {
-          "onestop_id": "o-9qh1-norwalktransitsystem",
-          "tags": {
-            "us_ntd_id": "90022",
-            "wikidata_id": "Q7060799",
-            "twitter_general": "CityofNorwalkCA"
-          },
-          "name": "Norwalk Transit System",
-          "short_name": "NTS",
-          "website": "http://www.ci.norwalk.ca.us/city-hall/departments/norwalk-transit-system-nts",
           "associated_feeds": [
             {
               "gtfs_agency_id": "630"
             }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-c262f-uniongaptransit",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/uniongap-wa-us/uniongap-wa-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-c262f-uniongaptransit",
-          "name": "Union Gap Transit",
-          "website": "https://uniongapwa.gov/transit/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "688"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-djkj-starmetro",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/starmetro-fl-us/starmetro-fl-us.zip"
-      },
-      "tags": {
-        "managed_by": "trillium"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-djkj-starmetro",
+          ],
+          "name": "Norwalk Transit System",
+          "onestop_id": "o-9qh1-norwalktransitsystem",
+          "short_name": "NTS",
           "tags": {
-            "us_ntd_id": "40036",
-            "wikidata_id": "Q7600550",
-            "twitter_general": "CityofTLH"
+            "twitter_general": "CityofNorwalkCA",
+            "us_ntd_id": "90022",
+            "wikidata_id": "Q7060799"
           },
-          "name": "StarMetro",
-          "website": "http://www.talgov.com/starmetro"
+          "website": "http://www.ci.norwalk.ca.us/city-hall/departments/norwalk-transit-system-nts"
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/nts-ca-us/nts-ca-us.zip"
+      }
     },
     {
-      "spec": "gtfs",
-      "id": "f-dne-bgcap~ky~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/bgcap-ky-us/bgcap-ky-us.zip"
-      },
-      "tags": {
-        "feed_id": "bgcap-ky-us"
-      },
+      "id": "f-9qh1f-elmontetransit",
       "operators": [
         {
-          "onestop_id": "o-dne-ky~bluegrassultra~transitservice",
-          "tags": {
-            "us_ntd_id": "4R04-40948"
-          },
-          "name": "Bluegrass Ultra-Transit Service",
-          "website": "http://www.bluegrasscommunityaction.org/Pages/bus.html",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "599"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-c1f6-thebus~ketchikangatewayborough~airportferry",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/kgb-ak-us/kgb-ak-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-c1f6-ak~thebus~ketchikangatewayborough",
-          "tags": {
-            "us_ntd_id": "0R04-00358"
-          },
-          "name": "Ketchikan Gateway Borough",
-          "short_name": "The Bus",
-          "website": "http://www.kgbak.us/Transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "553"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9q5-airportvaletexpress~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/airportvaletexpress-ca-us/airportvaletexpress-ca-us.zip"
-      },
-      "tags": {
-        "feed_id": "airportvaletexpress-ca-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q5-airportvaletexpress",
-          "name": "Airport Valet Express",
-          "short_name": "Bakersfield",
-          "website": "https://www.airportvaletexpress.com/fares/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "229"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-c3j-757",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/roamtransit-banff-ab-ca/roamtransit-banff-ab-ca.zip"
-      },
-      "tags": {
-        "feed_id": "757"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-c3j-roamtransit",
-          "name": "Bow Valley Regional Transit Services Commission",
-          "short_name": "Roam Transit",
-          "website": "http://www.roamtransit.com",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "782"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9wgzn-741",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/snowmassvillagetransportation-co-us/snowmassvillagetransportation-co-us.zip"
-      },
-      "tags": {
-        "feed_id": "741"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9wgzn-snowmassvillage",
-          "name": "Snowmass Village",
-          "website": "http://www.snowmasstransit.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "770"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9xh3-vailtransit",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/vailtransit-co-us/vailtransit-co-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9xh3-vailtransit",
-          "name": "Vail Transit",
-          "website": "http://www.vailgov.com/bus-schedules",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "680"
+              "gtfs_agency_id": "703"
             }
           ],
-          "tags": {
-            "twitter_general": "VailGov"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qh1f-elmontetransit",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/elmonte-ca-us/elmonte-ca-us.zip"
-      },
-      "operators": [
-        {
+          "name": "El Monte Transit",
           "onestop_id": "o-9qh1f-elmontetransit",
           "tags": {
             "us_ntd_id": "90265",
             "wikidata_id": "Q5351636"
           },
-          "name": "El Monte Transit",
-          "website": "http://www.ci.el-monte.ca.us/Government/PublicWorks/Transportation.aspx",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "703"
-            }
-          ]
+          "website": "http://www.ci.el-monte.ca.us/Government/PublicWorks/Transportation.aspx"
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/elmonte-ca-us/elmonte-ca-us.zip"
+      }
     },
     {
-      "spec": "gtfs",
-      "id": "f-9wg-rfta",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/rfta-co-us/rfta-co-us.zip"
+      "id": "f-9qh2s-corona~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
       },
       "operators": [
         {
-          "onestop_id": "o-9wg-rfta",
+          "name": "Corona Cruiser",
+          "onestop_id": "o-9qh2s-coronacruiser",
           "tags": {
-            "us_ntd_id": "8R01-80289",
-            "wikidata_id": "Q7339865",
-            "twitter_general": "RFTA"
+            "us_ntd_id": "90052"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "corona-ca-us",
+        "gtfs_data_exchange": "corona-cruiser",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/corona-ca-us/corona-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qh45-duartetransit~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "484"
+            }
+          ],
+          "name": "Duarte Transit",
+          "onestop_id": "o-9qh45-duartetransit",
+          "tags": {
+            "twitter_general": "cityofduarte",
+            "us_ntd_id": "90264"
           },
-          "name": "Roaring Fork Transportation Authority",
-          "short_name": "RFTA",
-          "website": "https://www.rfta.com/",
+          "website": "http://www.accessduarte.com/~accessdu/index.php?option=com_content&view=article&id=88&Itemid=131"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "duartetransit-ca-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/duartetransit-ca-us/duartetransit-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qhc-beaumont~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "73"
+            }
+          ],
+          "name": "Beaumont Transit System",
+          "onestop_id": "o-9qhc-beaumonttransitsystem",
+          "tags": {
+            "wikidata_id": "Q7142408"
+          },
+          "website": "http://www.ci.beaumont.ca.us/index.aspx?NID=160"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "beaumont-ca-us",
+        "gtfs_data_exchange": "beaumont-pass-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/beaumont-ca-us/beaumont-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qhf-bigbear~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "44"
+            }
+          ],
+          "name": "Mountain Transit",
+          "onestop_id": "o-9qhf-mountaintransit",
+          "tags": {
+            "us_ntd_id": "9R02-91012",
+            "wikidata_id": "Q6924864"
+          },
+          "website": "http://www.mountaintransit.org/?referrer=gtfs"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "bigbear-ca-us",
+        "gtfs_data_exchange": "mountain-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/bigbear-ca-us/bigbear-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9qnx-bullheadareatransit~az~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "258"
+            }
+          ],
+          "name": "Bullhead Area Transit System",
+          "onestop_id": "o-9qnx-bullheadareatransitsystem",
+          "tags": {
+            "twitter_general": "bullheadinfo",
+            "us_ntd_id": "9R01-91037"
+          },
+          "website": "http://www.bullheadcity.com/departments/human-services-transit/transportation"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "bullheadareatransit-az-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/bullheadareatransit-az-us/bullheadareatransit-az-us.zip"
+      }
+    },
+    {
+      "id": "f-9r0-redding~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "25"
+            },
+            {
+              "onestop_id": "f-9r0-redding~ca~us~rt"
+            },
+            {
+              "onestop_id": "f-9r0-redding~ca~us~rt~alerts"
+            }
+          ],
+          "name": "Redding Area Bus Authority",
+          "onestop_id": "o-9r0-reddingareabusauthority",
+          "short_name": "RABA",
+          "tags": {
+            "twitter_general": "cityofredding",
+            "us_ntd_id": "90093",
+            "wikidata_id": "Q7305617"
+          },
+          "website": "http://www.rabaride.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "redding-ca-us",
+        "gtfs_data_exchange": "redding-area-bus-authority",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/redding-ca-us/redding-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9r0-redding~ca~us~rt~alerts",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "25"
+            },
+            {
+              "onestop_id": "f-9r0-redding~ca~us~rt"
+            },
+            {
+              "onestop_id": "f-9r0-redding~ca~us~rt~alerts"
+            }
+          ],
+          "name": "Redding Area Bus Authority",
+          "onestop_id": "o-9r0-reddingareabusauthority",
+          "short_name": "RABA",
+          "tags": {
+            "twitter_general": "cityofredding",
+            "us_ntd_id": "90093",
+            "wikidata_id": "Q7305617"
+          },
+          "website": "http://www.rabaride.com/"
+        }
+      ],
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/redding-ca-us/service_alerts.proto"
+      }
+    },
+    {
+      "id": "f-9r0-trinity~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "34"
+            }
+          ],
+          "name": "Trinity Transit",
+          "onestop_id": "o-9r0-trinitytransit",
+          "tags": {
+            "us_ntd_id": "9R02-91035",
+            "wikidata_id": "Q7842993"
+          },
+          "website": "http://www.trinitytransit.org/?referrer=gtfs"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "trinity-ca-us",
+        "gtfs_data_exchange": "trinity-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/weaverville-ca-us/weaverville-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9r1-tehama~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "62"
+            }
+          ],
+          "name": "Susanville Indian Rancheria Public Transportation Program",
+          "onestop_id": "o-9r1-susanvilleindianrancheriapublictransportationprogram",
+          "tags": {
+            "us_ntd_id": "99256"
+          },
+          "website": "http://www.transitunlimited.org/Susanville_Indian_Rancheria_Public_Transportation_Program"
+        },
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "21"
+            }
+          ],
+          "name": "Tehama Rural Area Express",
+          "onestop_id": "o-9r1h-tehamaruralareaexpress",
+          "short_name": "TRAX",
+          "tags": {
+            "us_ntd_id": "9R02-91089"
+          },
+          "website": "http://www.taketrax.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "tehama-ca-us",
+        "gtfs_data_exchange": " Susanville Indian Rancheria Public Transportation Program",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/tehama-ca-us/tehama-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9r2-siskiyou~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "24"
+            }
+          ],
+          "name": "Siskiyou Transit and General Express",
+          "onestop_id": "o-9r2-siskiyoutransitandgeneralexpress",
+          "tags": {
+            "us_ntd_id": "9R02-91048"
+          },
+          "website": "http://www.co.siskiyou.ca.us/GS/stage.aspx"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "siskiyou-ca-us",
+        "gtfs_data_exchange": "siskiyou-transit-and-general-express",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/siskiyou-ca-us/siskiyou-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9r4-lassen~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "81"
+            }
+          ],
+          "name": "Lassen Rural Bus",
+          "onestop_id": "o-9r4-lassenruralbus",
+          "tags": {
+            "us_ntd_id": "9R02-91098"
+          },
+          "website": "http://www.lassentransportation.com/a/Lassen-Rural-Bus-LRB.php?referrer=gtfs"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "lassen-ca-us",
+        "gtfs_data_exchange": "lassen-rural-bus",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/lassen-ca-us/lassen-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9r4-plumas~ca~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "20"
+            }
+          ],
+          "name": "Plumas Transit",
+          "onestop_id": "o-9r4-plumastransit",
+          "tags": {
+            "us_ntd_id": "9R02-91119"
+          },
+          "website": "http://www.plumastransit.com"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "plumas-ca-us",
+        "gtfs_data_exchange": "plumas-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/plumas-ca-us/plumas-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-9r4-rtcride",
+      "license": {
+        "url": "https://www.rtcwashoe.com/terms-of-use/"
+      },
+      "operators": [
+        {
+          "name": "Regional Transportation Commission",
+          "onestop_id": "o-9r4-rtcride",
+          "short_name": "RTC",
+          "tags": {
+            "twitter_general": "rtcwashoe",
+            "us_ntd_id": "90001",
+            "wikidata_id": "Q7309179"
+          },
+          "website": "http://www.rtcwashoe.com"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "gtfs_data_exchange": "rtc-ride"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/rtc-nv-us/rtc-nv-us.zip"
+      }
+    },
+    {
+      "id": "f-9r88-rogue~valley~transportation~district",
+      "operators": [
+        {
+          "name": "Rogue Valley Transportation District",
+          "onestop_id": "o-9r88-rogue~valley~transportation~district",
+          "short_name": "RVTD",
+          "tags": {
+            "twitter_general": "ridervtd",
+            "us_ntd_id": "00034",
+            "wikidata_id": "Q7359553"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/rvtd-or-us/rvtd-or-us.zip"
+      }
+    },
+    {
+      "id": "f-9rb-benton~or~us~alerts",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/benton-or-us/service_alerts.proto"
+      }
+    },
+    {
+      "id": "f-9rc-cascadeseast~or~us~rt~alerts",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/cascadeseast-or-us/service_alerts.proto"
+      }
+    },
+    {
+      "id": "f-9ry8-mountainridestransportationauthoritymrta",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "MRTA"
+            }
+          ],
+          "name": "Mountain Rides Transportation Authority",
+          "onestop_id": "o-9ry8-mountainridestransportationauthoritymrta",
+          "short_name": "MRTA",
+          "tags": {
+            "twitter_general": "mountainrides"
+          },
+          "website": "http://www.mountainrides.org/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "gtfs_data_exchange": "mountain-rides-transportation-authority-mrta"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/mountainrides-id-us/mountainrides-id-us.zip"
+      }
+    },
+    {
+      "id": "f-9t9p7-universityofaz~cattran~freeshuttleservice",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "706"
+            }
+          ],
+          "name": "Cat Tran",
+          "onestop_id": "o-9t9p7-universityofaz~cattran~freeshuttleservice",
+          "website": "http://parking.arizona.edu/alternative/cattran.php"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/cattran-az-us/cattran-az-us.zip"
+      }
+    },
+    {
+      "id": "f-9vfu-dentoncountytransportationauthority",
+      "license": {
+        "url": "https://www.dcta.net/resources/open-data"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "feed_onestop_id": "f-dentoncountytransportationauthority~rt"
+            }
+          ],
+          "name": "Denton County Transportation Authority",
+          "onestop_id": "o-9vfu-dentoncountytransportationauthority",
+          "short_name": "DCTA",
+          "tags": {
+            "twitter_general": "RideDCTA",
+            "us_ntd_id": "60101",
+            "wikidata_id": "Q5259601"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://trilliumtransit.com/transit_feeds/dentoncounty-tx-us/dentoncounty-tx-us.zip",
+        "static_historic": [
+          "https://www.dcta.net/images/uploads/content_files/resource_center/DCTA_GTFS.zip"
+        ]
+      }
+    },
+    {
+      "id": "f-9vg3-startransit~tx~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "556"
+            }
+          ],
+          "name": "STAR Transit",
+          "onestop_id": "o-9vg3-startransit",
+          "tags": {
+            "us_ntd_id": "60114"
+          },
+          "website": "http://www.startransit.org/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "startransit-tx-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/startransit-tx-us/startransit-tx-us.zip"
+      }
+    },
+    {
+      "id": "f-9vxz-jatran~ms~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "name": "JATRAN",
+          "onestop_id": "o-9vxz-jatran",
+          "tags": {
+            "us_ntd_id": "50034",
+            "wikidata_id": "Q6117777"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "jatran-ms-us",
+        "gtfs_data_exchange": "jatran",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/jatran-ms-us/jatran-ms-us.zip"
+      }
+    },
+    {
+      "id": "f-9w-arizonashuttle~az~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "959"
+            }
+          ],
+          "name": "Arizona Shuttle",
+          "onestop_id": "o-9w-groometransportation",
+          "website": "https://groometransportation.com/arizona/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "arizonashuttle-az-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/arizonashuttle-az-us/arizonashuttle-az-us.zip"
+      }
+    },
+    {
+      "id": "f-9w0md-cottonwood~az~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "64"
+            }
+          ],
+          "name": "Cottonwood Area Transit",
+          "onestop_id": "o-9w0md-cottonwoodareatransit",
+          "tags": {
+            "us_ntd_id": "9R01-91010"
+          },
+          "website": "http://cottonwoodaz.gov/cat.php"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "cottonwood-az-us",
+        "gtfs_data_exchange": "cottonwood-area-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/cottonwood-az-us/cottonwood-az-us.zip"
+      }
+    },
+    {
+      "id": "f-9w0q-verdelynx~az~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "65"
+            }
+          ],
+          "name": "Verde Lynx",
+          "onestop_id": "o-9w0q-verdelynx",
+          "tags": {
+            "omd_provider_id": "verde-lynx",
+            "us_ntd_id": "9R01-91010"
+          },
+          "website": "https://cottonwoodaz.gov/166/Verde-Lynx-Public-Transportation"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "verdelynx-az-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/verdelynx-az-us/verdelynx-az-us.zip"
+      }
+    },
+    {
+      "id": "f-9we1-redappletransit~nm~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "459"
+            }
+          ],
+          "name": "Red Apple Transit",
+          "onestop_id": "o-9we1-redappletransit",
+          "tags": {
+            "us_ntd_id": "60100"
+          },
+          "website": "http://fmtn.org/index.aspx?nid=279"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "redappletransit-nm-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/redappletransit-nm-us/redappletransit-nm-us.zip"
+      }
+    },
+    {
+      "id": "f-9wg-rfta",
+      "operators": [
+        {
           "associated_feeds": [
             {
               "gtfs_agency_id": "639"
             }
-          ]
+          ],
+          "name": "Roaring Fork Transportation Authority",
+          "onestop_id": "o-9wg-rfta",
+          "short_name": "RFTA",
+          "tags": {
+            "twitter_general": "RFTA",
+            "us_ntd_id": "8R01-80289",
+            "wikidata_id": "Q7339865"
+          },
+          "website": "https://www.rfta.com/"
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/rfta-co-us/rfta-co-us.zip"
+      }
     },
     {
+      "id": "f-9wgzn-741",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "770"
+            }
+          ],
+          "name": "Snowmass Village",
+          "onestop_id": "o-9wgzn-snowmassvillage",
+          "website": "http://www.snowmasstransit.com/"
+        }
+      ],
       "spec": "gtfs",
-      "id": "f-9xj5sg-universitycoloradoboulder~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/universitycoloradoboulder-co-us/universitycoloradoboulder-co-us.zip"
-      },
       "tags": {
-        "feed_id": "universitycoloradoboulder-co-us"
+        "feed_id": "741"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/snowmassvillagetransportation-co-us/snowmassvillagetransportation-co-us.zip"
+      }
+    },
+    {
+      "id": "f-9wk-sandiashuttle~nm~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "955"
+            }
+          ],
+          "name": "Sandia Shuttle",
+          "onestop_id": "o-9wk-sandiashuttle",
+          "website": "http://sandiashuttle.com/?utm_source=google&utm_medium=transit&utm_campaign=sandia"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "sandiashuttle-nm-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/sandiashuttle-nm-us/sandiashuttle-nm-us.zip"
+      }
+    },
+    {
+      "id": "f-9wv-coloradoshuttle~co~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "954"
+            }
+          ],
+          "name": "Colorado Springs Shuttle",
+          "onestop_id": "o-9wv-groometransportation",
+          "website": "https://groometransportation.com/colorado-springs/?utm_source=google&utm_medium=transit&utm_campaign=coloradosprings"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "coloradoshuttle-co-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/coloradoshuttle-co-us/coloradoshuttle-co-us.zip"
+      }
+    },
+    {
+      "id": "f-9x-bustang~co~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
       },
       "operators": [
         {
-          "onestop_id": "o-9xj5sg-universityofcoloradoboulder",
-          "name": "University of Colorado Boulder",
-          "website": "https://www.colorado.edu/pts/",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "249"
+            }
+          ],
+          "name": "Bustang",
+          "onestop_id": "o-9x-bustang",
           "tags": {
-            "twitter_general": "cu_pts"
+            "twitter_general": "RideBustang",
+            "wikidata_id": "Q85749670"
           },
+          "website": "http://ridebustang.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "bustang-co-us",
+        "gtfs_data_exchange": "bustang",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/bustang-co-us/bustang-co-us.zip"
+      }
+    },
+    {
+      "id": "f-9xh-cme~co~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "672"
+            }
+          ],
+          "name": "Colorado Mountain Express",
+          "onestop_id": "o-9xh-coloradomountainexpress",
+          "tags": {
+            "twitter_general": "EpicMtnExpress"
+          },
+          "website": "http://www.coloradomountainexpress.com/googlemaps"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "cme-co-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/cme-co-us/cme-co-us.zip"
+      }
+    },
+    {
+      "id": "f-9xh-ecotransit~co~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "536"
+            }
+          ],
+          "name": "ECO Transit",
+          "onestop_id": "o-9xh-ecotransit",
+          "tags": {
+            "twitter_general": "EagleCounty"
+          },
+          "website": "http://www.eaglecounty.us/Transit/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "ecotransit-co-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/ecotransit-co-us/ecotransit-co-us.zip"
+      }
+    },
+    {
+      "id": "f-9xh3-vailtransit",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "680"
+            }
+          ],
+          "name": "Vail Transit",
+          "onestop_id": "o-9xh3-vailtransit",
+          "tags": {
+            "twitter_general": "VailGov"
+          },
+          "website": "http://www.vailgov.com/bus-schedules"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/vailtransit-co-us/vailtransit-co-us.zip"
+      }
+    },
+    {
+      "id": "f-9xhg-winterpark~co~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "806"
+            }
+          ],
+          "name": "The Lift",
+          "onestop_id": "o-9xhg-thelift",
+          "short_name": "The Lift",
+          "website": "http://www.wpgov.com/223/Transportation-Services"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "winterpark-co-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/winterpark-co-us/winterpark-co-us.zip"
+      }
+    },
+    {
+      "id": "f-9xhv-nps~romo~shuttles",
+      "license": {
+        "url": "https://creativecommons.org/publicdomain/zero/1.0/"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "NPS_ROMO"
+            }
+          ],
+          "name": "Rocky Mountain National Park",
+          "onestop_id": "o-9xhv-rockymountainnationalpark",
+          "website": "http://www.nps.gov/romo"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/rockymountainnationalpark-co-us/rockymountainnationalpark-co-us.zip"
+      }
+    },
+    {
+      "id": "f-9xj5s-viamobilityservices~co~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "689"
+            },
+            {
+              "feed_onestop_id": "f-9xj5s-viamobilityservices~rt"
+            }
+          ],
+          "name": "Via Mobility Services",
+          "onestop_id": "o-9xj5s-viamobilityservices",
+          "website": "http://buffbus.etaspot.net/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "viamobilityservices-co-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/viamobilityservices-co-us/viamobilityservices-co-us.zip"
+      }
+    },
+    {
+      "id": "f-9xj5sg-universitycoloradoboulder~co~us",
+      "operators": [
+        {
           "associated_feeds": [
             {
               "gtfs_agency_id": "809"
@@ -4555,1195 +2582,4268 @@
             {
               "feed_onestop_id": "f-cuboulder~rt~alerts"
             }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9zr78-muscabus",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/muscabus-ia-us/muscabus-ia-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9zr78-muscabus",
+          ],
+          "name": "University of Colorado Boulder",
+          "onestop_id": "o-9xj5sg-universityofcoloradoboulder",
           "tags": {
-            "us_ntd_id": "7R01-70101",
-            "twitter_general": "CityofMuscatine"
+            "twitter_general": "cu_pts"
           },
-          "name": "MuscaBus",
-          "website": "https://www.muscatineiowa.gov/75/Public-Transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "769"
-            }
-          ]
+          "website": "https://www.colorado.edu/pts/"
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "universitycoloradoboulder-co-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/universitycoloradoboulder-co-us/universitycoloradoboulder-co-us.zip"
+      }
     },
     {
-      "spec": "gtfs",
-      "id": "f-9zqy-cedarrapidstransit",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/cedarrapids-ia-us/cedarrapids-ia-us.zip"
-      },
+      "id": "f-9yz-jeffersoncounty~mo~us",
       "license": {
-        "url": "https://iowa-gtfs.com/"
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
       },
       "operators": [
         {
-          "onestop_id": "o-9zqy-cedarrapidstransit",
-          "tags": {
-            "us_ntd_id": "70008",
-            "wikidata_id": "Q5056856",
-            "twitter_general": "CityofCRiowa"
-          },
-          "name": "Cedar Rapids Transit",
-          "website": "http://www.cedar-rapids.org/residents/city_buses/index.php",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "750"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9q5d-707",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/simivalley-ca-us/simivalley-ca-us.zip"
-      },
-      "tags": {
-        "feed_id": "707"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q5d-simivalleytransit",
-          "tags": {
-            "us_ntd_id": "90050",
-            "twitter_general": "svtransit"
-          },
-          "name": "Simi Valley Transit",
-          "website": "http://www.simivalley.org/departments/community-services/simi-valley-transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "729"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9t9p7-universityofaz~cattran~freeshuttleservice",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/cattran-az-us/cattran-az-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9t9p7-universityofaz~cattran~freeshuttleservice",
-          "name": "Cat Tran",
-          "website": "http://parking.arizona.edu/alternative/cattran.php",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "706"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9xh-cme~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/cme-co-us/cme-co-us.zip"
-      },
-      "tags": {
-        "feed_id": "cme-co-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9xh-coloradomountainexpress",
-          "name": "Colorado Mountain Express",
-          "website": "http://www.coloradomountainexpress.com/googlemaps",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "672"
+              "gtfs_agency_id": "199"
             }
           ],
+          "name": "JeffCo Express",
+          "onestop_id": "o-9yz-jeffcoexpress",
           "tags": {
-            "twitter_general": "EpicMtnExpress"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dp0r-citylink",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/ridecitylink-il-us/ridecitylink-il-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dp0r-citylink",
-          "tags": {
-            "us_ntd_id": "50056",
-            "wikidata_id": "Q5600709",
-            "twitter_general": "CityLinkPeoria"
+            "twitter_general": "JeffCoExpress"
           },
-          "name": "CityLink",
-          "website": "http://www.ridecitylink.org/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "594"
-            }
-          ]
+          "website": "http://www.jeffcoexpress.org/"
         }
-      ]
-    },
-    {
+      ],
       "spec": "gtfs",
-      "id": "f-9mgve-avalon~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/avalon-ca-us/avalon-ca-us.zip"
-      },
       "tags": {
-        "feed_id": "avalon-ca-us"
+        "feed_id": "jeffersoncounty-mo-us",
+        "gtfs_data_exchange": "jeffco-express",
+        "managed_by": "trillium"
       },
-      "operators": [
-        {
-          "onestop_id": "o-9mgve-avalontransit",
-          "tags": {
-            "us_ntd_id": "90249",
-            "twitter_general": "avalongov"
-          },
-          "name": "Avalon Transit",
-          "website": "http://www.cityofavalon.com/transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "622"
-            },
-            {
-              "feed_onestop_id": "f-avalon~ca~rt"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dr7f-greaterbridgeporttransit",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/gbt-ct-us/gbt-ct-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dr7f-greaterbridgeporttransit",
-          "tags": {
-            "us_ntd_id": "10050",
-            "wikidata_id": "Q5600471",
-            "twitter_general": "gogbt"
-          },
-          "name": "Greater Bridgeport Transit",
-          "website": "http://www.gogbt.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "668"
-            }
-          ]
-        }
-      ]
+        "static_current": "http://data.trilliumtransit.com/gtfs/jeffersoncounty-mo-us/jeffersoncounty-mo-us.zip"
+      }
     },
     {
-      "spec": "gtfs",
-      "id": "f-9zr0n-759",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/burlington-ia-us/burlington-ia-us.zip"
-      },
-      "tags": {
-        "feed_id": "759"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9zr0n-burlingtonurbanservice",
-          "tags": {
-            "us_ntd_id": "7R01-70111"
-          },
-          "name": "Burlington Urban Service",
-          "website": "http://www.burlingtoniowa.org/2265/Burlington-Urban-Service-BUS",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "783"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
       "id": "f-9ze3-755",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/siouxcity-ia-us/siouxcity-ia-us.zip"
-      },
-      "tags": {
-        "feed_id": "755"
-      },
       "operators": [
         {
-          "onestop_id": "o-9ze3-siouxcitytransitsystem",
-          "tags": {
-            "us_ntd_id": "70012",
-            "wikidata_id": "Q7525465",
-            "twitter_general": "locatesiouxcity"
-          },
-          "name": "Sioux City Transit System",
-          "website": "https://www.sioux-city.org/services/transit",
           "associated_feeds": [
             {
               "gtfs_agency_id": "780"
             }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9zt1b-dodgerarearapidtransit",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/dart-ia-us/dart-ia-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9zt1b-dodgerarearapidtransit",
+          ],
+          "name": "Sioux City Transit System",
+          "onestop_id": "o-9ze3-siouxcitytransitsystem",
           "tags": {
-            "us_ntd_id": "7R01-70108"
+            "twitter_general": "locatesiouxcity",
+            "us_ntd_id": "70012",
+            "wikidata_id": "Q7525465"
           },
-          "name": "Dodger Area Rapid Transit",
-          "short_name": "DART",
-          "website": "http://www.midascog.net/transit/dart",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "781"
-            }
-          ]
+          "website": "https://www.sioux-city.org/services/transit"
         }
-      ]
-    },
-    {
+      ],
       "spec": "gtfs",
-      "id": "f-c1f-interisland~ak~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/interisland-ak-us/interisland-ak-us.zip"
-      },
       "tags": {
-        "feed_id": "interisland-ak-us"
+        "feed_id": "755"
       },
-      "operators": [
-        {
-          "onestop_id": "o-c1f-inter~islandferryauthority",
-          "tags": {
-            "us_ntd_id": "0R04-00382",
-            "wikidata_id": "Q6044644"
-          },
-          "name": "Inter-Island Ferry Authority",
-          "website": "http://www.interislandferry.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "659"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9ztt-masoncitypublictransit",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/masoncity-ia-us/masoncity-ia-us.zip"
+        "static_current": "http://data.trilliumtransit.com/gtfs/siouxcity-ia-us/siouxcity-ia-us.zip"
+      }
+    },
+    {
+      "id": "f-9zep-siouxareametro~sd~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
       },
       "operators": [
         {
-          "onestop_id": "o-9ztt-masoncitypublictransit",
-          "tags": {
-            "us_ntd_id": "7R01-70260",
-            "twitter_general": "masoncityiowa"
-          },
-          "name": "Mason City Public Transit",
-          "website": "https://www.masoncity.net/pview.aspx?id=18070&catid=0",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "779"
+              "gtfs_agency_id": "217"
             }
-          ]
+          ],
+          "name": "Sioux Area Metro",
+          "onestop_id": "o-9zep-siouxareametro",
+          "tags": {
+            "twitter_general": "citysiouxfalls",
+            "us_ntd_id": "80002",
+            "wikidata_id": "Q7525432"
+          },
+          "website": "http://www.siouxfalls.org/sam/"
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "siouxareametro-sd-us",
+        "gtfs_data_exchange": "sioux-area-metro",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/siouxareametro-sd-us/siouxareametro-sd-us.zip"
+      }
     },
     {
-      "spec": "gtfs",
       "id": "f-9zmzj-767",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/marshalltownmunicipaltransit-ia-us/marshalltownmunicipaltransit-ia-us.zip"
-      },
-      "tags": {
-        "feed_id": "767"
-      },
       "operators": [
         {
-          "onestop_id": "o-9zmzj-marshalltownmunicipaltransit",
-          "tags": {
-            "us_ntd_id": "7R01-70092"
-          },
-          "name": "Marshalltown Municipal Transit",
-          "website": "http://www.ci.marshalltown.ia.us/static/departments/works/transit.php",
           "associated_feeds": [
             {
               "gtfs_agency_id": "791"
             }
-          ]
+          ],
+          "name": "Marshalltown Municipal Transit",
+          "onestop_id": "o-9zmzj-marshalltownmunicipaltransit",
+          "tags": {
+            "us_ntd_id": "7R01-70092"
+          },
+          "website": "http://www.ci.marshalltown.ia.us/static/departments/works/transit.php"
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "767"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/marshalltownmunicipaltransit-ia-us/marshalltownmunicipaltransit-ia-us.zip"
+      }
     },
     {
-      "spec": "gtfs",
-      "id": "f-9zry5-clintonmta",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/clintonmta-ia-us/clintonmta-ia-us.zip"
-      },
+      "id": "f-9zq4g-762",
       "operators": [
         {
-          "onestop_id": "o-9zry5-clintonmta",
-          "tags": {
-            "us_ntd_id": "7R01-70173"
-          },
-          "name": "Clinton MTA",
-          "website": "http://www.cityofclintoniowa.us/departments/transit_and_fleet_maintenance/",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "776"
+              "gtfs_agency_id": "785"
             }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9zq4g-762",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/10-15transit-ia-us/10-15transit-ia-us.zip"
-      },
-      "tags": {
-        "feed_id": "762"
-      },
-      "operators": [
-        {
+          ],
+          "name": "10-15 Transit",
           "onestop_id": "o-9zq4g-10~15transit",
           "tags": {
             "us_ntd_id": "7R01-70242",
             "wikidata_id": "Q7110024"
           },
-          "name": "10-15 Transit",
-          "website": "http://www.unitedwaymahaska.org/oskaloosarides",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "785"
-            }
-          ]
+          "website": "http://www.unitedwaymahaska.org/oskaloosarides"
         }
-      ]
-    },
-    {
+      ],
       "spec": "gtfs",
-      "id": "f-djj2-pascocountypublictransit~fl~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/pascocountypublictransit-fl-us/pascocountypublictransit-fl-us.zip"
-      },
       "tags": {
-        "feed_id": "pascocountypublictransit-fl-us"
+        "feed_id": "762"
       },
-      "operators": [
-        {
-          "onestop_id": "o-djj2-pascocountypublictransportation",
-          "tags": {
-            "us_ntd_id": "40074",
-            "wikidata_id": "Q7141817",
-            "twitter_general": "RidePCPT"
-          },
-          "name": "Pasco County Public Transportation",
-          "website": "http://www.pascocountyfl.net/index.aspx?NID=243",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "749"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drt0-limoliner~ma~us",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/limoliner-ma-us/limoliner-ma-us.zip"
-      },
-      "tags": {
-        "feed_id": "limoliner-ma-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drt0-metrowestexpress",
-          "name": "Metrowest Express",
-          "website": "https://metrowestexpress.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "903"
-            }
-          ],
-          "tags": {
-            "twitter_general": "mwestexpress"
-          }
-        }
-      ]
+        "static_current": "http://data.trilliumtransit.com/gtfs/10-15transit-ia-us/10-15transit-ia-us.zip"
+      }
     },
     {
-      "spec": "gtfs",
-      "id": "f-9q8yy-missionbaytma~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/missionbaytma-ca-us/missionbaytma-ca-us.zip"
-      },
-      "tags": {
-        "feed_id": "missionbaytma-ca-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q8yy-missionbaytma",
-          "tags": {
-            "omd_provider_id": "mission-bay-tma",
-            "twitter_general": "MissionBayTMA"
-          },
-          "name": "Mission Bay TMA",
-          "website": "http://missionbaytma.org/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "671"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dhm-keywest~fl~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/keywest-fl-us/keywest-fl-us.zip"
-      },
-      "tags": {
-        "feed_id": "keywest-fl-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dhm-keywesttransit",
-          "tags": {
-            "us_ntd_id": "4R02-41060",
-            "twitter_general": "city_of_keywest"
-          },
-          "name": "Key West Transit",
-          "website": "http://kwtransit.com",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "910"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drm-plymouthbrockton~ma~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/plymouthbrockton-ma-us/plymouthbrockton-ma-us.zip"
-      },
-      "tags": {
-        "feed_id": "plymouthbrockton-ma-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drm-plymouth~brocktonstreetrailwayco",
-          "tags": {
-            "wikidata_id": "Q85793712",
-            "twitter_general": "PBBus"
-          },
-          "name": "Plymouth & Brockton Street Railway Co.",
-          "website": "http://www.p-b.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "801"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dnn3-thecomet~sc~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/thecomet-sc-us/thecomet-sc-us.zip"
-      },
-      "tags": {
-        "feed_id": "thecomet-sc-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dnn3-thecomet",
-          "tags": {
-            "us_ntd_id": "40141",
-            "wikidata_id": "Q5061436",
-            "twitter_general": "CatchTheCOMET"
-          },
-          "name": "The COMET",
-          "website": "http://catchthecomet.org/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "943"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9xhg-winterpark~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/winterpark-co-us/winterpark-co-us.zip"
-      },
-      "tags": {
-        "feed_id": "winterpark-co-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9xhg-thelift",
-          "name": "The Lift",
-          "short_name": "The Lift",
-          "website": "http://www.wpgov.com/223/Transportation-Services",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "806"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9q6-kcapta~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/kcapta-ca-us/kcapta-ca-us.zip"
-      },
-      "tags": {
-        "feed_id": "kcapta-ca-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q6-kingsarearuraltransit",
-          "tags": {
-            "us_ntd_id": "90200"
-          },
-          "name": "Kings Area Rural Transit",
-          "short_name": "KART",
-          "website": "http://mykartbus.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "804"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
       "id": "f-9zqv-coralvilletransitsystem~ia~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/coralvilletransitsystem-ia-us/coralvilletransitsystem-ia-us.zip"
-      },
-      "tags": {
-        "feed_id": "coralvilletransitsystem-ia-us"
-      },
       "operators": [
         {
-          "onestop_id": "o-9zqv-coralvilletransit",
-          "tags": {
-            "us_ntd_id": "70030",
-            "twitter_general": "coralville_ia"
-          },
-          "name": "Coralville Transit",
-          "website": "http://www.coralville.org/166/Bus-Schedules-Route-Maps",
           "associated_feeds": [
             {
               "gtfs_agency_id": "795"
             }
-          ]
+          ],
+          "name": "Coralville Transit",
+          "onestop_id": "o-9zqv-coralvilletransit",
+          "tags": {
+            "twitter_general": "coralville_ia",
+            "us_ntd_id": "70030"
+          },
+          "website": "http://www.coralville.org/166/Bus-Schedules-Route-Maps"
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "coralvilletransitsystem-ia-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/coralvilletransitsystem-ia-us/coralvilletransitsystem-ia-us.zip"
+      }
     },
     {
-      "spec": "gtfs",
       "id": "f-9zqvh-cambus~ia~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/cambus-ia-us/cambus-ia-us.zip"
-      },
-      "tags": {
-        "feed_id": "cambus-ia-us"
-      },
       "license": {
         "url": "https://iowa-gtfs.com/"
       },
       "operators": [
         {
-          "onestop_id": "o-9zqvh-universityofiowa~cambus",
-          "tags": {
-            "us_ntd_id": "70019",
-            "wikidata_id": "Q5025682",
-            "twitter_general": "uiowaparktrans"
-          },
-          "name": "University of Iowa - CAMBUS",
-          "short_name": "CAMBUS",
-          "website": "https://transportation.uiowa.edu/cambus",
           "associated_feeds": [
             {
               "gtfs_agency_id": "790"
             }
-          ]
+          ],
+          "name": "University of Iowa - CAMBUS",
+          "onestop_id": "o-9zqvh-universityofiowa~cambus",
+          "short_name": "CAMBUS",
+          "tags": {
+            "twitter_general": "uiowaparktrans",
+            "us_ntd_id": "70019",
+            "wikidata_id": "Q5025682"
+          },
+          "website": "https://transportation.uiowa.edu/cambus"
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "cambus-ia-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/cambus-ia-us/cambus-ia-us.zip"
+      }
     },
     {
-      "spec": "gtfs",
-      "id": "f-c0-bcferries~bc~ca",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/bcferries-bc-ca/bcferries-bc-ca.zip"
-      },
-      "tags": {
-        "feed_id": "bcferries-bc-ca"
+      "id": "f-9zqy-cedarrapidstransit",
+      "license": {
+        "url": "https://iowa-gtfs.com/"
       },
       "operators": [
         {
-          "onestop_id": "o-c0-bcferries",
-          "name": "BC Ferries",
-          "website": "https://www.bcferries.com/",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "750"
+            }
+          ],
+          "name": "Cedar Rapids Transit",
+          "onestop_id": "o-9zqy-cedarrapidstransit",
+          "tags": {
+            "twitter_general": "CityofCRiowa",
+            "us_ntd_id": "70008",
+            "wikidata_id": "Q5056856"
+          },
+          "website": "http://www.cedar-rapids.org/residents/city_buses/index.php"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/cedarrapids-ia-us/cedarrapids-ia-us.zip"
+      }
+    },
+    {
+      "id": "f-9zr0n-759",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "783"
+            }
+          ],
+          "name": "Burlington Urban Service",
+          "onestop_id": "o-9zr0n-burlingtonurbanservice",
+          "tags": {
+            "us_ntd_id": "7R01-70111"
+          },
+          "website": "http://www.burlingtoniowa.org/2265/Burlington-Urban-Service-BUS"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "759"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/burlington-ia-us/burlington-ia-us.zip"
+      }
+    },
+    {
+      "id": "f-9zr78-muscabus",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "769"
+            }
+          ],
+          "name": "MuscaBus",
+          "onestop_id": "o-9zr78-muscabus",
+          "tags": {
+            "twitter_general": "CityofMuscatine",
+            "us_ntd_id": "7R01-70101"
+          },
+          "website": "https://www.muscatineiowa.gov/75/Public-Transit"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/muscabus-ia-us/muscabus-ia-us.zip"
+      }
+    },
+    {
+      "id": "f-9zry5-clintonmta",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "776"
+            }
+          ],
+          "name": "Clinton MTA",
+          "onestop_id": "o-9zry5-clintonmta",
+          "tags": {
+            "us_ntd_id": "7R01-70173"
+          },
+          "website": "http://www.cityofclintoniowa.us/departments/transit_and_fleet_maintenance/"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/clintonmta-ia-us/clintonmta-ia-us.zip"
+      }
+    },
+    {
+      "id": "f-9zt1b-dodgerarearapidtransit",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "781"
+            }
+          ],
+          "name": "Dodger Area Rapid Transit",
+          "onestop_id": "o-9zt1b-dodgerarearapidtransit",
+          "short_name": "DART",
+          "tags": {
+            "us_ntd_id": "7R01-70108"
+          },
+          "website": "http://www.midascog.net/transit/dart"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/dart-ia-us/dart-ia-us.zip"
+      }
+    },
+    {
+      "id": "f-9ztt-masoncitypublictransit",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "779"
+            }
+          ],
+          "name": "Mason City Public Transit",
+          "onestop_id": "o-9ztt-masoncitypublictransit",
+          "tags": {
+            "twitter_general": "masoncityiowa",
+            "us_ntd_id": "7R01-70260"
+          },
+          "website": "https://www.masoncity.net/pview.aspx?id=18070&catid=0"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/masoncity-ia-us/masoncity-ia-us.zip"
+      }
+    },
+    {
+      "id": "f-acrta~oh~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/acrta-oh-us/acrta-oh-us.zip"
+      }
+    },
+    {
+      "id": "f-alhambra~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1669"
+            }
+          ],
+          "name": "Alhambra Community Transit",
+          "onestop_id": "o-9q5cz-alhambracommunitytransit",
+          "short_name": "ACT",
+          "tags": {
+            "us_ntd_id": "90247"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "supersedes_ids": ["f-alhambra~community"],
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/alhambra-ca-us/alhambra-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-allpointstransit~co~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1599"
+            }
+          ],
+          "name": "All Points Transit",
+          "onestop_id": "o-9wg6-allpointstransit",
+          "tags": {
+            "twitter_general": "AllPntsTransit",
+            "us_ntd_id": "8R01-88215"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/allpointstransit-co-us/allpointstransit-co-us.zip"
+      }
+    },
+    {
+      "id": "f-altavista~va~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/altavista-va-us/altavista-va-us.zip"
+      }
+    },
+    {
+      "id": "f-arcadia~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1670"
+            }
+          ],
+          "name": "Arcadia Transit",
+          "onestop_id": "o-9qh44-arcadiatransit",
+          "tags": {
+            "us_ntd_id": "90044"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/arcadia-ca-us/arcadia-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-arvin~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1659"
+            }
+          ],
+          "name": "Arvin Transit",
+          "onestop_id": "o-9q7-arvintransit",
+          "tags": {
+            "us_ntd_id": "9R02-91027",
+            "wikidata_id": "Q4802468"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/arvin-ca-us/arvin-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-auburntransit~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1593"
+            }
+          ],
+          "name": "Auburn Transit",
+          "onestop_id": "o-9qcvk-auburntransit",
+          "tags": {
+            "us_ntd_id": "9R02-91032"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/auburntransit-ca-us/auburntransit-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-avon~co~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/avon-co-us/avon-co-us.zip"
+      }
+    },
+    {
+      "id": "f-baldwinpark~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1683"
+            }
+          ],
+          "name": "Baldwin Park Transit",
+          "onestop_id": "o-9qh1g-baldwinparktransit",
+          "tags": {
+            "twitter_general": "BaldwinParkCA",
+            "us_ntd_id": "90251"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/baldwinpark-ca-us/baldwinpark-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-banning~pass~transit",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "onestop_id": "f-banning~pass~transit~rt"
+            },
+            {
+              "onestop_id": "f-banning~pass~transit~rt~alerts"
+            }
+          ],
+          "name": "City of Banning Transit",
+          "onestop_id": "o-9qhb-cityofbanningtransit"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/banning-ca-us/banning-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-banning~pass~transit~rt~alerts",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/banning-ca-us/service_alerts.proto"
+      }
+    },
+    {
+      "id": "f-bay~transit~va",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "bay"
+            }
+          ],
+          "name": "Bay Transit",
+          "onestop_id": "o-dq9-baytransit",
+          "tags": {
+            "us_ntd_id": "3R06-30172"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/baytransit-va-us/baytransit-va-us.zip"
+      }
+    },
+    {
+      "id": "f-beartransit~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "18"
+            }
+          ],
+          "name": "University of California Berkeley Shuttle",
+          "onestop_id": "o-9q9p3-beartransit~ucberkeleyshuttle",
+          "short_name": "Bear Transit",
+          "tags": {
+            "us_ntd_id": "9R02-91012",
+            "wikidata_id": "Q6924864"
+          },
+          "website": "http://pt.berkeley.edu/around/transit/routes/"
+        },
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1708"
+            }
+          ],
+          "name": "Bear Transit",
+          "onestop_id": "o-9q9p3-beartransit",
+          "tags": {
+            "twitter_general": "CalParking",
+            "wikidata_id": "Q4876580"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/beartransit-ca-us/beartransit-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-bellflower~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1673"
+            }
+          ],
+          "name": "Bellflower Bus",
+          "onestop_id": "o-9q5bz-bellflowerbus",
+          "tags": {
+            "us_ntd_id": "90254"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/bellflower-ca-us/bellflower-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-bellgardens~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1667"
+            }
+          ],
+          "name": "Bell Gardens Trolley",
+          "onestop_id": "o-9q5cp-bellgardenstrolley",
+          "tags": {
+            "twitter_general": "bellgardenscity",
+            "us_ntd_id": "90253"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/bellgardens-ca-us/bellgardens-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-benson~az~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/benson-az-us/benson-az-us.zip"
+      }
+    },
+    {
+      "id": "f-bentcounty~co~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1645"
+            }
+          ],
+          "name": "Bent County Transportation",
+          "onestop_id": "o-9wy-bentcountytransportation",
+          "tags": {
+            "us_ntd_id": "8R01-88229"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/bentcounty-co-us/bentcounty-co-us.zip"
+      }
+    },
+    {
+      "id": "f-blackhawktramway~co~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1646"
+            }
+          ],
+          "name": "Blackhawk and Central City Tramway",
+          "onestop_id": "o-9xhfr-blackhawkandcentralcitytramway",
+          "tags": {
+            "us_ntd_id": "8R01-80119"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/blackhawktramway-co-us/blackhawktramway-co-us.zip"
+      }
+    },
+    {
+      "id": "f-blackstone~va~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/blackstone-va-us/blackstone-va-us.zip"
+      }
+    },
+    {
+      "id": "f-blossomexpress~ca~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/blossomexpress-ca-us/blossomexpress-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-bouldercounty~co~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/bouldercounty-co-us/bouldercounty-co-us.zip"
+      }
+    },
+    {
+      "id": "f-breckenridgefreeride~co~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1631"
+            }
+          ],
+          "name": "Breckenridge Free Ride",
+          "onestop_id": "o-9xh8d-breckenridgefreeride",
+          "tags": {
+            "twitter_general": "breckfreeride",
+            "us_ntd_id": "8R01-80170"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/breckenridgefreeride-co-us/breckenridgefreeride-co-us.zip"
+      }
+    },
+    {
+      "id": "f-bristol~va~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/bristol-va-us/bristol-va-us.zip"
+      }
+    },
+    {
+      "id": "f-c0-bcferries~bc~ca",
+      "operators": [
+        {
           "associated_feeds": [
             {
               "gtfs_agency_id": "965"
             }
-          ]
+          ],
+          "name": "BC Ferries",
+          "onestop_id": "o-c0-bcferries",
+          "website": "https://www.bcferries.com/"
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "bcferries-bc-ca"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/bcferries-bc-ca/bcferries-bc-ca.zip"
+      }
     },
     {
-      "spec": "gtfs",
-      "id": "f-9xj5s-viamobilityservices~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/viamobilityservices-co-us/viamobilityservices-co-us.zip"
-      },
-      "tags": {
-        "feed_id": "viamobilityservices-co-us"
-      },
+      "id": "f-c1f-interisland~ak~us",
       "operators": [
         {
-          "onestop_id": "o-9xj5s-viamobilityservices",
-          "name": "Via Mobility Services",
-          "website": "http://buffbus.etaspot.net/",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "689"
-            },
-            {
-              "feed_onestop_id": "f-9xj5s-viamobilityservices~rt"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dr-coachcompany~ma~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/coachcompany-ma-us/coachcompany-ma-us.zip"
-      },
-      "tags": {
-        "feed_id": "coachcompany-ma-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dr-coachcompany",
-          "name": "Coach Company",
-          "website": "https://coachco.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "930"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qdd-maderaareaexpress~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/cityofmadera-ca-us/cityofmadera-ca-us.zip"
-      },
-      "tags": {
-        "feed_id": "maderaareaexpress-ca-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qdd-maderaareaexpress",
-          "tags": {
-            "us_ntd_id": "90199"
-          },
-          "name": "Madera Area Express",
-          "website": "https://www.cityofmadera.ca.gov/home/departments/transit/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "960"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drt3-middlesex~ma~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/middlesex-ma-us/middlesex-ma-us.zip"
-      },
-      "tags": {
-        "feed_id": "middlesex-ma-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drt3-middlesex3tma",
-          "name": "Middlesex 3 TMA",
-          "website": "http://www.middlesex3tma.com/SERVICES/SHUTTLES",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "555"
+              "gtfs_agency_id": "659"
             }
           ],
+          "name": "Inter-Island Ferry Authority",
+          "onestop_id": "o-c1f-inter~islandferryauthority",
           "tags": {
-            "twitter_general": "middlesex3tma"
-          }
+            "us_ntd_id": "0R04-00382",
+            "wikidata_id": "Q6044644"
+          },
+          "website": "http://www.interislandferry.com/"
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "interisland-ak-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/interisland-ak-us/interisland-ak-us.zip"
+      }
     },
     {
+      "id": "f-c1f6-thebus~ketchikangatewayborough~airportferry",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "553"
+            }
+          ],
+          "name": "Ketchikan Gateway Borough",
+          "onestop_id": "o-c1f6-ak~thebus~ketchikangatewayborough",
+          "short_name": "The Bus",
+          "tags": {
+            "us_ntd_id": "0R04-00358"
+          },
+          "website": "http://www.kgbak.us/Transit"
+        }
+      ],
       "spec": "gtfs",
-      "id": "f-drkg-seatbus~ct~us",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/seatbus-ct-us/seatbus-ct-us.zip"
-      },
-      "tags": {
-        "feed_id": "seatbus-ct-us"
+        "static_current": "http://data.trilliumtransit.com/gtfs/kgb-ak-us/kgb-ak-us.zip"
+      }
+    },
+    {
+      "id": "f-c20-tillamook~or~us~rt~alerts",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/tillamook-or-us/service_alerts.proto"
+      }
+    },
+    {
+      "id": "f-c20-wilsonville~or~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
       },
       "operators": [
         {
-          "onestop_id": "o-drkg-southeastareatransitdistrict",
-          "tags": {
-            "us_ntd_id": "10040",
-            "wikidata_id": "Q7569291",
-            "twitter_general": "S_E_A_T"
-          },
-          "name": "Southeast Area Transit District",
-          "short_name": "SEAT",
-          "website": "http://www.seatbus.com",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "978"
+              "gtfs_agency_id": "101"
             }
-          ]
+          ],
+          "name": "South Metro Area Regional Transit",
+          "onestop_id": "o-c20-southmetroareametroaltransit",
+          "short_name": "SMART",
+          "tags": {
+            "us_ntd_id": "00046",
+            "wikidata_id": "Q7567940"
+          },
+          "website": "http://www.ridesmart.com/"
         }
-      ]
-    },
-    {
+      ],
       "spec": "gtfs",
-      "id": "f-9q9j-commute~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/commute-ca-us/commute-ca-us.zip"
-      },
       "tags": {
-        "feed_id": "commute-ca-us"
+        "feed_id": "wilsonville-or-us",
+        "gtfs_data_exchange": "smart",
+        "managed_by": "trillium"
       },
-      "operators": [
-        {
-          "onestop_id": "o-9q9j-commuteorgshuttles",
-          "tags": {
-            "wikidata_id": "Q7162971",
-            "twitter_general": "SMCountyCommute"
-          },
-          "name": "Commute.org Shuttles",
-          "website": "http://www.commute.org",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "936"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9q5-dpwlacounty~ca~us",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/dpwlacounty-ca-us/dpwlacounty-ca-us.zip"
-      },
-      "tags": {
-        "feed_id": "dpwlacounty-ca-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q5-lagobus",
-          "tags": {
-            "us_ntd_id": "90270,90271,90272,90273,90274,90275,90276,90278",
-            "twitter_general": "LACoPublicWorks"
-          },
-          "name": "LA Go Bus",
-          "website": "https://dpw.lacounty.gov/transit/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1466"
-            }
-          ]
-        }
-      ]
+        "static_current": "http://data.trilliumtransit.com/gtfs/wilsonville-or-us/wilsonville-or-us.zip"
+      }
     },
     {
-      "spec": "gtfs",
       "id": "f-c20-wotm~wa~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/wotm-wa-us/wotm-wa-us.zip"
-      },
-      "tags": {
-        "feed_id": "wotm-wa-us"
-      },
       "operators": [
         {
-          "onestop_id": "o-c20-wahkiakumonthemove",
-          "tags": {
-            "us_ntd_id": "0R03-00371"
-          },
-          "name": "Wahkiakum on the Move",
-          "website": "https://www.co.wahkiakum.wa.us/240/General-Services",
           "associated_feeds": [
             {
               "gtfs_agency_id": "1478"
             }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drgv-lctferries~vt~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/lctferries-vt-us/lctferries-vt-us.zip"
-      },
-      "tags": {
-        "feed_id": "lctferries-vt-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drgv-lakechamplainferries",
-          "tags": {
-            "wikidata_id": "Q6475257"
-          },
-          "name": "Lake Champlain Ferries",
-          "website": "http://ferries.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "789"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-d-groometransportation~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/groometransportation-us/groometransportation-us.zip"
-      },
-      "tags": {
-        "feed_id": "groometransportation-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-d-groometransportation",
-          "name": "Groome Transportation",
-          "website": "https://groometransportation.com",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "948"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dn6hr-tma~tn~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/tma-tn-us/tma-tn-us.zip"
-      },
-      "tags": {
-        "feed_id": "tma-tn-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dn6hr-franklintransit",
-          "tags": {
-            "us_ntd_id": "40162",
-            "twitter_general": "franklintransit"
-          },
-          "name": "Franklin Transit",
-          "website": "http://franklintransit.org/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1495"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dp-945963",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/indiantrails-mi-us/indiantrails-mi-us.zip"
-      },
-      "tags": {
-        "feed_id": "945_963"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dp-indiantrails",
-          "tags": {
-            "wikidata_id": "Q6021774",
-            "twitter_general": "indiantrailsbus"
-          },
-          "name": "Detroit Connector",
-          "website": "https://detroit.umich.edu/transportation/detroit-connector/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "945"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9w-arizonashuttle~az~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/arizonashuttle-az-us/arizonashuttle-az-us.zip"
-      },
-      "tags": {
-        "feed_id": "arizonashuttle-az-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9w-groometransportation",
-          "name": "Arizona Shuttle",
-          "website": "https://groometransportation.com/arizona/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "959"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9wk-sandiashuttle~nm~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/sandiashuttle-nm-us/sandiashuttle-nm-us.zip"
-      },
-      "tags": {
-        "feed_id": "sandiashuttle-nm-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9wk-sandiashuttle",
-          "name": "Sandia Shuttle",
-          "website": "http://sandiashuttle.com/?utm_source=google&utm_medium=transit&utm_campaign=sandia",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "955"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9wv-coloradoshuttle~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/coloradoshuttle-co-us/coloradoshuttle-co-us.zip"
-      },
-      "tags": {
-        "feed_id": "coloradoshuttle-co-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9wv-groometransportation",
-          "name": "Colorado Springs Shuttle",
-          "website": "https://groometransportation.com/colorado-springs/?utm_source=google&utm_medium=transit&utm_campaign=coloradosprings",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "954"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qb-airportexpressinc~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/airportexpressinc-ca-us/airportexpressinc-ca-us.zip"
-      },
-      "tags": {
-        "feed_id": "airportexpressinc-ca-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qb-sonomacountyairportexpress",
-          "name": "Sonoma County Airport Express",
-          "website": "http://airportexpressinc.com/?utm_source=google&utm_medium=transit&utm_campaign=sonoma",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "953"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9qdc-clovistransit~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/clovistransit-ca-us/clovistransit-ca-us.zip"
-      },
-      "tags": {
-        "feed_id": "clovistransit-ca-us"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qdc-clovistransit",
-          "name": "Clovis Transit",
-          "website": "https://cityofclovis.com/general-services/transit/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "971"
-            }
           ],
+          "name": "Wahkiakum on the Move",
+          "onestop_id": "o-c20-wahkiakumonthemove",
           "tags": {
-            "twitter_general": "clovistransit"
+            "us_ntd_id": "0R03-00371"
+          },
+          "website": "https://www.co.wahkiakum.wa.us/240/General-Services"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "wotm-wa-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/wotm-wa-us/wotm-wa-us.zip"
+      }
+    },
+    {
+      "id": "f-c20dz-washingtonparkshuttle~or~us~alerts",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/washingtonparkshuttle-or-us/service_alerts.proto"
+      }
+    },
+    {
+      "id": "f-c20w-rivercitiestransit~wa~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "name": "RiverCities Transit",
+          "onestop_id": "o-c20w-rivercitiestransit",
+          "tags": {
+            "us_ntd_id": "00016",
+            "wikidata_id": "Q28451877"
           }
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "rivercitiestransit-wa-us",
+        "gtfs_data_exchange": "rivercities-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/rivercitiestransit-wa-us/rivercitiestransit-wa-us.zip"
+      }
     },
     {
+      "id": "f-c215-gorgewet~wa~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1814"
+            }
+          ],
+          "name": "Skamania County Transit",
+          "onestop_id": "o-c215-skamaniacountypublictransitgorgewetbus",
+          "website": "https://www.skamaniacounty.org/departments-offices/senior-services/services/public-transportation"
+        }
+      ],
       "spec": "gtfs",
-      "id": "f-9q5bf-lawndale~ca~us",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/cityoflawndale-ca-us/cityoflawndale-ca-us.zip"
-      },
-      "tags": {
-        "feed_id": "lawndale-ca-us"
+        "static_current": "http://data.trilliumtransit.com/gtfs/skamaniacounty-wa-us/skamaniacounty-wa-us.zip"
+      }
+    },
+    {
+      "id": "f-c22-mason~wa~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
       },
       "operators": [
         {
-          "onestop_id": "o-9q5bf-lawndalebeat",
-          "tags": {
-            "us_ntd_id": "90280"
-          },
-          "name": "Lawndale Beat",
-          "website": "http://www.lawndalecity.org/html/DEPTHTML/CSD/Beat.htm",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "1522"
+              "gtfs_agency_id": "480"
             }
-          ]
+          ],
+          "name": "Mason Transit Authority",
+          "onestop_id": "o-c22-masontransitauthority",
+          "tags": {
+            "twitter_general": "masontransit",
+            "us_ntd_id": "0R03-00315",
+            "wikidata_id": "Q20712385"
+          },
+          "website": "http://www.masontransit.org"
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "mason-wa-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/mason-wa-us/mason-wa-us.zip"
+      }
     },
     {
+      "id": "f-c24-peopleforpeople",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "pfp"
+            }
+          ],
+          "name": "People for People",
+          "onestop_id": "o-c24-peopleforpeople",
+          "short_name": "Community Connector",
+          "tags": {
+            "us_ntd_id": "0R03-00287"
+          },
+          "website": "http://www.pfp.org/pfp/Transportation/CommunityConnector.aspx"
+        }
+      ],
       "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/pfp-wa-us/pfp-wa-us.zip"
+      }
+    },
+    {
+      "id": "f-c26-linktransit~wa~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "name": "Link Transit",
+          "onestop_id": "o-c26-linktransit",
+          "tags": {
+            "twitter_general": "LinkTransit",
+            "us_ntd_id": "00043",
+            "wikidata_id": "Q25000891"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "linktransit-wa-us",
+        "gtfs_data_exchange": "link-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/linktransit-wa-us/linktransit-wa-us.zip"
+      }
+    },
+    {
+      "id": "f-c262f-uniongaptransit",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "688"
+            }
+          ],
+          "name": "Union Gap Transit",
+          "onestop_id": "o-c262f-uniongaptransit",
+          "website": "https://uniongapwa.gov/transit/"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/uniongap-wa-us/uniongap-wa-us.zip"
+      }
+    },
+    {
+      "id": "f-c263-selah~wa~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "868"
+            }
+          ],
+          "name": "Selah Transit",
+          "onestop_id": "o-c263-selahtransit",
+          "website": "https://selahwa.gov/transit/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "selah-wa-us"
+      },
+      "urls": {
+        "static_current": "http://trilliumtransit.com/transit_feeds/selah-wa-us/selah-wa-us.zip"
+      }
+    },
+    {
+      "id": "f-c28-islandtransit",
+      "operators": [
+        {
+          "name": "Island Transit",
+          "onestop_id": "o-c28-islandtransit",
+          "tags": {
+            "us_ntd_id": "0R03-00298",
+            "wikidata_id": "Q16980701"
+          },
+          "website": "http://www.islandtransit.org/"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/islandtransit-wa-us/islandtransit-wa-us.zip"
+      }
+    },
+    {
+      "id": "f-c2pvx-butte~mt~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "150"
+            }
+          ],
+          "name": "Butte-Silver Bow",
+          "onestop_id": "o-c2pvx-butte~silverbow",
+          "tags": {
+            "us_ntd_id": "8R02-88296"
+          },
+          "website": "http://www.buttebus.org/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "butte-mt-us",
+        "gtfs_data_exchange": "butte-silver-bow",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/butte-mt-us/butte-mt-us.zip"
+      }
+    },
+    {
+      "id": "f-c2qft-udash~mt~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "465"
+            }
+          ],
+          "name": "University of Montana",
+          "onestop_id": "o-c2qft-udash~universityofmontana",
+          "short_name": "UDASH",
+          "tags": {
+            "twitter_general": "udash",
+            "us_ntd_id": "80107"
+          },
+          "website": "http://life.umt.edu/asum/asum_agencies/Transportation/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "udash-mt-us",
+        "gtfs_data_exchange": "mountain-line-mutd",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/udash-mt-us/udash-mt-us.zip"
+      }
+    },
+    {
+      "id": "f-c3j-757",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "782"
+            }
+          ],
+          "name": "Bow Valley Regional Transit Services Commission",
+          "onestop_id": "o-c3j-roamtransit",
+          "short_name": "Roam Transit",
+          "website": "http://www.roamtransit.com"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "757"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/roamtransit-banff-ab-ca/roamtransit-banff-ab-ca.zip"
+      }
+    },
+    {
+      "id": "f-c427-cityandboroughofjuneau~ak~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "474"
+            },
+            {
+              "feed_onestop_id": "f-cityandboroughofjuneau~rt"
+            }
+          ],
+          "name": "Capital Transit",
+          "onestop_id": "o-c427-capitaltransit",
+          "tags": {
+            "twitter_general": "cbjuneau",
+            "us_ntd_id": "0R04-00391",
+            "wikidata_id": "Q5035680"
+          },
+          "website": "http://www.juneau.org/capitaltransit/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "cityandboroughofjuneau-ak-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/cityandboroughofjuneau-ak-us/cityandboroughofjuneau-ak-us.zip"
+      }
+    },
+    {
+      "id": "f-c815-streamlinetransit~mt~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "259"
+            }
+          ],
+          "name": "Streamline",
+          "onestop_id": "o-c815-streamline",
+          "tags": {
+            "twitter_general": "ridestreamline",
+            "us_ntd_id": "8R02-80235"
+          },
+          "website": "http://www.streamlinebus.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "streamlinetransit-mt-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/streamlinetransit-mt-us/streamlinetransit-mt-us.zip"
+      }
+    },
+    {
+      "id": "f-calabasas~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1674"
+            }
+          ],
+          "name": "Calabasas Transit System",
+          "onestop_id": "o-9q5d5-calabasastransitsystem",
+          "tags": {
+            "us_ntd_id": "90257"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/calabasas-ca-us/calabasas-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-camarillo~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1656"
+            }
+          ],
+          "name": "Camarillo Area Transit",
+          "onestop_id": "o-9q56e-camarilloareatransit",
+          "tags": {
+            "us_ntd_id": "90163"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/camarillo-ca-us/camarillo-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-carson~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1684"
+            }
+          ],
+          "name": "Carson Circuit",
+          "onestop_id": "o-9q5b-carsoncircuit",
+          "tags": {
+            "us_ntd_id": "90258",
+            "wikidata_id": "Q5046916"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "supersedes_ids": ["f-carson~circuit"],
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/carson-ca-us/carson-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-catalinaflyer~ca~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/catalinaflyer-ca-us/catalinaflyer-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-chicagowatertaxi~il~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/chicagowatertaxi-il-us/chicagowatertaxi-il-us.zip"
+      }
+    },
+    {
+      "id": "f-cityofdekalb~il~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1507"
+            }
+          ],
+          "name": "DeKalb Public Transit",
+          "onestop_id": "o-dp2y-dekalbpublictransit",
+          "tags": {
+            "twitter_general": "cityofdekalb_il",
+            "us_ntd_id": "50176"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/cityofdekalb-il-us/cityofdekalb-il-us.zip"
+      }
+    },
+    {
+      "id": "f-cityoffountaintransit~co~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/cityoffountaintransit-co-us/cityoffountaintransit-co-us.zip"
+      }
+    },
+    {
+      "id": "f-cityofhelena~mt~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/cityofhelena-mt-us/cityofhelena-mt-us.zip"
+      }
+    },
+    {
+      "id": "f-cityofridgecrest~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1665"
+            }
+          ],
+          "name": "Ridgerunner",
+          "onestop_id": "o-9qk6-ridgerunner",
+          "tags": {
+            "us_ntd_id": "9R02-91006"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/cityofridgecrest-ca-us/cityofridgecrest-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-clearcreek~co~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/clearcreek-co-us/clearcreek-co-us.zip"
+      }
+    },
+    {
+      "id": "f-compton~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1666"
+            }
+          ],
+          "name": "Compton Renaissance Transit",
+          "onestop_id": "o-9q5bv-comptonrenaissancetransit",
+          "tags": {
+            "us_ntd_id": "90260"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/compton-ca-us/compton-ca-us.zip"
+      }
+    },
+    {
       "id": "f-corridorrides",
+      "spec": "gtfs",
       "urls": {
         "static_current": "http://data.trilliumtransit.com/gtfs/corridorrides-ia-us/corridorrides-ia-us.zip"
       }
     },
     {
+      "id": "f-cripplecreek~co~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1600"
+            }
+          ],
+          "name": "Cripple Creek Transportation",
+          "onestop_id": "o-9wvh-cripplecreektransportation",
+          "tags": {
+            "us_ntd_id": "8R01-80275"
+          }
+        }
+      ],
       "spec": "gtfs",
-      "id": "f-gtrans~ca~us",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/gtrans-ca-us/gtrans-ca-us.zip"
+        "static_current": "http://data.trilliumtransit.com/gtfs/cripplecreek-co-us/cripplecreek-co-us.zip"
+      }
+    },
+    {
+      "id": "f-cudahy~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1685"
+            }
+          ],
+          "name": "Cudahy Area Rapid Transit",
+          "onestop_id": "o-9q5cnw-cudahyarearapidtransit",
+          "tags": {
+            "twitter_general": "CityOfCudahyCA",
+            "us_ntd_id": "90262"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/cudahy-ca-us/cudahy-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-d-groometransportation~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "948"
+            }
+          ],
+          "name": "Groome Transportation",
+          "onestop_id": "o-d-groometransportation",
+          "website": "https://groometransportation.com"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "groometransportation-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/groometransportation-us/groometransportation-us.zip"
+      }
+    },
+    {
+      "id": "f-delano~ca~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/delano-ca-us/delano-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-dhm-keywest~fl~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "910"
+            }
+          ],
+          "name": "Key West Transit",
+          "onestop_id": "o-dhm-keywesttransit",
+          "tags": {
+            "twitter_general": "city_of_keywest",
+            "us_ntd_id": "4R02-41060"
+          },
+          "website": "http://kwtransit.com"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "keywest-fl-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/keywest-fl-us/keywest-fl-us.zip"
+      }
+    },
+    {
+      "id": "f-districtthree~va~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/districtthree-va-us/districtthree-va-us.zip"
+      }
+    },
+    {
+      "id": "f-dj3-ecat~fl~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "413"
+            }
+          ],
+          "name": "Escambia County Area Transit",
+          "onestop_id": "o-dj3-escambiacountyareatransit",
+          "short_name": "ECAT",
+          "tags": {
+            "twitter_general": "rideecat",
+            "us_ntd_id": "40038",
+            "wikidata_id": "Q5396846"
+          },
+          "website": "https://goecat.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "ecat-fl-us",
+        "gtfs_data_exchange": "escambia-county-area-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/ecat-fl-us/ecat-fl-us.zip"
+      }
+    },
+    {
+      "id": "f-dj6m-okaloosacountytransit~fl~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "412"
+            }
+          ],
+          "name": "Emerald Coast Rider",
+          "onestop_id": "o-dj6m-emeraldcoastrider",
+          "short_name": "ECR",
+          "tags": {
+            "us_ntd_id": "40128"
+          },
+          "website": "http://ecrider.org/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "okaloosacountytransit-fl-us",
+        "gtfs_data_exchange": "emerald-coast-rider",
+        "status": "outdated"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/okaloosacountytransit-fl-us/okaloosacountytransit-fl-us.zip"
+      }
+    },
+    {
+      "id": "f-dj75-baytowntrolley~fl~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "407"
+            },
+            {
+              "feed_onestop_id": "f-baytowntrolley~fl~rt"
+            }
+          ],
+          "name": "Bay Town Trolley",
+          "onestop_id": "o-dj75-baytowntrolley",
+          "tags": {
+            "twitter_general": "BayTownTrolley",
+            "wikidata_id": "Q4874138"
+          },
+          "website": "http://www.baytowntrolley.org"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "baytowntrolley-fl-us",
+        "gtfs_data_exchange": "bay-town-trolley",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/baytowntrolley-fl-us/baytowntrolley-fl-us.zip"
+      }
+    },
+    {
+      "id": "f-djf8-montgomerytransit~al~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
       },
       "operators": [
         {
-          "onestop_id": "o-9q5b-gtrans",
-          "name": "GTrans",
+          "name": "Montgomery Transit",
+          "onestop_id": "o-djf8-montgomerytransit",
+          "tags": {
+            "us_ntd_id": "40044",
+            "wikidata_id": "Q6905645"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "montgomerytransit-al-us",
+        "gtfs_data_exchange": "montgomery-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/montgomerytransit-al-us/montgomerytransit-al-us.zip"
+      }
+    },
+    {
+      "id": "f-djj2-pascocountypublictransit~fl~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "749"
+            }
+          ],
+          "name": "Pasco County Public Transportation",
+          "onestop_id": "o-djj2-pascocountypublictransportation",
+          "tags": {
+            "twitter_general": "RidePCPT",
+            "us_ntd_id": "40074",
+            "wikidata_id": "Q7141817"
+          },
+          "website": "http://www.pascocountyfl.net/index.aspx?NID=243"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "pascocountypublictransit-fl-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/pascocountypublictransit-fl-us/pascocountypublictransit-fl-us.zip"
+      }
+    },
+    {
+      "id": "f-djj6-thehernandoexpress~fl~us",
+      "operators": [
+        {
+          "name": "Hernando County Transit",
+          "onestop_id": "o-djj6-hernandobus",
+          "short_name": "The Bus",
+          "tags": {
+            "twitter_general": "HernandoCoGov",
+            "us_ntd_id": "40146",
+            "wikidata_id": "Q7670246"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "thehernandoexpress-fl-us",
+        "status": "outdated"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/thehernandoexpress-fl-us/thehernandoexpress-fl-us.zip"
+      }
+    },
+    {
+      "id": "f-djjk-citruscounty~fl~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "409"
+            }
+          ],
+          "name": "Citrus County Transit",
+          "onestop_id": "o-djjk-orangelinebuscitruscountytransit",
+          "short_name": "Orange Line Bus",
+          "tags": {
+            "twitter_general": "citrusbocc",
+            "wikidata_id": "Q5122888"
+          },
+          "website": "http://www.citruscountytransit.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "citruscounty-fl-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/citruscounty-fl-us/citruscounty-fl-us.zip"
+      }
+    },
+    {
+      "id": "f-djjt-suntran~fl~us",
+      "operators": [
+        {
+          "name": "SunTran",
+          "onestop_id": "o-djjt-suntrancityofocala",
+          "tags": {
+            "twitter_general": "CityofOcalaFL",
+            "us_ntd_id": "40120",
+            "wikidata_id": "Q5123847"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "suntran-fl-us",
+        "gtfs_data_exchange": "suntran"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/suntran-fl-us/suntran-fl-us.zip"
+      }
+    },
+    {
+      "id": "f-djkj-starmetro",
+      "operators": [
+        {
+          "name": "StarMetro",
+          "onestop_id": "o-djkj-starmetro",
+          "tags": {
+            "twitter_general": "CityofTLH",
+            "us_ntd_id": "40036",
+            "wikidata_id": "Q7600550"
+          },
+          "website": "http://www.talgov.com/starmetro"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/starmetro-fl-us/starmetro-fl-us.zip"
+      }
+    },
+    {
+      "id": "f-djn-spacecoast~fl~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "71"
+            }
+          ],
+          "name": "Space Coast Area Transit",
+          "onestop_id": "o-djn-spacecoastareatransit",
+          "tags": {
+            "twitter_general": "321Transit",
+            "us_ntd_id": "40063",
+            "wikidata_id": "Q7572299"
+          },
+          "website": "http://www.ridescat.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "spacecoast-fl-us",
+        "gtfs_data_exchange": "space-coast-area-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/spacecoast-fl-us/spacecoast-fl-us.zip"
+      }
+    },
+    {
+      "id": "f-djq-sunshinebuscompany~fl~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "408"
+            }
+          ],
+          "name": "Sunshine Bus Company",
+          "onestop_id": "o-djq-sunshinebuscompany",
+          "website": "http://www.sunshinebus.net/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "sunshinebuscompany-fl-us",
+        "gtfs_data_exchange": "sunshine-bus-company",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/sunshinebuscompany-fl-us/sunshinebuscompany-fl-us.zip"
+      }
+    },
+    {
+      "id": "f-djz4-carta~sc~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "213"
+            },
+            {
+              "feed_onstop_id": "f-djz4-carta~sc~us~rt"
+            },
+            {
+              "feed_onstop_id": "f-djz4-carta~sc~us~alerts"
+            }
+          ],
+          "name": "Charleston Area Regional Transportation Authority",
+          "onestop_id": "o-djz4-charlestonarearegionaltransportationauthority",
+          "short_name": "CARTA",
+          "tags": {
+            "twitter_general": "ridecarta",
+            "us_ntd_id": "40110",
+            "wikidata_id": "Q5084103"
+          },
+          "website": "http://www.ridecarta.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "carta-sc-us",
+        "gtfs_data_exchange": "charleston-area-regional-transportation-authority",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/carta-sc-us/carta-sc-us.zip"
+      }
+    },
+    {
+      "id": "f-djz4-carta~sc~us~alerts",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/carta-sc-us/service_alerts.proto"
+      }
+    },
+    {
+      "id": "f-dn6hr-tma~tn~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1495"
+            }
+          ],
+          "name": "Franklin Transit",
+          "onestop_id": "o-dn6hr-franklintransit",
+          "tags": {
+            "twitter_general": "franklintransit",
+            "us_ntd_id": "40162"
+          },
+          "website": "http://franklintransit.org/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "tma-tn-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/tma-tn-us/tma-tn-us.zip"
+      }
+    },
+    {
+      "id": "f-dne-bgcap~ky~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "599"
+            }
+          ],
+          "name": "Bluegrass Ultra-Transit Service",
+          "onestop_id": "o-dne-ky~bluegrassultra~transitservice",
+          "tags": {
+            "us_ntd_id": "4R04-40948"
+          },
+          "website": "http://www.bluegrasscommunityaction.org/Pages/bus.html"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "bgcap-ky-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/bgcap-ky-us/bgcap-ky-us.zip"
+      }
+    },
+    {
+      "id": "f-dnh0-gwinnettcountytransit",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "url": "http://atlantaregional.com/File%20Library/Transportation/Transit/Developers-Agreement-for-Web.pdf",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "GCT"
+            }
+          ],
+          "name": "Gwinnett County Transit",
+          "onestop_id": "o-dnh0-gwinnettcountytransit",
+          "short_name": "GCT",
+          "tags": {
+            "twitter_general": "gctransit",
+            "us_ntd_id": "40138",
+            "wikidata_id": "Q5623666"
+          },
+          "website": "http://www.gctransit.com"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/gwinnettcountytransit-ga-us/gwinnettcountytransit-ga-us.zip"
+      }
+    },
+    {
+      "id": "f-dnjj-clemson~sc~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "name": "Clemson Area Transit",
+          "onestop_id": "o-dnjj-clemsonareatransit",
+          "short_name": "catbus",
+          "tags": {
+            "twitter_general": "catclemson",
+            "us_ntd_id": "40208",
+            "wikidata_id": "Q5131543"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "clemson-sc-us",
+        "gtfs_data_exchange": "clemson-area-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/clemson-sc-us/clemson-sc-us.zip"
+      }
+    },
+    {
+      "id": "f-dnm6-asheville~nc~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "190"
+            },
+            {
+              "onestop_id": "f-dnm6-asheville~nc~us~alerts"
+            },
+            {
+              "onestop_id": "f-dnm6-asheville~nc~us~rt"
+            }
+          ],
+          "name": "Asheville Redefines Transit",
+          "onestop_id": "o-dnm6-ashevilleredefinestransit",
+          "short_name": "ART",
+          "tags": {
+            "twitter_general": "cityofasheville",
+            "us_ntd_id": "40005",
+            "wikidata_id": "Q4804926"
+          },
+          "website": "http://www.ashevillenc.gov/Departments/Transit.aspx"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "asheville-nc-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/asheville-nc-us/asheville-nc-us.zip"
+      }
+    },
+    {
+      "id": "f-dnm6-asheville~nc~us~alerts",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "onestop_id": "f-dnm6-asheville~nc~us"
+            },
+            {
+              "onestop_id": "f-dnm6-asheville~nc~us~rt"
+            }
+          ],
+          "name": "Asheville Redefines Transit",
+          "onestop_id": "o-dnm6-ashevilleredefinestransit"
+        }
+      ],
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/asheville-nc-us/service_alerts.proto"
+      }
+    },
+    {
+      "id": "f-dnn3-thecomet~sc~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "943"
+            }
+          ],
+          "name": "The COMET",
+          "onestop_id": "o-dnn3-thecomet",
+          "tags": {
+            "twitter_general": "CatchTheCOMET",
+            "us_ntd_id": "40141",
+            "wikidata_id": "Q5061436"
+          },
+          "website": "http://catchthecomet.org/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "thecomet-sc-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/thecomet-sc-us/thecomet-sc-us.zip"
+      }
+    },
+    {
+      "id": "f-dnq9-ckrider~nc~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "541"
+            }
+          ],
+          "name": "Concord Kannapolis Area Transit",
+          "onestop_id": "o-dnq9-concordkannapolisareatransit",
+          "tags": {
+            "us_ntd_id": "40167",
+            "wikidata_id": "Q5158814"
+          },
+          "website": "http://www.ckrider.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "ckrider-nc-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/ckrider-nc-us/ckrider-nc-us.zip"
+      }
+    },
+    {
+      "id": "f-dnr-tta~regionalbus~nc~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "url": "https://gotriangle.org/developer-terms-and-conditions",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "name": "GoTriangle",
+          "onestop_id": "o-dnr-gotriangle",
+          "tags": {
+            "twitter_general": "ocptnc",
+            "us_ntd_id": "40108",
+            "wikidata_id": "Q7840091"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "tta-regionalbus-nc-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/tta-regionalbus-nc-us/tta-regionalbus-nc-us.zip"
+      }
+    },
+    {
+      "id": "f-dnrg-cary~transit~nc~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "name": "Cary Transit",
+          "onestop_id": "o-dnrg-carytransit",
+          "short_name": "GoCary",
+          "tags": {
+            "twitter_general": "TownofCary",
+            "us_ntd_id": "40143",
+            "wikidata_id": "Q5005923"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "cary-transit-nc-us",
+        "gtfs_data_exchange": "cary-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/cary-transit-nc-us/cary-transit-nc-us.zip"
+      }
+    },
+    {
+      "id": "f-dnru-chapel~hill~transit~nc~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "name": "Chapel Hill Transit",
+          "onestop_id": "o-dnru-chapelhilltransit",
+          "tags": {
+            "twitter_general": "chapelhillgov",
+            "us_ntd_id": "40051",
+            "wikidata_id": "Q5073024"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "chapel-hill-transit-nc-us",
+        "gtfs_data_exchange": "chapel-hill-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/chapel-hill-transit-nc-us/chapel-hill-transit-nc-us.zip"
+      }
+    },
+    {
+      "id": "f-dnru-durham~area~transit~authority~nc~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "url": "https://godurhamtransit.org/developer-terms-and-conditions",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "onestop_id": "f-dnru-durham~area~transit~authority~nc~us~rt"
+            }
+          ],
+          "name": "GoDurham",
+          "onestop_id": "o-dnru-godurham",
+          "tags": {
+            "twitter_general": "godurhamtransit",
+            "us_ntd_id": "40087",
+            "wikidata_id": "Q5316462"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "durham-area-transit-authority-nc-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/durham-area-transit-authority-nc-us/durham-area-transit-authority-nc-us.zip"
+      }
+    },
+    {
+      "id": "f-dnrug-duke~nc~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "240"
+            }
+          ],
+          "name": "Duke Transit",
+          "onestop_id": "o-dnrug-duketransit",
+          "website": "http://parking.duke.edu/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "duke-nc-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/duke-nc-us/duke-nc-us.zip"
+      }
+    },
+    {
+      "id": "f-dnx-radartransit",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1763"
+            }
+          ],
+          "name": "RADAR",
+          "onestop_id": "o-dnx-radar",
+          "tags": {
+            "us_ntd_id": "3R06-30178"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/radar-va-us/radar-va-us.zip"
+      }
+    },
+    {
+      "id": "f-dnxs-gltc~lynchburg~va~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "name": "Greater Lynchburg Transit Co.",
+          "onestop_id": "o-dnxs-greaterlynchburgtransitco",
+          "short_name": "GLTC",
+          "tags": {
+            "twitter_general": "GLTCONLINE",
+            "us_ntd_id": "30008",
+            "wikidata_id": "Q5600625"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "gltc-lynchburg-va-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/gltc-lynchburg-va-us/gltc-lynchburg-va-us.zip"
+      }
+    },
+    {
+      "id": "f-downey~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1682"
+            }
+          ],
+          "name": "DowneyLINK",
+          "onestop_id": "o-9q5cp-downeylink",
+          "tags": {
+            "us_ntd_id": "90263"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/downey-ca-us/downey-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-dp-945963",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "945"
+            }
+          ],
+          "name": "Detroit Connector",
+          "onestop_id": "o-dp-indiantrails",
+          "tags": {
+            "twitter_general": "indiantrailsbus",
+            "wikidata_id": "Q6021774"
+          },
+          "website": "https://detroit.umich.edu/transportation/detroit-connector/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "945_963"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/indiantrails-mi-us/indiantrails-mi-us.zip"
+      }
+    },
+    {
+      "id": "f-dp0r-citylink",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "594"
+            }
+          ],
+          "name": "CityLink",
+          "onestop_id": "o-dp0r-citylink",
+          "tags": {
+            "twitter_general": "CityLinkPeoria",
+            "us_ntd_id": "50056",
+            "wikidata_id": "Q5600709"
+          },
+          "website": "http://www.ridecitylink.org/"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/ridecitylink-il-us/ridecitylink-il-us.zip"
+      }
+    },
+    {
+      "id": "f-dp1b-terrehautetransit~in~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "260"
+            }
+          ],
+          "name": "Terre Haute Transit",
+          "onestop_id": "o-dp1b-terrehautetransit",
+          "tags": {
+            "us_ntd_id": "50053",
+            "wikidata_id": "Q7703361"
+          },
+          "website": "http://terrehaute.in.gov/departments/transit-department"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "terrehautetransit-in-us",
+        "gtfs_data_exchange": "terre-haute-transit",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/terrehautetransit-in-us/terrehautetransit-in-us.zip"
+      }
+    },
+    {
+      "id": "f-dp4j-citybus",
+      "license": {
+        "url": "https://gocitybus.com/gtfs-gis-data-download"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "816"
+            },
+            {
+              "gtfs_agency_id": "9eca155d-a6ad-42b1-8ad5-4888c7c42aaa"
+            }
+          ],
+          "name": "CityBus of Greater Lafayette Indiana",
+          "onestop_id": "o-dp4j-citybus",
+          "short_name": "CityBus",
+          "tags": {
+            "twitter_general": "gocitybus",
+            "us_ntd_id": "50051",
+            "wikidata_id": "Q5600598"
+          },
+          "website": "http://www.gocitybus.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/citybus-lafayette-in-us/citybus-lafayette-in-us.zip"
+      }
+    },
+    {
+      "id": "f-dp89-beloittransit~wi~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "name": "Beloit Transit System",
+          "onestop_id": "o-dp89-beloittransitsystem",
+          "tags": {
+            "us_ntd_id": "50109"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "beloittransit-wi-us",
+        "gtfs_data_exchange": "beloit-transit-system",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/beloittransit-wi-us/beloittransit-wi-us.zip"
+      }
+    },
+    {
+      "id": "f-dp8d-jts~wi~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "254"
+            }
+          ],
+          "name": "Janesville Transit System",
+          "onestop_id": "o-dp8d-janesvilletransitsystem",
+          "tags": {
+            "twitter_general": "City_Janesville",
+            "us_ntd_id": "50108",
+            "wikidata_id": "Q6153111"
+          },
+          "website": "http://www.ci.janesville.wi.us/index.aspx?page=124"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "jts-wi-us",
+        "gtfs_data_exchange": "janesville-transit-system",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/jts-wi-us/jts-wi-us.zip"
+      }
+    },
+    {
+      "id": "f-dp9e-belleurbansystem",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "629"
+            }
+          ],
+          "name": "Belle Urban System",
+          "onestop_id": "o-dp9e-belleurbansystem",
+          "short_name": "BUS",
+          "tags": {
+            "twitter_general": "CityofRacine",
+            "us_ntd_id": "50006",
+            "wikidata_id": "Q4883698"
+          },
+          "website": "http://www.racinetransit.com"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/racine-wi-us/racine-wi-us.zip"
+      }
+    },
+    {
+      "id": "f-dp9k-waukeshacounty~wi~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "189"
+            }
+          ],
+          "name": "Waukesha County Transit",
+          "onestop_id": "o-dp9k-waukeshacountytransit",
+          "tags": {
+            "us_ntd_id": "50096",
+            "wikidata_id": "Q7975163"
+          },
+          "website": "http://www.ci.waukesha.wi.us/web/guest/waukeshametro/transit_home"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "waukeshacounty-wi-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/waukeshacounty-wi-us/waukeshacounty-wi-us.zip"
+      }
+    },
+    {
+      "id": "f-dpc4-oshkosh~wi~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "name": "GO Transit (City of Oshkosh)",
+          "onestop_id": "o-dpc4-gotransitcityofoshkosh",
+          "tags": {
+            "twitter_general": "Oshkosh_Transit",
+            "us_ntd_id": "50009",
+            "wikidata_id": "Q5514128"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "oshkosh-wi-us",
+        "gtfs_data_exchange": "go-transit-city-of-oshkosh",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/oshkosh-wi-us/oshkosh-wi-us.zip"
+      }
+    },
+    {
+      "id": "f-dpc8-sheboygan~wi~us",
+      "operators": [
+        {
+          "name": "Shoreline Metro",
+          "onestop_id": "o-dpc8-shorelinemetro",
+          "tags": {
+            "us_ntd_id": "50088",
+            "wikidata_id": "Q7501442"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "sheboygan-wi-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/sheboygan-wi-us/sheboygan-wi-us.zip"
+      }
+    },
+    {
+      "id": "f-dpq-lakecounty~oh~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "508"
+            }
+          ],
+          "name": "Laketran",
+          "onestop_id": "o-dpq-laketran",
+          "tags": {
+            "twitter_general": "laketran",
+            "us_ntd_id": "50117",
+            "wikidata_id": "Q6479195"
+          },
+          "website": "http://www.laketran.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "lakecounty-oh-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/lakecounty-oh-us/lakecounty-oh-us.zip"
+      }
+    },
+    {
+      "id": "f-dps-michiganflyer~mi~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "535"
+            }
+          ],
+          "name": "Michigan Flyer",
+          "onestop_id": "o-dps-michiganflyer",
+          "tags": {
+            "twitter_general": "MichiganFlyer1",
+            "wikidata_id": "Q6021774"
+          },
+          "website": "http://www.michiganflyer.com/Home.aspx"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "michiganflyer-mi-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/michiganflyer-mi-us/michiganflyer-mi-us.zip"
+      }
+    },
+    {
+      "id": "f-dq25-capital~area~transit~nc~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "url": "https://goraleigh.org/developer-terms-and-conditions",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "name": "GoRaleigh",
+          "onestop_id": "o-dq25-goraleigh",
+          "tags": {
+            "twitter_general": "GoRaleighNC",
+            "us_ntd_id": "40007",
+            "wikidata_id": "Q5035469"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "capital-area-transit-nc-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/capital-area-transit-nc-us/capital-area-transit-nc-us.zip"
+      }
+    },
+    {
+      "id": "f-dq2s-tarriver~nc~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "560"
+            }
+          ],
+          "name": "Tar River Transit",
+          "onestop_id": "o-dq2s-tarrivertransit",
+          "tags": {
+            "twitter_general": "cityofrockymtnc",
+            "us_ntd_id": "40096",
+            "wikidata_id": "Q7684999"
+          },
+          "website": "http://www.tarrivertransit.org"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "tarriver-nc-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/tarriver-nc-us/tarriver-nc-us.zip"
+      }
+    },
+    {
+      "id": "f-dqc-thebusofprincegeorgescounty",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "2166"
+            }
+          ],
+          "name": "Prince George's County",
+          "onestop_id": "o-dqc-thebusofprincegeorgescounty",
+          "short_name": "The Bus",
+          "tags": {
+            "twitter_general": "PGCountyDPWT",
+            "us_ntd_id": "30035",
+            "wikidata_id": "Q7711628"
+          },
+          "website": "https://www.princegeorgescountymd.gov/1120/Countys-TheBus"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/princegeorgescounty-md-us/princegeorgescounty-md-us.zip"
+      }
+    },
+    {
+      "id": "f-dr-coachcompany~ma~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "930"
+            }
+          ],
+          "name": "Coach Company",
+          "onestop_id": "o-dr-coachcompany",
+          "website": "https://coachco.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "coachcompany-ma-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/coachcompany-ma-us/coachcompany-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-dr-peterpanbuslines",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "642"
+            }
+          ],
+          "name": "Peter Pan Bonanza Division",
+          "onestop_id": "o-dr-peterpanbonanzadivision",
+          "website": "https://peterpanbus.com/"
+        },
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "PeterPan"
+            }
+          ],
+          "name": "Peter Pan Bus Lines",
+          "onestop_id": "o-dr-peterpanbuslines",
+          "tags": {
+            "twitter_general": "PeterPanBus",
+            "twitter_service_alerts": "peterpanalerts",
+            "us_ntd_id": "1R02-10157",
+            "wikidata_id": "Q204807"
+          },
+          "website": "http://peterpanbus.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/peterpan-ma-us/peterpan-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-dr5r-path~nj~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "unknown",
+        "url": "http://www.panynj.gov/path/developers.html",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "name": "Port Authority Trans-Hudson",
+          "onestop_id": "o-dr5r-path",
+          "short_name": "PATH",
+          "tags": {
+            "twitter_general": "PATHTrain",
+            "us_ntd_id": "20098",
+            "wikidata_id": "Q1055811"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "path-nj-us",
+        "gtfs_data_exchange": "path",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/path-nj-us/path-nj-us.zip"
+      }
+    },
+    {
+      "id": "f-dr7f-greaterbridgeporttransit",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "668"
+            }
+          ],
+          "name": "Greater Bridgeport Transit",
+          "onestop_id": "o-dr7f-greaterbridgeporttransit",
+          "tags": {
+            "twitter_general": "gogbt",
+            "us_ntd_id": "10050",
+            "wikidata_id": "Q5600471"
+          },
+          "website": "http://www.gogbt.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/gbt-ct-us/gbt-ct-us.zip"
+      }
+    },
+    {
+      "id": "f-dre-berkshire~ma~us",
+      "license": {
+        "attribution_text": "Clearly acknowledge MassDOT as the provider of the Data.",
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "url": "https://www.massdot.state.ma.us/Portals/0/docs/developers/develop_license_agree.pdf",
+        "use_without_attribution": "no"
+      },
+      "operators": [
+        {
+          "name": "Berkshire Regional Transit Authority",
+          "onestop_id": "o-dre-berkshiremetroaltransitauthority",
+          "short_name": "BRTA",
+          "tags": {
+            "us_ntd_id": "10007",
+            "wikidata_id": "Q20708878"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "berkshire-ma-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/berkshire-ma-us/berkshire-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-dre-greenmtncn~vt~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "219"
+            },
+            {
+              "feed_onestop_id": "f-greenmtncn~vt~rt"
+            }
+          ],
+          "name": "Green Mountain Community Network, Inc.",
+          "onestop_id": "o-dre-greenmountaincommunitynetworkinc",
+          "tags": {
+            "us_ntd_id": "1R06-10151",
+            "wikidata_id": "Q5602891"
+          },
+          "website": "http://www.greenmtncn.org/index.html"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "greenmtncn-vt-us",
+        "gtfs_data_exchange": "o-dre-greenmountaincommunitynetworkinc",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/greenmtncn-vt-us/greenmtncn-vt-us.zip"
+      }
+    },
+    {
+      "id": "f-drg-addisoncounty~vt~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "230"
+            }
+          ],
+          "name": "Addison County Transit Resources",
+          "onestop_id": "o-drg-addisoncountytransitresources",
+          "tags": {
+            "us_ntd_id": "1R06-10143"
+          },
+          "website": "http://actr-vt.org/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "addisoncounty-vt-us",
+        "gtfs_data_exchange": "addison-county-transit-resources",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/addisoncounty-vt-us/addisoncounty-vt-us.zip"
+      }
+    },
+    {
+      "id": "f-drgv-lctferries~vt~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "789"
+            }
+          ],
+          "name": "Lake Champlain Ferries",
+          "onestop_id": "o-drgv-lakechamplainferries",
+          "tags": {
+            "wikidata_id": "Q6475257"
+          },
+          "website": "http://ferries.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "lctferries-vt-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/lctferries-vt-us/lctferries-vt-us.zip"
+      }
+    },
+    {
+      "id": "f-drke-ninetown~connecticut~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "539"
+            }
+          ],
+          "name": "9 Town Transit",
+          "onestop_id": "o-drke-9towntransit",
+          "tags": {
+            "twitter_general": "9towntransit",
+            "us_ntd_id": "1R01-10140",
+            "wikidata_id": "Q5401887"
+          },
+          "website": "http://estuarytransit.org/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "ninetown-connecticut-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/ninetown-connecticut-us/ninetown-connecticut-us.zip"
+      }
+    },
+    {
+      "id": "f-drkg-seatbus~ct~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "978"
+            }
+          ],
+          "name": "Southeast Area Transit District",
+          "onestop_id": "o-drkg-southeastareatransitdistrict",
+          "short_name": "SEAT",
+          "tags": {
+            "twitter_general": "S_E_A_T",
+            "us_ntd_id": "10040",
+            "wikidata_id": "Q7569291"
+          },
+          "website": "http://www.seatbus.com"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "seatbus-ct-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/seatbus-ct-us/seatbus-ct-us.zip"
+      }
+    },
+    {
+      "id": "f-drm-blockislandferry~ri~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "276"
+            }
+          ],
+          "name": "Block Island Ferry",
+          "onestop_id": "o-drm-blockislandferry",
+          "tags": {
+            "twitter_general": "BlockIsleFerry"
+          },
+          "website": "http://www.blockislandferry.com"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "blockislandferry-ri-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/blockislandferry-ri-us/blockislandferry-ri-us.zip"
+      }
+    },
+    {
+      "id": "f-drm-plymouthbrockton~ma~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "801"
+            }
+          ],
+          "name": "Plymouth & Brockton Street Railway Co.",
+          "onestop_id": "o-drm-plymouth~brocktonstreetrailwayco",
+          "tags": {
+            "twitter_general": "PBBus",
+            "wikidata_id": "Q85793712"
+          },
+          "website": "http://www.p-b.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "plymouthbrockton-ma-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/plymouthbrockton-ma-us/plymouthbrockton-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drm-thegreaterattleborotauntonregionaltransitauthority",
+      "license": {
+        "url": "https://www.mass.gov/doc/developers-license-agreement-11132009/download"
+      },
+      "operators": [
+        {
+          "name": "Greater Attleboro Taunton Regional Transit Authority",
+          "onestop_id": "o-drm-thegreaterattleborotauntonregionaltransitauthority",
+          "short_name": "GATRA",
+          "tags": {
+            "us_ntd_id": "10064",
+            "wikidata_id": "Q5600434"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/gatra-ma-us/gatra-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drm-vineyardfastferry~ri~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "281"
+            }
+          ],
+          "name": "Vineyard Fast Ferry",
+          "onestop_id": "o-drm-vineyardfastferry",
+          "tags": {
+            "wikidata_id": "https://twitter.com/RIFastFerry"
+          },
+          "website": "https://www.vineyardfastferry.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "vineyardfastferry-ri-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/vineyardfastferry-ri-us/vineyardfastferry-ri-us.zip"
+      }
+    },
+    {
+      "id": "f-drmg-marthasvineyard~ma~us",
+      "license": {
+        "attribution_text": "Clearly acknowledge MassDOT as the provider of the Data.",
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "url": "https://www.massdot.state.ma.us/Portals/0/docs/developers/develop_license_agree.pdf",
+        "use_without_attribution": "no"
+      },
+      "operators": [
+        {
+          "name": "Martha's Vineyard Transit Authority",
+          "onestop_id": "o-drmg-marthasvineyardtransitauthority",
+          "short_name": "VTA",
+          "tags": {
+            "twitter_general": "VTA_MV",
+            "us_ntd_id": "1R02-10145",
+            "wikidata_id": "Q20715059"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "marthasvineyard-ma-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/marthasvineyard-ma-us/marthasvineyard-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drmm-southeasternregionaltransitauthority",
+      "license": {
+        "url": "https://www.mass.gov/doc/developers-license-agreement-11132009/download"
+      },
+      "operators": [
+        {
+          "name": "Southeastern Regional Transit Authority",
+          "onestop_id": "o-drmm-southeasternregionaltransitauthority",
+          "short_name": "SRTA",
+          "tags": {
+            "twitter_general": "srtabus",
+            "us_ntd_id": "10006",
+            "wikidata_id": "Q7569500"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "gtfs_data_exchange": "southeastern-regional-transit-authority",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/srta-ma-us/srta-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drmr-brockton~ma~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "url": "https://www.mass.gov/doc/developers-license-agreement-11132009/download",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "name": "Brockton Area Transit Authority",
+          "onestop_id": "o-drmr-brocktonareatransitauthority",
+          "short_name": "BAT",
+          "tags": {
+            "twitter_general": "BrocktonBAT",
+            "us_ntd_id": "10004",
+            "wikidata_id": "Q4972867"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "brockton-ma-us",
+        "gtfs_data_exchange": "brockton-area-transit-authority",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/brockton-ma-us/brockton-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drms-cuttyhunkferryco~ma~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "277"
+            }
+          ],
+          "name": "Cuttyhunk Ferry Co.",
+          "onestop_id": "o-drms-cuttyhunkferryco",
+          "website": "http://www.cuttyhunkferryco.com"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "cuttyhunkferryco-ma-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/cuttyhunkferryco-ma-us/cuttyhunkferryco-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drmu1-patriotpartyboats~ma~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "280"
+            }
+          ],
+          "name": "Patriot Party Boats",
+          "onestop_id": "o-drmu1-patriotpartyboats",
+          "website": "http://www.patriotpartyboats.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "patriotpartyboats-ma-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/patriotpartyboats-ma-us/patriotpartyboats-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drq-capecodregionaltransitauthorityccrta",
+      "license": {
+        "attribution_text": "Clearly acknowledge MassDOT as the provider of the Data.",
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "url": "https://www.massdot.state.ma.us/Portals/0/docs/developers/develop_license_agree.pdf",
+        "use_without_attribution": "no"
+      },
+      "operators": [
+        {
+          "name": "Cape Cod Regional Transit Authority",
+          "onestop_id": "o-drq-capecodregionaltransitauthorityccrta",
+          "short_name": "CCRTA",
+          "tags": {
+            "twitter_general": "CapeCodRTA",
+            "us_ntd_id": "10105",
+            "wikidata_id": "Q5034704"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "gtfs_data_exchange": "cape-cod-regional-transit-authority",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/capecod-ma-us/capecod-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drq-freedomcruiseline~ma~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "278"
+            }
+          ],
+          "name": "Freedom Cruise Line",
+          "onestop_id": "o-drq-freedomcruiseline",
+          "website": "http://www.nantucketislandferry.com"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "freedomcruiseline-ma-us",
+        "gtfs_data_exchange": "freedom-cruise-line",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/freedomcruiseline-ma-us/freedomcruiseline-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drq4-thewave~nantucketregionaltransitauthority",
+      "license": {
+        "url": "https://www.mass.gov/doc/developers-license-agreement-11132009/download"
+      },
+      "operators": [
+        {
+          "name": "Nantucket Regional Transit Authority",
+          "onestop_id": "o-drq4-thewave~nantucketregionaltransitauthority",
+          "short_name": "WAVE",
+          "tags": {
+            "us_ntd_id": "1R02-10162",
+            "wikidata_id": "Q6964378"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/nantucket-ma-us/nantucket-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drq5-hylinecruises~ma~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "279"
+            }
+          ],
+          "name": "Hy-Line Cruises",
+          "onestop_id": "o-drq5-hy~linecruises",
+          "tags": {
+            "twitter_general": "hylinecruises",
+            "wikidata_id": "Q14715606"
+          },
+          "website": "https://www.hylinecruises.com"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "hylinecruises-ma-us",
+        "gtfs_data_exchange": "hy-line-cruises",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/hylinecruises-ma-us/hylinecruises-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drs-crtransit~vt~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "232"
+            },
+            {
+              "feed_onestop_id": "f-crtransit~vt~rt"
+            }
+          ],
+          "name": "The Current",
+          "onestop_id": "o-drs-thecurrent",
+          "tags": {
+            "us_ntd_id": "1R06-10144",
+            "wikidata_id": "Q28448928"
+          },
+          "website": "http://crtransit.org/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "crtransit-vt-us",
+        "gtfs_data_exchange": "the-current",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/crtransit-vt-us/crtransit-vt-us.zip"
+      }
+    },
+    {
+      "id": "f-drs-thebus~vt~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "220"
+            },
+            {
+              "feed_onestop_id": "f-thebus~vt~rt"
+            }
+          ],
+          "name": "The Bus (Marble Valley Regional Transit District)",
+          "onestop_id": "o-drs-thebusmarblevalleymetroaltransitdistrict",
+          "short_name": "MVRTD",
+          "tags": {
+            "us_ntd_id": "1R06-10154",
+            "wikidata_id": "Q6755227"
+          },
+          "website": "http://www.thebus.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "thebus-vt-us",
+        "gtfs_data_exchange": "the-bus-marble-valley-regional-transit-district",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/thebus-vt-us/thebus-vt-us.zip"
+      }
+    },
+    {
+      "id": "f-drs-truenorthtransit~ma~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "521"
+            }
+          ],
+          "name": "Massachusetts Area Express",
+          "onestop_id": "o-drs-max",
+          "short_name": "MAX",
+          "website": "http://ridemaxbus.com"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "truenorthtransit-ma-us",
+        "managed_by": "trillium",
+        "status": "unpublished"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/truenorthtransit-ma-us/truenorthtransit-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drsb-wrta",
+      "license": {
+        "attribution_text": "Clearly acknowledge MassDOT as the provider of the Data.",
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "url": "https://www.massdot.state.ma.us/Portals/0/docs/developers/develop_license_agree.pdf",
+        "use_without_attribution": "no"
+      },
+      "operators": [
+        {
+          "name": "Worcester Regional Transit Authority",
+          "onestop_id": "o-drsb-wrta",
+          "short_name": "WRTA",
+          "tags": {
+            "twitter_general": "therta",
+            "us_ntd_id": "10014",
+            "wikidata_id": "Q8034217"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/wrta-ma-us/wrta-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drsf-montachusett~ma~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "url": "https://www.mass.gov/doc/developers-license-agreement-11132009/download",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "name": "Montachusett Regional Transit Authority",
+          "onestop_id": "o-drsf-montachusettmetroaltransitauthority",
+          "short_name": "MART",
+          "tags": {
+            "us_ntd_id": "10061",
+            "wikidata_id": "Q6903133"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "montachusett-ma-us",
+        "gtfs_data_exchange": "montachusett-regional-transit-authority",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/montachusett-ma-us/montachusett-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drsh-dvtamoover~vt~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "218"
+            },
+            {
+              "feed_onestop_id": "f-dvtamoover~vt~rt"
+            }
+          ],
+          "name": "MOOver!",
+          "onestop_id": "o-drsh-moover",
+          "tags": {
+            "us_ntd_id": "1R06-10144",
+            "wikidata_id": "Q28448928"
+          },
+          "website": "http://www.moover.com"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "dvtamoover-vt-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/dvtamoover-vt-us/dvtamoover-vt-us.zip"
+      }
+    },
+    {
+      "id": "f-drt-baystatecruisecompany~ma~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "275"
+            }
+          ],
+          "name": "Bay State Cruise Company",
+          "onestop_id": "o-drt-baystatecruisecompany",
+          "website": "http://www.baystatecruisecompany.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "baystatecruisecompany-ma-us",
+        "gtfs_data_exchange": "bay-state-cruise-company",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/baystatecruisecompany-ma-us/baystatecruisecompany-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drt0-limoliner~ma~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "903"
+            }
+          ],
+          "name": "Metrowest Express",
+          "onestop_id": "o-drt0-metrowestexpress",
+          "tags": {
+            "twitter_general": "mwestexpress"
+          },
+          "website": "https://metrowestexpress.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "limoliner-ma-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/limoliner-ma-us/limoliner-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drt3-123bc~ma~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "466"
+            }
+          ],
+          "name": "128 Business Council",
+          "onestop_id": "o-drt3-128businesscouncil",
+          "tags": {
+            "twitter_general": "UnlockTheGrid"
+          },
+          "website": "http://128bc.org/rev-hartwell-area-shuttle/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "123bc-ma-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/route128corridor-ma-us/route128corridor-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drt3-909983",
+      "license": {
+        "url": "http://www.massport.com/media/1651/massportdatalicenseagreement.pdf"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "2272"
+            }
+          ],
+          "name": "Massport",
+          "onestop_id": "o-drt3pb-massport",
+          "tags": {
+            "twitter_general": "Massport",
+            "wikidata_id": "Q2777980"
+          },
+          "website": "http://www.massport.com/logan-airport/to-from-logan/transportation-options/on-airport-shuttle/"
+        },
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "2274"
+            }
+          ],
+          "name": "Logan Express",
+          "onestop_id": "o-drt3-loganexpress",
+          "website": "http://www.massport.com/logan-airport/to-from-logan/transportation-options/logan-express/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "1710"
+      },
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/massport-ma-us/massport-ma-us.zip",
+        "static_historic": [
+          "https://www.massport.com/media/ptydscvm/massport_gtfs-1013-4.zip"
+        ]
+      }
+    },
+    {
+      "id": "f-drt3-middlesex~ma~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "555"
+            }
+          ],
+          "name": "Middlesex 3 TMA",
+          "onestop_id": "o-drt3-middlesex3tma",
+          "tags": {
+            "twitter_general": "middlesex3tma"
+          },
+          "website": "http://www.middlesex3tma.com/SERVICES/SHUTTLES"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "middlesex-ma-us"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/middlesex-ma-us/middlesex-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drt6-lowellregionaltransitauthority",
+      "license": {
+        "url": "https://www.mass.gov/doc/developers-license-agreement-11132009/download"
+      },
+      "operators": [
+        {
+          "name": "Lowell Regional Transit Authority",
+          "onestop_id": "o-drt6-lowellregionaltransitauthority",
+          "short_name": "LRTA",
+          "tags": {
+            "twitter_general": "mylrta",
+            "us_ntd_id": "10005",
+            "wikidata_id": "Q2078562"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "gtfs_data_exchange": "lowell-regional-transit-authority",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/lowell-ma-us/lowell-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drt7-merrimackvalley~ma~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "url": "https://www.mass.gov/doc/developers-license-agreement-11132009/download",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "441"
+            },
+            {
+              "feed_onestop_id": "f-merrimackvalley~rt"
+            }
+          ],
+          "name": "Merrimack Valley Regional Transit Authority",
+          "onestop_id": "o-drt7-merrimackvalleymetroaltransitauthority",
+          "short_name": "MVRTA",
+          "tags": {
+            "twitter_general": "mvrta_",
+            "us_ntd_id": "10013",
+            "wikidata_id": "Q6820290"
+          },
+          "website": "http://www.mvrta.com"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "merrimackvalley-ma-us",
+        "gtfs_data_exchange": "merrimack-valley-regional-transit-authority",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/merrimackvalley-ma-us/merrimackvalley-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-drtd-capeann~ma~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "name": "Cape Ann Transportation Authority",
+          "onestop_id": "o-drtd-capeanntransportation",
+          "short_name": "CATA",
+          "tags": {
+            "twitter_general": "capeanntransit",
+            "us_ntd_id": "10053",
+            "wikidata_id": "Q5034570"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "capeann-ma-us",
+        "gtfs_data_exchange": "cape-ann-transportation-authority",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/capeann-ma-us/capeann-ma-us.zip"
+      }
+    },
+    {
+      "id": "f-dru-chittendoncounty~vt~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "url": "https://vermont-gtfs.org/",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "460"
+            }
+          ],
+          "name": "Chittenden County Transporation Authority",
+          "onestop_id": "o-drg-chittendencountytransporationauthority",
+          "website": "http://www.cctaride.org"
+        },
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "461"
+            },
+            {
+              "feed_onestop_id": "f-chittendoncounty~rt"
+            }
+          ],
+          "name": "Green Mountain Transit Agency",
+          "onestop_id": "o-dru-greenmountaintransitagency",
+          "tags": {
+            "twitter_general": "RideGMT",
+            "us_ntd_id": "10066",
+            "wikidata_id": "Q28404107"
+          },
+          "website": "http://www.gmtaride.org"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "chittendoncounty-vt-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/ccta-vt-us/ccta-vt-us.zip"
+      }
+    },
+    {
+      "id": "f-dru-ruralcommunity~vt~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "221"
+            },
+            {
+              "feed_onestop_id": "f-ruralcommunity~vt~rt"
+            }
+          ],
+          "name": "Rural Community Transportation",
+          "onestop_id": "o-dru-ruralcommunitytransportation",
+          "short_name": "RCT",
+          "tags": {
+            "us_ntd_id": "1R06-10148",
+            "wikidata_id": "Q7380490"
+          },
+          "website": "http://www.riderct.org/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "ruralcommunity-vt-us",
+        "gtfs_data_exchange": "rural-community-transportation",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/ruralcommunity-vt-us/ruralcommunity-vt-us.zip"
+      }
+    },
+    {
+      "id": "f-dru-stagecoach~vt~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "222"
+            }
+          ],
+          "name": "Stagecoach Transportation Services",
+          "onestop_id": "o-dru-stagecoachtransportationservices",
+          "tags": {
+            "us_ntd_id": "1R06-10168"
+          },
+          "website": "http://stagecoach-rides.org"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "stagecoach-vt-us",
+        "gtfs_data_exchange": "stagecoach-transportation-services",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/stagecoach-vt-us/stagecoach-vt-us.zip"
+      }
+    },
+    {
+      "id": "f-dru-vttranslines~vt~us",
+      "license": {
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "use_without_attribution": "yes"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "228"
+            }
+          ],
+          "name": "Vermont Translines",
+          "onestop_id": "o-dru-vermonttranslines",
+          "tags": {
+            "twitter_general": "vttranslines"
+          },
+          "website": "https://www.vttranslines.com/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "vttranslines-vt-us",
+        "managed_by": "trillium"
+      },
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/vttranslines-vt-us/vttranslines-vt-us.zip"
+      }
+    },
+    {
+      "id": "f-drvc-rtp~me~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "522"
+            }
+          ],
+          "name": "Lakes Region Explorer",
+          "onestop_id": "o-drvc-lakesregionexplorer",
+          "website": "http://rtprides.org/lake-region-bus/"
+        }
+      ],
+      "spec": "gtfs",
+      "tags": {
+        "feed_id": "rtp-me-us"
+      },
+      "urls": {
+        "static_current": "http://trilliumtransit.com/transit_feeds/rtp-me-us/rtp-me-us.zip"
+      }
+    },
+    {
+      "id": "f-dsi~co~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/dsi-co-us/dsi-co-us.zip"
+      }
+    },
+    {
+      "id": "f-elsegundo~ca~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/elsegundo-ca-us/elsegundo-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-estestransit~co~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/estestransit-co-us/estestransit-co-us.zip"
+      }
+    },
+    {
+      "id": "f-farmville~va~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/farmville-va-us/farmville-va-us.zip"
+      }
+    },
+    {
+      "id": "f-gardenofthegods~co~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/gardenofthegods-co-us/gardenofthegods-co-us.zip"
+      }
+    },
+    {
+      "id": "f-getaroundtownexpress~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1721"
+            }
+          ],
+          "name": "Get Around Town Express",
+          "onestop_id": "o-9q5cn-getaroundtownexpress",
+          "tags": {
+            "us_ntd_id": "90291"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/getaroundtownexpress-ca-us/getaroundtownexpress-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-get~va~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/get-va-us/get-va-us.zip"
+      }
+    },
+    {
+      "id": "f-glendora~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1664"
+            }
+          ],
+          "name": "Glendora Transportation Division",
+          "onestop_id": "o-9qh4j-glendoratransportationdivision",
+          "tags": {
+            "twitter_general": "CityofGlendora",
+            "us_ntd_id": "90266"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/glendora-ca-us/glendora-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-glenn~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1707"
+            }
+          ],
+          "name": "Glenn Transit Service",
+          "onestop_id": "o-9r11-glenntransitservice",
+          "tags": {
+            "us_ntd_id": "9R02-91088"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/glenn-ca-us/glenn-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-gowal~fl~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/gowal-fl-us/gowal-fl-us.zip"
+      }
+    },
+    {
+      "id": "f-grahamtransit~va~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/grahamtransit-va-us/grahamtransit-va-us.zip"
+      }
+    },
+    {
+      "id": "f-greenride~co~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/greenride-co-us/greenride-co-us.zip"
+      }
+    },
+    {
+      "id": "f-gtrans~ca~us",
+      "operators": [
+        {
           "associated_feeds": [
             {
               "gtfs_agency_id": "860"
             }
           ],
+          "name": "GTrans",
+          "onestop_id": "o-9q5b-gtrans",
           "tags": {
+            "twitter_general": "RideGTrans",
             "us_ntd_id": "90042",
-            "wikidata_id": "Q5522428",
-            "twitter_general": "RideGTrans"
+            "wikidata_id": "Q5522428"
           }
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/gtrans-ca-us/gtrans-ca-us.zip"
+      }
     },
     {
+      "id": "f-guadalupeflyer~ca~us",
       "spec": "gtfs",
-      "id": "f-morongo~basin",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/morongobasin-ca-us/morongobasin-ca-us.zip"
-      },
+        "static_current": "http://data.trilliumtransit.com/gtfs/guadalupeflyer-ca-us/guadalupeflyer-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-gulfcoastcenter~tx~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/gulfcoastcenter-tx-us/gulfcoastcenter-tx-us.zip"
+      }
+    },
+    {
+      "id": "f-harborconnector~md~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/harborconnector-md-us/harborconnector-md-us.zip"
+      }
+    },
+    {
+      "id": "f-homejames~co~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/homejames-co-us/homejames-co-us.zip"
+      }
+    },
+    {
+      "id": "f-huntingtonpark~ca~us",
       "operators": [
         {
-          "onestop_id": "o-9qj-morongobasintransitauthority",
-          "name": "Morongo Basin Transit Authority",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "74"
+              "gtfs_agency_id": "1668"
             }
           ],
+          "name": "Huntington Park Express",
+          "onestop_id": "o-9q5cm-huntingtonparkexpress",
           "tags": {
-            "us_ntd_id": "9R02-91090",
-            "wikidata_id": "Q6913253"
+            "us_ntd_id": "90267"
           }
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/huntingtonpark-ca-us/huntingtonpark-ca-us.zip"
+      }
     },
     {
-      "spec": "gtfs",
-      "id": "f-madera~county~connection",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/maderactc-ca-us/maderactc-ca-us.zip"
+      "id": "f-iowa~city~transit",
+      "license": {
+        "url": "https://iowa-gtfs.com/"
       },
       "operators": [
         {
-          "onestop_id": "o-9qd-maderacountyconnection",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "796"
+            }
+          ],
+          "name": "Iowa City Transit System",
+          "onestop_id": "o-9zqu-iowacitytransitsystem",
           "tags": {
-            "us_ntd_id": "9R02-91005",
-            "twitter_general": "maderacounty"
-          },
-          "name": "Madera County Connection",
-          "website": "http://www.maderactc.org/public-transit/?referrer=gtfs",
+            "twitter_general": "CityOfIowaCity",
+            "us_ntd_id": "70018"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/iowacitytransit-ia-us/iowacitytransit-ia-us.zip"
+      }
+    },
+    {
+      "id": "f-lacampana~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1660"
+            }
+          ],
+          "name": "La Campana",
+          "onestop_id": "o-9q5cq-lacampana",
+          "tags": {
+            "us_ntd_id": "90252"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/lacampana-ca-us/lacampana-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-lapuente~ca~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/lapuente-ca-us/lapuente-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-lasvegasloop~nv~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/lasvegasloop-nv-us/lasvegasloop-nv-us.zip"
+      }
+    },
+    {
+      "id": "f-lmht~morton~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/lmht-morton-us/lmht-morton-us.zip"
+      }
+    },
+    {
+      "id": "f-lowercolumbiacap~wa~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/lowercolumbiacap-wa-us/lowercolumbiacap-wa-us.zip"
+      }
+    },
+    {
+      "id": "f-lubbock~tx~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "31"
+            }
+          ],
+          "name": "Citibus",
+          "onestop_id": "o-9tzw-citibus",
+          "tags": {
+            "twitter_general": "citibuslubbock",
+            "us_ntd_id": "60010",
+            "wikidata_id": "Q5122457"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/lubbock-tx-us/lubbock-tx-us.zip"
+      }
+    },
+    {
+      "id": "f-lynwood~trolley",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1743"
+            }
+          ],
+          "name": "Lynwood Trolley / Breeze",
+          "onestop_id": "o-9q5by-lynwoodtrolley~breeze",
+          "tags": {
+            "us_ntd_id": "90281"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/lynwood-ca-us/lynwood-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-madera~county~connection",
+      "operators": [
+        {
           "associated_feeds": [
             {
               "feed_onestop_id": "f-madera~county~connection~rt"
@@ -5751,119 +6851,183 @@
             {
               "feed_onestop_id": "f-madera~county~connection~rt~alerts"
             }
-          ]
+          ],
+          "name": "Madera County Connection",
+          "onestop_id": "o-9qd-maderacountyconnection",
+          "tags": {
+            "twitter_general": "maderacounty",
+            "us_ntd_id": "9R02-91005"
+          },
+          "website": "http://www.maderactc.org/public-transit/?referrer=gtfs"
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/maderactc-ca-us/maderactc-ca-us.zip"
+      }
     },
     {
-      "spec": "gtfs-rt",
       "id": "f-madera~county~connection~rt~alerts",
+      "spec": "gtfs-rt",
       "urls": {
         "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/maderactc-ca-us/service_alerts.proto"
       }
     },
     {
+      "id": "f-middletown~ct~us",
       "spec": "gtfs",
-      "id": "f-blossomexpress~ca~us",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/blossomexpress-ca-us/blossomexpress-ca-us.zip"
+        "static_current": "http://data.trilliumtransit.com/gtfs/middletown-ct-us/middletown-ct-us.zip"
       }
     },
     {
+      "id": "f-montebello~bus",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "582"
+            }
+          ],
+          "name": "Montebello Bus Lines",
+          "onestop_id": "o-9qh1-montebellobuslines",
+          "tags": {
+            "twitter_general": "MontebelloBus",
+            "us_ntd_id": "90041",
+            "wikidata_id": "Q6905005"
+          }
+        }
+      ],
       "spec": "gtfs",
-      "id": "f-str~qc~ca",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/str-qc-ca/str-qc-ca.zip"
+        "static_current": "http://data.trilliumtransit.com/gtfs/montebello-ca-us/montebello-ca-us.zip"
       }
     },
     {
-      "spec": "gtfs",
-      "id": "f-valpotransit~chi~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/valpotransit-chi-us/valpotransit-chi-us.zip"
-      },
+      "id": "f-moorpark~city~transit",
       "operators": [
         {
-          "onestop_id": "o-dp6-valparaisotransit",
-          "name": "Valparaiso Transit",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "1486"
+              "gtfs_agency_id": "877"
             }
           ],
+          "name": "Moorpark City Transit",
+          "onestop_id": "o-9q57p-moorparkcitytransit",
           "tags": {
-            "us_ntd_id": "50183",
-            "wikidata_id": "Q60738936",
-            "twitter_general": "ValpoTransit"
+            "us_ntd_id": "90227"
           }
         }
-      ]
-    },
-    {
+      ],
       "spec": "gtfs",
-      "id": "f-cityofdekalb~il~us",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/cityofdekalb-il-us/cityofdekalb-il-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dp2y-dekalbpublictransit",
-          "name": "DeKalb Public Transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1507"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "50176",
-            "twitter_general": "cityofdekalb_il"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-smart~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/smart-ca-us/smart-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qb-sonomamarinarearailtransit",
-          "name": "Sonoma Marin Area Rail Transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1535"
-            },
-            {
-              "feed_onestop_id": "f-smart~ca~rt"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90299",
-            "wikidata_id": "Q7562166",
-            "twitter_general": "smarttrain"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-avon~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/avon-co-us/avon-co-us.zip"
+        "static_current": "http://data.trilliumtransit.com/gtfs/moorparkcitytransit-ca-us/moorparkcitytransit-ca-us.zip"
       }
     },
     {
+      "id": "f-morongo~basin",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "74"
+            }
+          ],
+          "name": "Morongo Basin Transit Authority",
+          "onestop_id": "o-9qj-morongobasintransitauthority",
+          "tags": {
+            "us_ntd_id": "9R02-91090",
+            "wikidata_id": "Q6913253"
+          }
+        }
+      ],
       "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/morongobasin-ca-us/morongobasin-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-mountadams~wa~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/mountadams-wa-us/mountadams-wa-us.zip"
+      }
+    },
+    {
+      "id": "f-mountainvillage~co~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1702"
+            }
+          ],
+          "name": "Town of Mountain Village",
+          "onestop_id": "o-9werc-townofmountainvillage",
+          "tags": {
+            "us_ntd_id": "8R01-80256"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/mountainvillage-co-us/mountainvillage-co-us.zip"
+      }
+    },
+    {
+      "id": "f-needles~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "38"
+            }
+          ],
+          "name": "Needles Area Transit",
+          "onestop_id": "o-9qnqp-needlesareatransit",
+          "tags": {
+            "us_ntd_id": "9R02-91020",
+            "wikidata_id": "Q6986643"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/needles-ca-us/needles-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-petersburg~va~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/petersburg-va-us/petersburg-va-us.zip"
+      }
+    },
+    {
+      "id": "f-playavistashuttle~ca~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/playavistashuttle-ca-us/playavistashuttle-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-ponyexpress~va~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/ponyexpress-va-us/ponyexpress-va-us.zip"
+      }
+    },
+    {
+      "id": "f-prairieexpress~co~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/prairieexpress-co-us/prairieexpress-co-us.zip"
+      }
+    },
+    {
       "id": "f-qline~mi~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/qline-mi-us/qline-mi-us.zip"
-      },
       "operators": [
         {
-          "onestop_id": "o-dpsbv-qlinedetroit",
-          "name": "Qline Detroit",
           "associated_feeds": [
             {
               "gtfs_agency_id": "1494"
@@ -5872,1556 +7036,398 @@
               "feed_onestop_id": "f-qline~mi~rt"
             }
           ],
+          "name": "Qline Detroit",
+          "onestop_id": "o-dpsbv-qlinedetroit",
           "tags": {
+            "twitter_general": "qlinedetroit",
             "us_ntd_id": "50213",
-            "wikidata_id": "Q5265966",
-            "twitter_general": "qlinedetroit"
+            "wikidata_id": "Q5265966"
           }
         }
-      ]
-    },
-    {
+      ],
       "spec": "gtfs",
-      "id": "f-9r0-trinity~ca~us",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/weaverville-ca-us/weaverville-ca-us.zip"
-      },
-      "tags": {
-        "feed_id": "trinity-ca-us",
-        "managed_by": "trillium",
-        "gtfs_data_exchange": "trinity-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9r0-trinitytransit",
-          "tags": {
-            "us_ntd_id": "9R02-91035",
-            "wikidata_id": "Q7842993"
-          },
-          "name": "Trinity Transit",
-          "website": "http://www.trinitytransit.org/?referrer=gtfs",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "34"
-            }
-          ]
-        }
-      ]
+        "static_current": "http://data.trilliumtransit.com/gtfs/qline-mi-us/qline-mi-us.zip"
+      }
     },
     {
-      "spec": "gtfs",
-      "id": "f-needles~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/needles-ca-us/needles-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qnqp-needlesareatransit",
-          "name": "Needles Area Transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "38"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "9R02-91020",
-            "wikidata_id": "Q6986643"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-auburntransit~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/auburntransit-ca-us/auburntransit-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qcvk-auburntransit",
-          "name": "Auburn Transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1593"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "9R02-91032"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-moorpark~city~transit",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/moorparkcitytransit-ca-us/moorparkcitytransit-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q57p-moorparkcitytransit",
-          "name": "Moorpark City Transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "877"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90227"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-breckenridgefreeride~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/breckenridgefreeride-co-us/breckenridgefreeride-co-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9xh8d-breckenridgefreeride",
-          "name": "Breckenridge Free Ride",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1631"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "8R01-80170",
-            "twitter_general": "breckfreeride"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
       "id": "f-roadrunnertransit~co~us",
+      "spec": "gtfs",
       "urls": {
         "static_current": "http://data.trilliumtransit.com/gtfs/roadrunnertransit-co-us/roadrunnertransit-co-us.zip"
       }
     },
     {
-      "spec": "gtfs",
-      "id": "f-tsctransit~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/tsctransit-co-us/tsctransit-co-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-allpointstransit~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/allpointstransit-co-us/allpointstransit-co-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9wg6-allpointstransit",
-          "name": "All Points Transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1599"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "8R01-88215",
-            "twitter_general": "AllPntsTransit"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-cripplecreek~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/cripplecreek-co-us/cripplecreek-co-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9wvh-cripplecreektransportation",
-          "name": "Cripple Creek Transportation",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1600"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "8R01-80275"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-summitstage~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/summitstage-co-us/summitstage-co-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9xh8-summitstage",
-          "name": "Summit Stage",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1602"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "8R01-80161",
-            "twitter_general": "SummitCountyGov"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-bentcounty~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/bentcounty-co-us/bentcounty-co-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9wy-bentcountytransportation",
-          "name": "Bent County Transportation",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1645"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "8R01-88229"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-estestransit~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/estestransit-co-us/estestransit-co-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-guadalupeflyer~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/guadalupeflyer-ca-us/guadalupeflyer-ca-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-vatransit~va~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/vatransit-va-us/vatransit-va-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dqb-virginiaregionaltransit",
-          "name": "Virginia Regional Transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1587"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "3R06-30118,3R06-30120,3R06-30125"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-southcountytransitlink~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/southcountytransitlink-ca-us/southcountytransitlink-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qc-southcountytransitlink",
-          "name": "South County Transit Link",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1661"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "9R02-90216",
-            "wikidata_id": "Q96406074"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-camarillo~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/camarillo-ca-us/camarillo-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q56e-camarilloareatransit",
-          "name": "Camarillo Area Transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1656"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90163"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-bellgardens~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/bellgardens-ca-us/bellgardens-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q5cp-bellgardenstrolley",
-          "name": "Bell Gardens Trolley",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1667"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90253",
-            "twitter_general": "bellgardenscity"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
       "id": "f-rosemead~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/rosemead-ca-us/rosemead-ca-us.zip"
-      },
       "operators": [
         {
-          "onestop_id": "o-9qh1b-rosemeadexplorer",
-          "name": "Rosemead Explorer",
           "associated_feeds": [
             {
               "gtfs_agency_id": "1672"
             }
           ],
+          "name": "Rosemead Explorer",
+          "onestop_id": "o-9qh1b-rosemeadexplorer",
           "tags": {
             "us_ntd_id": "90289"
           }
         }
-      ]
-    },
-    {
+      ],
       "spec": "gtfs",
-      "id": "f-compton~ca~us",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/compton-ca-us/compton-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q5bv-comptonrenaissancetransit",
-          "name": "Compton Renaissance Transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1666"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90260"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-arvin~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/arvin-ca-us/arvin-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q7-arvintransit",
-          "name": "Arvin Transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1659"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "9R02-91027",
-            "wikidata_id": "Q4802468"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-alhambra~ca~us",
-      "supersedes_ids": ["f-alhambra~community"],
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/alhambra-ca-us/alhambra-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q5cz-alhambracommunitytransit",
-          "name": "Alhambra Community Transit",
-          "short_name": "ACT",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1669"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90247"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-blackhawktramway~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/blackhawktramway-co-us/blackhawktramway-co-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9xhfr-blackhawkandcentralcitytramway",
-          "name": "Blackhawk and Central City Tramway",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1646"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "8R01-80119"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-westcovina~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/westcovina-ca-us/westcovina-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qh1s-gowestshuttle",
-          "name": "Go West Shuttle",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1671"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90293"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-cityofridgecrest~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/cityofridgecrest-ca-us/cityofridgecrest-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qk6-ridgerunner",
-          "name": "Ridgerunner",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1665"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "9R02-91006"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-bellflower~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/bellflower-ca-us/bellflower-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q5bz-bellflowerbus",
-          "name": "Bellflower Bus",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1673"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90254"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-prairieexpress~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/prairieexpress-co-us/prairieexpress-co-us.zip"
+        "static_current": "http://data.trilliumtransit.com/gtfs/rosemead-ca-us/rosemead-ca-us.zip"
       }
     },
     {
-      "spec": "gtfs",
-      "id": "f-lacampana~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/lacampana-ca-us/lacampana-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q5cq-lacampana",
-          "name": "La Campana",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1660"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90252"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dsi~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/dsi-co-us/dsi-co-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-sanmiguel~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/sanmiguel-co-us/sanmiguel-co-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-lubbock~tx~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/lubbock-tx-us/lubbock-tx-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9tzw-citibus",
-          "name": "Citibus",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "31"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "60010",
-            "wikidata_id": "Q5122457",
-            "twitter_general": "citibuslubbock"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-calabasas~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/calabasas-ca-us/calabasas-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q5d5-calabasastransitsystem",
-          "name": "Calabasas Transit System",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1674"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90257"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-clearcreek~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/clearcreek-co-us/clearcreek-co-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-carson~ca~us",
-      "supersedes_ids": ["f-carson~circuit"],
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/carson-ca-us/carson-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q5b-carsoncircuit",
-          "name": "Carson Circuit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1684"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90258",
-            "wikidata_id": "Q5046916"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-downey~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/downey-ca-us/downey-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q5cp-downeylink",
-          "name": "DowneyLINK",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1682"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90263"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-cudahy~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/cudahy-ca-us/cudahy-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q5cnw-cudahyarearapidtransit",
-          "name": "Cudahy Area Rapid Transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1685"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90262",
-            "twitter_general": "CityOfCudahyCA"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-glendora~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/glendora-ca-us/glendora-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qh4j-glendoratransportationdivision",
-          "name": "Glendora Transportation Division",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1664"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90266",
-            "twitter_general": "CityofGlendora"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-huntingtonpark~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/huntingtonpark-ca-us/huntingtonpark-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q5cm-huntingtonparkexpress",
-          "name": "Huntington Park Express",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1668"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90267"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-montebello~bus",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/montebello-ca-us/montebello-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qh1-montebellobuslines",
-          "name": "Montebello Bus Lines",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "582"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90041",
-            "wikidata_id": "Q6905005",
-            "twitter_general": "MontebelloBus"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-baldwinpark~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/baldwinpark-ca-us/baldwinpark-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qh1g-baldwinparktransit",
-          "name": "Baldwin Park Transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1683"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90251",
-            "twitter_general": "BaldwinParkCA"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-arcadia~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/arcadia-ca-us/arcadia-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qh44-arcadiatransit",
-          "name": "Arcadia Transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1670"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90044"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-beartransit~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/beartransit-ca-us/beartransit-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q9p3-beartransit~ucberkeleyshuttle",
-          "tags": {
-            "us_ntd_id": "9R02-91012",
-            "wikidata_id": "Q6924864"
-          },
-          "name": "University of California Berkeley Shuttle",
-          "short_name": "Bear Transit",
-          "website": "http://pt.berkeley.edu/around/transit/routes/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "18"
-            }
-          ]
-        },
-        {
-          "onestop_id": "o-9q9p3-beartransit",
-          "name": "Bear Transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1708"
-            }
-          ],
-          "tags": {
-            "wikidata_id": "Q4876580",
-            "twitter_general": "CalParking"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
       "id": "f-sanjuancapistrano~ca~us",
+      "spec": "gtfs",
       "urls": {
         "static_current": "http://data.trilliumtransit.com/gtfs/sanjuancapistrano-ca-us/sanjuancapistrano-ca-us.zip"
       }
     },
     {
-      "spec": "gtfs",
-      "id": "f-cityoffountaintransit~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/cityoffountaintransit-co-us/cityoffountaintransit-co-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-mountainvillage~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/mountainvillage-co-us/mountainvillage-co-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9werc-townofmountainvillage",
-          "name": "Town of Mountain Village",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1702"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "8R01-80256"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-telluride~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/telluride-co-us/telluride-co-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9werfd-townoftelluride",
-          "name": "Town of Telluride",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1701"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "8R01-88226"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-taft~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/taft-ca-us/taft-ca-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-getaroundtownexpress~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/getaroundtownexpress-ca-us/getaroundtownexpress-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q5cn-getaroundtownexpress",
-          "name": "Get Around Town Express",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1721"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90291"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-glenn~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/glenn-ca-us/glenn-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9r11-glenntransitservice",
-          "name": "Glenn Transit Service",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1707"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "9R02-91088"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-sierramadre~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/sierramadre-ca-us/sierramadre-ca-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-playavistashuttle~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/playavistashuttle-ca-us/playavistashuttle-ca-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dp4j-citybus",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/citybus-lafayette-in-us/citybus-lafayette-in-us.zip"
-      },
-      "license": {
-        "url": "https://gocitybus.com/gtfs-gis-data-download"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dp4j-citybus",
-          "tags": {
-            "us_ntd_id": "50051",
-            "wikidata_id": "Q5600598",
-            "twitter_general": "gocitybus"
-          },
-          "name": "CityBus of Greater Lafayette Indiana",
-          "short_name": "CityBus",
-          "website": "http://www.gocitybus.com/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "816"
-            },
-            {
-              "gtfs_agency_id": "9eca155d-a6ad-42b1-8ad5-4888c7c42aaa"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9q7m-portervilletransit",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/porterville-ca-us/porterville-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q7m5-portervilletransit",
-          "name": "Porterville Transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "Porterville"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90198",
-            "twitter_general": "ridept"
-          }
-        },
-        {
-          "onestop_id": "o-9q7m-portervilletransit",
-          "tags": {
-            "us_ntd_id": "90198"
-          },
-          "name": "Porterville Transit"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-wausau~wi~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/wausau-wi-us/wausau-wi-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dpbrb-metroride",
-          "name": "Metro Ride",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1735"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "50091",
-            "wikidata_id": "Q6824689"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-homejames~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/homejames-co-us/homejames-co-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-get~va~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/get-va-us/get-va-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dnx-radartransit",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/radar-va-us/radar-va-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dnx-radar",
-          "name": "RADAR",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1763"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "3R06-30178"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-lynwood~trolley",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/lynwood-ca-us/lynwood-ca-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q5by-lynwoodtrolley~breeze",
-          "name": "Lynwood Trolley / Breeze",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1743"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "90281"
-          }
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-altavista~va~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/altavista-va-us/altavista-va-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-ponyexpress~va~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/ponyexpress-va-us/ponyexpress-va-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-9xhv-nps~romo~shuttles",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/rockymountainnationalpark-co-us/rockymountainnationalpark-co-us.zip"
-      },
-      "license": {
-        "url": "https://creativecommons.org/publicdomain/zero/1.0/"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9xhv-rockymountainnationalpark",
-          "name": "Rocky Mountain National Park",
-          "website": "http://www.nps.gov/romo",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "NPS_ROMO"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-bouldercounty~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/bouldercounty-co-us/bouldercounty-co-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-startransit~va~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/startransit-va-us/startransit-va-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-tahoe~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/tahoe-ca-us/tahoe-ca-us.zip"
-      },
-      "operators": [{
-        "onestop_id": "o-9qft-tahoetransportationdistrict",
-        "name": "Tahoe Transportation District",
-        "short_name": "TTD",
-        "website": "https://www.tahoetransportation.org/",
-        "tags": {
-          "us_ntd_id": "91092"
-        },
-        "associated_feeds": [
-          {
-            "feed_onestop_id": "f-tahoe~ca~rt"
-          }
-        ]
-      }]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-gardenofthegods~co~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/gardenofthegods-co-us/gardenofthegods-co-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-wintran~va~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/wintran-va-us/wintran-va-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-westberkeleyshuttle~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/westberkeleyshuttle-ca-us/westberkeleyshuttle-ca-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-lapuente~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/lapuente-ca-us/lapuente-ca-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-elsegundo~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/elsegundo-ca-us/elsegundo-ca-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-catalinaflyer~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/catalinaflyer-ca-us/catalinaflyer-ca-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-farmville~va~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/farmville-va-us/farmville-va-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
       "id": "f-sanleandro~ca~us",
+      "spec": "gtfs",
       "urls": {
         "static_current": "http://data.trilliumtransit.com/gtfs/sanleandro-ca-us/sanleandro-ca-us.zip"
       }
     },
     {
+      "id": "f-sanmiguel~co~us",
       "spec": "gtfs",
-      "id": "f-grahamtransit~va~us",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/grahamtransit-va-us/grahamtransit-va-us.zip"
+        "static_current": "http://data.trilliumtransit.com/gtfs/sanmiguel-co-us/sanmiguel-co-us.zip"
       }
     },
     {
+      "id": "f-sierramadre~ca~us",
       "spec": "gtfs",
-      "id": "f-lasvegasloop~nv~us",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/lasvegasloop-nv-us/lasvegasloop-nv-us.zip"
+        "static_current": "http://data.trilliumtransit.com/gtfs/sierramadre-ca-us/sierramadre-ca-us.zip"
       }
     },
     {
-      "spec": "gtfs",
-      "id": "f-harborconnector~md~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/harborconnector-md-us/harborconnector-md-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-bristol~va~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/bristol-va-us/bristol-va-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-bay~transit~va",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/baytransit-va-us/baytransit-va-us.zip"
-      },
+      "id": "f-smart~ca~us",
       "operators": [
         {
-          "onestop_id": "o-dq9-baytransit",
-          "name": "Bay Transit",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "bay"
+              "gtfs_agency_id": "1535"
+            },
+            {
+              "feed_onestop_id": "f-smart~ca~rt"
             }
           ],
+          "name": "Sonoma Marin Area Rail Transit",
+          "onestop_id": "o-9qb-sonomamarinarearailtransit",
           "tags": {
-            "us_ntd_id": "3R06-30172"
+            "twitter_general": "smarttrain",
+            "us_ntd_id": "90299",
+            "wikidata_id": "Q7562166"
           }
         }
-      ]
-    },
-    {
+      ],
       "spec": "gtfs",
-      "id": "f-petersburg~va~us",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/petersburg-va-us/petersburg-va-us.zip"
+        "static_current": "http://data.trilliumtransit.com/gtfs/smart-ca-us/smart-ca-us.zip"
       }
     },
     {
-      "spec": "gtfs",
-      "id": "f-blackstone~va~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/blackstone-va-us/blackstone-va-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-lmht~morton~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/lmht-morton-us/lmht-morton-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-lowercolumbiacap~wa~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/lowercolumbiacap-wa-us/lowercolumbiacap-wa-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-mountadams~wa~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/mountadams-wa-us/mountadams-wa-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-districtthree~va~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/districtthree-va-us/districtthree-va-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-benson~az~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/benson-az-us/benson-az-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-c215-gorgewet~wa~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/skamaniacounty-wa-us/skamaniacounty-wa-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-c215-skamaniacountypublictransitgorgewetbus",
-          "name": "Skamania County Transit",
-          "website": "https://www.skamaniacounty.org/departments-offices/senior-services/services/public-transportation",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1814"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-thurston~wa~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/thurston-wa-us/thurston-wa-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-acrta~oh~us",
-      "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/acrta-oh-us/acrta-oh-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-cityofhelena~mt~us",
-      "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/cityofhelena-mt-us/cityofhelena-mt-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-chicagowatertaxi~il~us",
-      "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/chicagowatertaxi-il-us/chicagowatertaxi-il-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-gulfcoastcenter~tx~us",
-      "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/gulfcoastcenter-tx-us/gulfcoastcenter-tx-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-delano~ca~us",
-      "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/delano-ca-us/delano-ca-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-gowal~fl~us",
-      "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/gowal-fl-us/gowal-fl-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-greenride~co~us",
-      "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/greenride-co-us/greenride-co-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-middletown~ct~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/middletown-ct-us/middletown-ct-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-turlock~ca~us",
-      "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/turlock-ca-us/turlock-ca-us.zip"
-      },
-      "operators": [{
-        "onestop_id": "o-9qdj3-turlocktransit",
-        "name": "Turlock Transit",
-        "tags": {
-          "us_ntd_id": "90201"
-        },
-        "associated_feeds": [
-          {
-            "feed_onestop_id": "f-turlock~ca~rt"
-          },
-          {
-            "feed_onestop_id": "f-turlock~ca~us~rt~alerts"
-          }
-        ]
-      }]
-    },
-    {
-      "spec": "gtfs-rt",
-      "id": "f-turlock~ca~us~rt~alerts",
-      "urls": {
-        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/turlock-ca-us/service_alerts.proto"
-      },
-      "license": {
-        "url": "https://www.turlocktransit.com/developers.html"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-tulare~tcat",
-      "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/tcat-flex-ca-us/tcat-ca-us.zip"
-      }
-    },
-    {
-      "spec": "gtfs-rt",
-      "id": "f-c20-tillamook~or~us~rt~alerts",
-      "urls": {
-        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/tillamook-or-us/service_alerts.proto"
-      }
-    },
-    {
-      "spec": "gtfs-rt",
-      "id": "f-9rc-cascadeseast~or~us~rt~alerts",
-      "urls": {
-        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/cascadeseast-or-us/service_alerts.proto"
-      }
-    },
-    {
-      "spec": "gtfs-rt",
-      "id": "f-9pz-lincolncounty~or~us~rt~alerts",
-      "urls": {
-        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/lincolncounty-or-us/service_alerts.proto"
-      }
-    },
-    {
-      "spec": "gtfs-rt",
-      "id": "f-c20dz-washingtonparkshuttle~or~us~alerts",
-      "urls": {
-        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/washingtonparkshuttle-or-us/service_alerts.proto"
-      }
-    },
-    {
-      "spec": "gtfs-rt",
-      "id": "f-9rb-benton~or~us~alerts",
-      "urls": {
-        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/benton-or-us/service_alerts.proto"
-      }
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-dqc-thebusofprincegeorgescounty",
-      "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/princegeorgescounty-md-us/princegeorgescounty-md-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dqc-thebusofprincegeorgescounty",
-          "tags": {
-            "us_ntd_id": "30035",
-            "wikidata_id": "Q7711628",
-            "twitter_general": "PGCountyDPWT"
-          },
-          "name": "Prince George's County",
-          "short_name": "The Bus",
-          "website": "https://www.princegeorgescountymd.gov/1120/Countys-TheBus",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "2166"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-c24-peopleforpeople",
-      "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/pfp-wa-us/pfp-wa-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-c24-peopleforpeople",
-          "tags": {
-            "us_ntd_id": "0R03-00287"
-          },
-          "name": "People for People",
-          "short_name": "Community Connector",
-          "website": "http://www.pfp.org/pfp/Transportation/CommunityConnector.aspx",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "pfp"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
       "id": "f-snoqualmie~wa~us",
+      "spec": "gtfs",
       "urls": {
         "static_current": "https://data.trilliumtransit.com/gtfs/snoqualmie-wa-us/snoqualmie-wa-us.zip"
       }
     },
     {
-      "spec": "gtfs",
-      "id": "f-c28-islandtransit",
-      "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/islandtransit-wa-us/islandtransit-wa-us.zip"
-      },
+      "id": "f-southcountytransitlink~ca~us",
       "operators": [
         {
-          "onestop_id": "o-c28-islandtransit",
-          "tags": {
-            "us_ntd_id": "0R03-00298",
-            "wikidata_id": "Q16980701"
-          },
-          "name": "Island Transit",
-          "website": "http://www.islandtransit.org/"
-        }
-      ]
-    },
-    {
-      "spec": "gtfs",
-      "id": "f-drt3-909983",
-      "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/massport-ma-us/massport-ma-us.zip",
-        "static_historic": [
-          "https://www.massport.com/media/ptydscvm/massport_gtfs-1013-4.zip"
-        ]
-      },
-      "license": {
-        "url": "http://www.massport.com/media/1651/massportdatalicenseagreement.pdf"
-      },
-      "tags": {
-        "feed_id": "1710"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-drt3pb-massport",
-          "name": "Massport",
-          "website": "http://www.massport.com/logan-airport/to-from-logan/transportation-options/on-airport-shuttle/",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "2272"
+              "gtfs_agency_id": "1661"
             }
           ],
+          "name": "South County Transit Link",
+          "onestop_id": "o-9qc-southcountytransitlink",
           "tags": {
-            "wikidata_id": "Q2777980",
-            "twitter_general": "Massport"
+            "us_ntd_id": "9R02-90216",
+            "wikidata_id": "Q96406074"
           }
-        },
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/southcountytransitlink-ca-us/southcountytransitlink-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-startransit~va~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/startransit-va-us/startransit-va-us.zip"
+      }
+    },
+    {
+      "id": "f-str~qc~ca",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/str-qc-ca/str-qc-ca.zip"
+      }
+    },
+    {
+      "id": "f-summitstage~co~us",
+      "operators": [
         {
-          "onestop_id": "o-drt3-loganexpress",
-          "name": "Logan Express",
-          "website": "http://www.massport.com/logan-airport/to-from-logan/transportation-options/logan-express/",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "2274"
+              "gtfs_agency_id": "1602"
             }
-          ]
+          ],
+          "name": "Summit Stage",
+          "onestop_id": "o-9xh8-summitstage",
+          "tags": {
+            "twitter_general": "SummitCountyGov",
+            "us_ntd_id": "8R01-80161"
+          }
         }
-      ]
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/summitstage-co-us/summitstage-co-us.zip"
+      }
+    },
+    {
+      "id": "f-taft~ca~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/taft-ca-us/taft-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-tahoe~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "feed_onestop_id": "f-tahoe~ca~rt"
+            }
+          ],
+          "name": "Tahoe Transportation District",
+          "onestop_id": "o-9qft-tahoetransportationdistrict",
+          "short_name": "TTD",
+          "tags": {
+            "us_ntd_id": "91092"
+          },
+          "website": "https://www.tahoetransportation.org/"
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/tahoe-ca-us/tahoe-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-telluride~co~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1701"
+            }
+          ],
+          "name": "Town of Telluride",
+          "onestop_id": "o-9werfd-townoftelluride",
+          "tags": {
+            "us_ntd_id": "8R01-88226"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/telluride-co-us/telluride-co-us.zip"
+      }
+    },
+    {
+      "id": "f-thurston~wa~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/thurston-wa-us/thurston-wa-us.zip"
+      }
+    },
+    {
+      "id": "f-trivalley~vt~us",
+      "license": {
+        "url": "http://vermont-gtfs.org/"
+      },
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "986"
+            }
+          ],
+          "name": "Tri-Valley Transit",
+          "onestop_id": "o-dru-tri~valleytransit",
+          "tags": {
+            "twitter_general": "actransitvt",
+            "us_ntd_id": "1R06-10143"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/trivalleytransit-vt-us/trivalleytransit-vt-us.zip"
+      }
+    },
+    {
+      "id": "f-tsctransit~co~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/tsctransit-co-us/tsctransit-co-us.zip"
+      }
+    },
+    {
+      "id": "f-tulare~tcat",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/tcat-flex-ca-us/tcat-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-turlock~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "feed_onestop_id": "f-turlock~ca~rt"
+            },
+            {
+              "feed_onestop_id": "f-turlock~ca~us~rt~alerts"
+            }
+          ],
+          "name": "Turlock Transit",
+          "onestop_id": "o-9qdj3-turlocktransit",
+          "tags": {
+            "us_ntd_id": "90201"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/turlock-ca-us/turlock-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-turlock~ca~us~rt~alerts",
+      "license": {
+        "url": "https://www.turlocktransit.com/developers.html"
+      },
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_alerts": "http://gtfs-realtime.trilliumtransit.com/gtfs-realtime/feed/turlock-ca-us/service_alerts.proto"
+      }
+    },
+    {
+      "id": "f-valpotransit~chi~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1486"
+            }
+          ],
+          "name": "Valparaiso Transit",
+          "onestop_id": "o-dp6-valparaisotransit",
+          "tags": {
+            "twitter_general": "ValpoTransit",
+            "us_ntd_id": "50183",
+            "wikidata_id": "Q60738936"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/valpotransit-chi-us/valpotransit-chi-us.zip"
+      }
+    },
+    {
+      "id": "f-vatransit~va~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1587"
+            }
+          ],
+          "name": "Virginia Regional Transit",
+          "onestop_id": "o-dqb-virginiaregionaltransit",
+          "tags": {
+            "us_ntd_id": "3R06-30118,3R06-30120,3R06-30125"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/vatransit-va-us/vatransit-va-us.zip"
+      }
+    },
+    {
+      "id": "f-wausau~wi~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1735"
+            }
+          ],
+          "name": "Metro Ride",
+          "onestop_id": "o-dpbrb-metroride",
+          "tags": {
+            "us_ntd_id": "50091",
+            "wikidata_id": "Q6824689"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/wausau-wi-us/wausau-wi-us.zip"
+      }
+    },
+    {
+      "id": "f-westberkeleyshuttle~ca~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/westberkeleyshuttle-ca-us/westberkeleyshuttle-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-westcovina~ca~us",
+      "operators": [
+        {
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1671"
+            }
+          ],
+          "name": "Go West Shuttle",
+          "onestop_id": "o-9qh1s-gowestshuttle",
+          "tags": {
+            "us_ntd_id": "90293"
+          }
+        }
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/westcovina-ca-us/westcovina-ca-us.zip"
+      }
+    },
+    {
+      "id": "f-wintran~va~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://data.trilliumtransit.com/gtfs/wintran-va-us/wintran-va-us.zip"
+      }
     }
   ],
   "license_spdx_identifier": "CDLA-Permissive-1.0"


### PR DESCRIPTION
uses https://github.com/interline-io/transitland-lib/pull/181

to make it easier to detect the differences in #465 