### PR TITLE
Update googletf.gohrt.com.dmfr.json

### DIFF
--- a/feeds/gohrt.com.dmfr.json
+++ b/feeds/gohrt.com.dmfr.json
@@ -6,7 +6,9 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://gtfs.gohrt.com/gtfs/google_transit.zip",
-        "static_historic": "http://googletf.gohrt.com/google_transit.zip"
+        "static_historic": [
+          "http://googletf.gohrt.com/google_transit.zip"
+        ]
       },
       "tags": {
         "gtfs_data_exchange": "hampton-roads-transit-hrt"

--- a/feeds/googletf.gohrt.com.dmfr.json
+++ b/feeds/googletf.gohrt.com.dmfr.json
@@ -5,7 +5,8 @@
       "id": "f-dq9-hrt",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://googletf.gohrt.com/google_transit.zip"
+        "static_current": "https://gtfs.gohrt.com/gtfs/google_transit.zip",
+        "static_historic": "http://googletf.gohrt.com/google_transit.zip"
       },
       "tags": {
         "gtfs_data_exchange": "hampton-roads-transit-hrt"


### PR DESCRIPTION
Updates static_current URL and moves previous static_current to static_historic

Current feed on transit.land has effective date through 2021-05-15. An updated feed URL found on https://virginia-gtfs.com/ (as I understand, part of a Virginia DRPT effort to centralize feed links for Virginia) has the agency's current feed, which goes through September 2022.

Not sure if the name of the json file needs to change given the source URL change. Edit instructions didn't seem to speak to that so I left as is.