### PR TITLE
fix `static_historical` URLs in oregon-gtfs DMFR

### DIFF
--- a/feeds/oregon-gtfs.com.dmfr.json
+++ b/feeds/oregon-gtfs.com.dmfr.json
@@ -136,7 +136,7 @@
       "spec": "gtfs",
       "id": "f-c20f-bluestar~or~us",
       "urls": {
-        "static_historical": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/bluestar-or-us/bluestar-or-us.zip"
+        "static_historical": ["https://oregon-gtfs.trilliumtransit.com/gtfs_data/bluestar-or-us/bluestar-or-us.zip"]
       },
       "license": {
         "url": "https://oregon-gtfs.trilliumtransit.com",
@@ -378,7 +378,7 @@
       "spec": "gtfs",
       "id": "f-9rb-citytocityshuttle~or~us",
       "urls": {
-        "static_historical": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/citytocityshuttle-or-us/citytocityshuttle-or-us.zip"
+        "static_historical": ["https://oregon-gtfs.trilliumtransit.com/gtfs_data/citytocityshuttle-or-us/citytocityshuttle-or-us.zip"]
       },
       "license": {
         "url": "https://oregon-gtfs.trilliumtransit.com",
@@ -429,7 +429,7 @@
       "spec": "gtfs",
       "id": "f-9rbm-corvallis~or~us",
       "urls": {
-        "static_historical": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/corvallis-or-us/corvallis-or-us.zip"
+        "static_historical": ["https://oregon-gtfs.trilliumtransit.com/gtfs_data/corvallis-or-us/corvallis-or-us.zip"]
       },
       "license": {
         "url": "https://oregon-gtfs.trilliumtransit.com",
@@ -637,7 +637,7 @@
       "spec": "gtfs",
       "id": "f-9rc-eugenetobend~or~us",
       "urls": {
-        "static_historical": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/eugenetobend-or-us/eugenetobend-or-us.zip"
+        "static_historical": ["https://oregon-gtfs.trilliumtransit.com/gtfs_data/eugenetobend-or-us/eugenetobend-or-us.zip"]
       },
       "license": {
         "url": "https://oregon-gtfs.trilliumtransit.com",
@@ -999,7 +999,7 @@
       "spec": "gtfs",
       "id": "f-philomathconnection~or~us",
       "urls": {
-        "static_historical": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/philomathconnection-or-us/philomathconnection-or-us.zip"
+        "static_historical": ["https://oregon-gtfs.trilliumtransit.com/gtfs_data/philomathconnection-or-us/philomathconnection-or-us.zip"]
       },
       "license": {
         "url": "https://oregon-gtfs.trilliumtransit.com",
@@ -1214,7 +1214,7 @@
       "spec": "gtfs",
       "id": "f-c20c-sctd~or~us",
       "urls": {
-        "static_historical": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/sctd-or-us/sctd-or-us.zip"
+        "static_historical": ["https://oregon-gtfs.trilliumtransit.com/gtfs_data/sctd-or-us/sctd-or-us.zip"]
       },
       "license": {
         "url": "https://oregon-gtfs.trilliumtransit.com",
@@ -1247,7 +1247,7 @@
       "spec": "gtfs",
       "id": "f-9rb3p-southlanewheels~or~us",
       "urls": {
-        "static_historical": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/southlanewheels-or-us/southlanewheels-or-us.zip"
+        "static_historical": ["https://oregon-gtfs.trilliumtransit.com/gtfs_data/southlanewheels-or-us/southlanewheels-or-us.zip"]
       },
       "license": {
         "url": "https://oregon-gtfs.trilliumtransit.com",
@@ -1276,7 +1276,7 @@
       "spec": "gtfs",
       "id": "f-c0p-sunsetempiretransportationdistrict",
       "urls": {
-        "static_historical": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/clatsopcounty-or-us/clatsopcounty-or-us.zip"
+        "static_historical": ["https://oregon-gtfs.trilliumtransit.com/gtfs_data/clatsopcounty-or-us/clatsopcounty-or-us.zip"]
       },
       "license": {
         "url": "https://oregon-gtfs.trilliumtransit.com",
@@ -1444,7 +1444,7 @@
       "spec": "gtfs",
       "id": "f-c20fb-ceic~or~us",
       "urls": {
-        "static_historical": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/ceic-or-us/ceic-or-us.zip"
+        "static_historical": ["https://oregon-gtfs.trilliumtransit.com/gtfs_data/ceic-or-us/ceic-or-us.zip"]
       },
       "license": {
         "url": "https://oregon-gtfs.trilliumtransit.com",
@@ -1556,7 +1556,7 @@
       "spec": "gtfs",
       "id": "f-c20-yamhillcounty~or~us",
       "urls": {
-        "static_historical": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/yamhill-or-us/yamhill-or-us.zip"
+        "static_historical": ["https://oregon-gtfs.trilliumtransit.com/gtfs_data/yamhill-or-us/yamhill-or-us.zip"]
       },
       "license": {
         "url": "https://oregon-gtfs.trilliumtransit.com",


### PR DESCRIPTION
I wonder why this wasn't caught in the validation of #441