### PR TITLE
Update Link Transit Static GTFS Feed

### DIFF
--- a/feeds/linktransit.com.dmfr.json
+++ b/feeds/linktransit.com.dmfr.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.4.0.json",
+  "feeds": [
+    {
+      "id": "f-c26-linktransit~wa~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://link.rideralerts.com/InfoPoint/gtfs-zip.ashx"
+      },
+      "license": {
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes"
+      },
+      "tags": {
+        "feed_id": "linktransit-wa-us",
+        "gtfs_data_exchange": "link-transit"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-c26-linktransit",
+          "name": "Link Transit",
+          "website": "https://www.linktransit.com/",
+          "tags": {
+            "twitter_general": "LinkTransit",
+            "us_ntd_id": "00043",
+            "wikidata_id": "Q25000891"
+          }
+        }
+      ]
+    }
+  ],
+  "license_spdx_identifier": "CDLA-Permissive-1.0"
+}

--- a/feeds/trilliumtransit.com.dmfr.json
+++ b/feeds/trilliumtransit.com.dmfr.json
@@ -3423,34 +3423,6 @@
       ]
     },
     {
-      "id": "f-c26-linktransit~wa~us",
-      "spec": "gtfs",
-      "urls": {
-        "static_historic": [
-          "https://data.trilliumtransit.com/gtfs/linktransit-wa-us/linktransit-wa-us.zip"
-        ]
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes"
-      },
-      "tags": {
-        "gtfs_data_exchange": "link-transit",
-        "status": "outdated"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-c26-linktransit",
-          "name": "Link Transit",
-          "tags": {
-            "twitter_general": "LinkTransit",
-            "us_ntd_id": "00043",
-            "wikidata_id": "Q25000891"
-          }
-        }
-      ]
-    },
-    {
       "id": "f-c262f-uniongaptransit",
       "spec": "gtfs",
       "urls": {

--- a/scripts/debug/add_feed_tags.py
+++ b/scripts/debug/add_feed_tags.py
@@ -218,7 +218,7 @@ FEED_TAGS = [
     {"onestop_id":"f-9q7-kerncounty~ca~us","tags":{"feed_id": "kerncounty-ca-us", "managed_by": "trillium", "gtfs_data_exchange": "kern-regional-transit"}},
     {"onestop_id":"f-9muq-lagunabeach~ca~us","tags":{"feed_id": "lagunabeach-ca-us", "demo_feed": "true", "managed_by": "trillium", "gtfs_data_exchange": "laguna-beach-transit"}},
     {"onestop_id":"f-9qb-laketransit~ca~us","tags":{"feed_id": "laketransit-ca-us", "managed_by": "trillium", "gtfs_data_exchange": "lake-transit"}},
-    {"onestop_id":"f-c26-linktransit~wa~us","tags":{"feed_id": "linktransit-wa-us", "managed_by": "trillium", "gtfs_data_exchange": "link-transit"}},
+    {"onestop_id":"f-c26-linktransit~wa~us","tags":{"feed_id": "linktransit-wa-us", "gtfs_data_exchange": "link-transit"}},
     {"onestop_id":"f-9qb-mendocino~ca~us","tags":{"feed_id": "mendocino-ca-us", "managed_by": "trillium", "gtfs_data_exchange": "mendocino-transit-authority"}},
     {"onestop_id":"f-9qd-mercedthebus~ca~us","tags":{"feed_id": "mercedthebus-ca-us", "managed_by": "trillium", "gtfs_data_exchange": "the-bus"}},
     {"onestop_id":"f-drt7-merrimackvalley~ma~us","tags":{"feed_id": "merrimackvalley-ma-us", "managed_by": "trillium", "gtfs_data_exchange": "merrimack-valley-regional-transit-authority"}},


### PR DESCRIPTION
This feed has been provided by Link Transit. 

Note: there is a conflicting PR for Link Transit here https://github.com/transitland/transitland-atlas/pull/675/files

However the feed version is newer in this PR, published Nov 17, 2022 whereas the trillium version in PR 675 is from Jan 28, 2022. 