### PR TITLE
Create vamusalgarve.pt.dmfr.json

### DIFF
--- a/feeds/vamusalgarve.pt.dmfr.json
+++ b/feeds/vamusalgarve.pt.dmfr.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.4.0.json",
+  "feeds": [
+    {
+      "id": "f-ey-vamusalgarve",
+	  "spec": "gtfs",
+      "urls": {
+        "static_current": "https://drive.google.com/uc?export=download&id=1CM8O4ndsfSJhka42SxFUZ9eB-wE10NqX"
+      },
+      "license": {
+        "url": "https://creativecommons.org/licenses/by-nd/4.0/",
+        "use_without_attribution": "yes",
+        "create_derived_product": "no"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-ey-vamusalgarve",
+          "name": "Vamus Transportes do Algarve",
+          "short_name": "Vamus",
+          "website": "https://www.vamusalgarve.pt/",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "vizur"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "license_spdx_identifier": "CDLA-Permissive-1.0"
+}


### PR DESCRIPTION
This is the official GTFS static of Vamus Algarve regional transit agency.
It is the same source used by Google Maps.
Thank you!