### PR TITLE
Create rejseplanen.dk.dmfr.json

### DIFF
--- a/feeds/rejseplanen.dk.dmfr.json
+++ b/feeds/rejseplanen.dk.dmfr.json
@@ -7,18 +7,6 @@
       "urls": {
         "static_current": "https://www.rejseplanen.info/labs/GTFS.zip"
       },
-      "operators": [
-        {
-          "onestop_id": "f-rejseplanen~dk~gtfs",
-          "name": "Rejseplanen",
-          "website": "rejseplanen.dk",
-          "associated_feeds": [
-            {
-              "feed_onestop_id": "f-rejseplanen~dk~gtfs"
-            }
-          ]
-        }
-      ]
     }
   ],
   "license_spdx_identifier": "CC-BY-ND-3.0"

--- a/feeds/rejseplanen.dk.dmfr.json
+++ b/feeds/rejseplanen.dk.dmfr.json
@@ -6,7 +6,7 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.rejseplanen.info/labs/GTFS.zip"
-      },
+      }
     }
   ],
   "license_spdx_identifier": "CC-BY-ND-3.0"

--- a/feeds/rejseplanen.dk.dmfr.json
+++ b/feeds/rejseplanen.dk.dmfr.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.4.0.json",
+  "feeds": [
+    {
+      "id": "f-rejseplanen~dk~gtfs",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rejseplanen.info/labs/GTFS.zip"
+      },
+      "operators": [
+        {
+          "onestop_id": "f-rejseplanen~dk~gtfs",
+          "name": "Rejseplanen",
+          "website": "rejseplanen.dk",
+          "associated_feeds": [
+            {
+              "feed_onestop_id": "f-rejseplanen~dk~gtfs"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "license_spdx_identifier": "CC-BY-ND-3.0"
+}


### PR DESCRIPTION
I used the Samtrafiken file as a template, as I couldn't find the example file. For now, I've just added the data provider as the operator. Should I add all operators/agencies instead? They are included in the GTFS file, so using those instead would make it easier to create and maintain them. Thanks!