### PR TITLE
Update Tisséo to the new v2 dataset

### DIFF
--- a/feeds/data.toulouse-metropole.fr.dmfr.json
+++ b/feeds/data.toulouse-metropole.fr.dmfr.json
@@ -5,7 +5,10 @@
       "id": "f-spc0-tisséo",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://data.toulouse-metropole.fr/explore/dataset/tisseo-gtfs/files/bd1298f158bc39ed9065e0c17ebb773b/download/"
+        "static_current": "https://data.toulouse-metropole.fr/explore/dataset/tisseo-gtfs/files/fc1dda89077cf37e4f7521760e0ef4e9/download/",
+        "static_historic": [
+          "https://data.toulouse-metropole.fr/explore/dataset/tisseo-gtfs/files/bd1298f158bc39ed9065e0c17ebb773b/download/"
+        ]
       },
       "license": {
         "url": "http://opendatacommons.org/licenses/odbl/summary/"
@@ -16,6 +19,9 @@
           "name": "Tisséo",
           "website": "http://www.tisseo.fr",
           "associated_feeds": [
+            {
+              "gtfs_agency_id": "network:1"
+            },
             {
               "gtfs_agency_id": "6192449487677451"
             }


### PR DESCRIPTION
Hello,

Tisséo released a new v2 set and deprecated the v1 set.
I updated the URL with the new dataset.

Have a good day !