### PR TITLE
Updated LPP to use the new GTFS URL

### DIFF
--- a/feeds/data.lpp.si.dmfr.json
+++ b/feeds/data.lpp.si.dmfr.json
@@ -5,7 +5,7 @@
       "id": "f-u24q-ljubljanskipotniškipromet",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://data.lpp.si/routes/getGTFS"
+        "static_current": "https://data.lpp.si/api/gtfs/feed.zip"
       },
       "operators": [
         {


### PR DESCRIPTION
Looks like the feed URL for *Ljubljanski Potniški Promet* (Ljubljana, Slovenia) has been down for a few years now. 

I've updated it to the correct URL.