### PR TITLE
GOVCbus feed

### DIFF
--- a/feeds/goldcoasttransit.org.dmfr.json
+++ b/feeds/goldcoasttransit.org.dmfr.json
@@ -8,18 +8,13 @@
         "static_current": "http://www.goldcoasttransit.org/images/GTFS/GTFS.zip"
       },
       "license": {
-        "url": "http://www.goldcoasttransit.org/2-uncategorised/250-gtfs-data-download"
+        "url": "https://www.gctd.org/about/developer-resources/"
       },
       "operators": [
         {
           "onestop_id": "o-9q54-goldcoasttransit",
           "name": "Gold Coast Transit",
           "short_name": "GCT",
-          "associated_feeds": [
-            {
-              "feed_onestop_id": "f-goldcoasttransit~rt"
-            }
-          ],
           "tags": {
             "twitter_general": "goldcoastbus",
             "us_ntd_id": "90035",
@@ -27,15 +22,6 @@
           }
         }
       ]
-    },
-    {
-      "id": "f-goldcoasttransit~rt",
-      "spec": "gtfs-rt",
-      "urls": {
-        "realtime_vehicle_positions": "https://govcbus.com/gtfs-rt/vehiclepositions",
-        "realtime_trip_updates": "https://govcbus.com/gtfs-rt/tripupdates",
-        "realtime_alerts": "https://govcbus.com/gtfs-rt/alerts"
-      }
     }
   ],
   "license_spdx_identifier": "CDLA-Permissive-1.0"

--- a/feeds/govcbus.com.dmfr.json
+++ b/feeds/govcbus.com.dmfr.json
@@ -2,6 +2,31 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.4.0.json",
   "feeds": [
     {
+      "id": "f-9q5-govcbus",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://govcbus.com/gtfs"
+      },
+      "license": {
+        "url": "https://gtfs-directory.syncromatics.com/"
+      },
+      "tags": {
+        "exclude_from_global_query": "true"
+      }
+    },
+    {
+      "id": "f-9q5-govcbus~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://govcbus.com/gtfs-rt/vehiclepositions",
+        "realtime_trip_updates": "https://govcbus.com/gtfs-rt/tripupdates",
+        "realtime_alerts": "https://govcbus.com/gtfs-rt/alerts"
+      },
+      "license": {
+        "url": "https://gtfs-directory.syncromatics.com/"
+      }
+    },
+    {
       "id": "f-9q5-vctc~ca~us",
       "spec": "gtfs",
       "urls": {
@@ -18,7 +43,10 @@
               "gtfs_agency_id": "607"
             },
             {
-              "feed_onestop_id": "f-9q5-vctc~ca~us~rt"
+              "feed_onestop_id": "f-9q5-govcbus"
+            },
+            {
+              "feed_onestop_id": "f-9q5-govcbus~rt"
             }
           ],
           "tags": {
@@ -28,18 +56,6 @@
           }
         }
       ]
-    },
-    {
-      "id": "f-9q5-vctc~ca~us~rt",
-      "spec": "gtfs-rt",
-      "urls": {
-        "realtime_vehicle_positions": "https://govcbus.com/gtfs-rt/vehiclepositions",
-        "realtime_trip_updates": "https://govcbus.com/gtfs-rt/tripupdates",
-        "realtime_alerts": "https://govcbus.com/gtfs-rt/alerts"
-      },
-      "license": {
-        "url": "https://gtfs-directory.syncromatics.com/"
-      }
     }
   ],
   "license_spdx_identifier": "CDLA-Permissive-1.0"


### PR DESCRIPTION
- add static feed for use together with RT feed
- exclude from global query so static records don't conflict with the other agency-specific feeds (mainly from Trillium)

closes #469