### PR TITLE
fix KART url

### DIFF
--- a/feeds/connexionz.net.dmfr.json
+++ b/feeds/connexionz.net.dmfr.json
@@ -5,7 +5,7 @@
       "id": "f-9q6-kcapta~ca~us",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.kartbus.org/data/gtfs.zip",
+        "static_current": "http://kart.connexionz.net/rtt/public/utility/gtfs.aspx",
         "static_historic": [
           "http://data.trilliumtransit.com/gtfs/kcapta-ca-us/kcapta-ca-us.zip"
         ]


### PR DESCRIPTION
they claim on the developer page that /data/gtfs.zip works... but it clearly doesn't, so changed it out for the other link provided