### PR TITLE
update: Transdev Royan Atlantique

### DIFF
--- a/feeds/data.agglo-royan.fr.dmfr.json
+++ b/feeds/data.agglo-royan.fr.dmfr.json
@@ -5,7 +5,10 @@
       "id": "f-gbp7-carabus~transdevroyanatlantique",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://data.agglo-royan.fr/dataset/9b761974-a195-4e33-91b7-ecee3b368016/resource/144c2734-9d66-4177-904d-a67768f5ee1d/download/carabus-royan-frmaj070717.zip"
+        "static_current": "https://data.agglo-royan.fr/dataset/9b761974-a195-4e33-91b7-ecee3b368016/resource/d4915904-ebd0-43cf-9b35-fbfc04ce91fd/download/gtfs_20220914_01.zip",
+        "static_historic": [
+          "https://data.agglo-royan.fr/dataset/9b761974-a195-4e33-91b7-ecee3b368016/resource/144c2734-9d66-4177-904d-a67768f5ee1d/download/carabus-royan-frmaj070717.zip"
+        ]
       },
       "license": {
         "use_without_attribution": "no",


### PR DESCRIPTION
update source: https://transport.data.gouv.fr/datasets/donnees-gtfs-du-reseau-de-transport-public-cara-bus