### PR TITLE
Update NORTA static feed

### DIFF
--- a/feeds/norta.com.dmfr.json
+++ b/feeds/norta.com.dmfr.json
@@ -6,17 +6,17 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.norta.com/OpnesourceData/Download",
-        "static_historic":[
+        "static_historic": [
           "https://transitfeeds-data.s3-us-west-1.amazonaws.com/public/feeds/new-orleans-regional-transit-authority/336/20170801/gtfs.zip"
         ]
       },
       "license": {
         "url": "https://www.norta.com/help-and-contacts/business-information/open-transit-data-(otd)"
       },
-      "authorization":{
-        "type":"query_param",
-        "param_name":"key",
-         "info_url":"https://www.norta.com/help-and-contacts/business-information/open-transit-data-(otd)"
+      "authorization": {
+        "type": "query_param",
+        "param_name": "key",
+        "info_url": "https://www.norta.com/help-and-contacts/business-information/open-transit-data-(otd)"
       },
       "operators": [
         {

--- a/feeds/norta.com.dmfr.json
+++ b/feeds/norta.com.dmfr.json
@@ -5,10 +5,18 @@
       "id": "f-9vrf-neworleansrta",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://transitfeeds-data.s3-us-west-1.amazonaws.com/public/feeds/new-orleans-regional-transit-authority/336/20170801/gtfs.zip"
+        "static_current": "https://www.norta.com/OpnesourceData/Download",
+        "static_historic":[
+          "https://transitfeeds-data.s3-us-west-1.amazonaws.com/public/feeds/new-orleans-regional-transit-authority/336/20170801/gtfs.zip"
+        ]
       },
       "license": {
-        "url": "https://www.norta.com/Business-Center/Developer-Information"
+        "url": "https://www.norta.com/help-and-contacts/business-information/open-transit-data-(otd)"
+      },
+      "authorization":{
+        "type":"query_param",
+        "param_name":"key",
+         "info_url":"https://www.norta.com/help-and-contacts/business-information/open-transit-data-(otd)"
       },
       "operators": [
         {


### PR DESCRIPTION
No, "OpnesourceData" is not a typo. 
Access to feed requires creating an account and agreeing to their terms, which can be a bit finicky with their jank website, after which they email you a direct link with your key already appended to the URL.  Additionally, RT feeds are available, if you're willing to jump through a few more hoops, at the same URL.