### PR TITLE
remove ceres area transit and stanislaus regional transit

### DIFF
--- a/feeds/stanrta.org.dmfr.json
+++ b/feeds/stanrta.org.dmfr.json
@@ -22,7 +22,11 @@
       "operators": [
         {
           "onestop_id": "o-9q9-modestoareaexpress",
-          "name": "StanRTA",
+          "supersedes_ids": [
+            "o-9q9-stanislausmetroaltransit",
+            "o-9q9vz-ceresareatransit"
+          ],
+          "name": "Stanislaus Regional Transit Authority (StanRTA)",
           "short_name": "The S",
           "website": "https://stanrta.org/",
           "associated_feeds": [

--- a/feeds/stanrta.org.dmfr.json
+++ b/feeds/stanrta.org.dmfr.json
@@ -4,11 +4,12 @@
     {
       "id": "f-9q9-modesto~ca~us",
       "supersedes_ids": [
-        "f-9q9y-escalon~ca~us"
+        "f-9q9y-escalon~ca~us",
+        "f-9qd-stanislaus~ca~us"
       ],
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.modestoareaexpress.com/preview-gtfs.zip",
+        "static_current": "https://stanrta.org/preview-gtfs.zip",
         "static_historic": [
           "http://data.trilliumtransit.com/gtfs/modesto-ca-us/modesto-ca-us.zip"
         ]
@@ -21,13 +22,10 @@
       "operators": [
         {
           "onestop_id": "o-9q9-modestoareaexpress",
-          "name": "Modesto Area Express",
-          "short_name": "MAX",
-          "website": "http://www.modestoareaexpress.com/",
+          "name": "StanRTA",
+          "short_name": "The S",
+          "website": "https://stanrta.org/",
           "associated_feeds": [
-            {
-              "gtfs_agency_id": "95"
-            },
             {
               "feed_onestop_id": "f-modestoareaexpress~rt"
             }

--- a/feeds/trilliumtransit.com.dmfr.json
+++ b/feeds/trilliumtransit.com.dmfr.json
@@ -1117,46 +1117,6 @@
       ]
     },
     {
-      "id": "f-9qd-stanislaus~ca~us",
-      "spec": "gtfs",
-      "urls": {
-        "static_historic": [
-          "https://data.trilliumtransit.com/gtfs/stanislaus-ca-us/stanislaus-ca-us.zip"
-        ]
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes"
-      },
-      "tags": {
-        "status": "outdated"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q9-stanislausmetroaltransit",
-          "name": "Stanislaus Regional Transit",
-          "short_name": "StaRT",
-          "website": "http://www.srt.org/",
-          "associated_feeds": [
-            {
-              "feed_onestop_id": "f-stanrta~rt"
-            }
-          ],
-          "tags": {
-            "twitter_general": "RideStaRT",
-            "us_ntd_id": "90236",
-            "wikidata_id": "Q7598964"
-          }
-        },
-        {
-          "onestop_id": "o-9q9vz-ceresareatransit",
-          "name": "Ceres Area Transit",
-          "short_name": "CAT",
-          "website": "http://www.ci.ceres.ca.us/CeresAreaTransit/CAT.html"
-        }
-      ]
-    },
-    {
       "id": "f-9qd-yosemite~ca~us",
       "spec": "gtfs",
       "urls": {


### PR DESCRIPTION
ceres and stanislaus have been merged (along with others) into one agency, so removing duplicated routes