### PR TITLE
udpate Navarra Public Transport

### DIFF
--- a/feeds/navarra.es.dmfr.json
+++ b/feeds/navarra.es.dmfr.json
@@ -5,7 +5,10 @@
       "id": "f-ezw-automÓvilesrÍoalhamasa~elcartelabargaalberto~autobusesparr",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.navarra.es/appsext/DescargarFichero/default.aspx?codigoAcceso=OpenData&fichero=TransporteInterurbano/gtfs.zip"
+        "static_current": "https://datosabiertos.navarra.es/es/dataset/ebfb5edd-0cd9-4b31-b0d9-8bc2d25e2493/resource/d3c1c89a-5d4c-4c25-97b5-66da663d3691/download/gtfs.zip",
+        "static_historic": [
+          "http://www.navarra.es/appsext/DescargarFichero/default.aspx?codigoAcceso=OpenData&fichero=TransporteInterurbano/gtfs.zip"
+        ]
       },
       "license": {
         "url": "http://creativecommons.org/licenses/by/3.0/es/",


### PR DESCRIPTION
from: https://datosabiertos.navarra.es/es/dataset/transporte-p-blico-interurbano-regular-de-viajeros-en-autob-s