### PR TITLE
Dunkerque

### DIFF
--- a/feeds/data.gouv.fr.dmfr.json
+++ b/feeds/data.gouv.fr.dmfr.json
@@ -22,6 +22,18 @@
       }
     },
     {
+      "id": "f-dunkerque~fr",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.data.gouv.fr/fr/datasets/r/18ee1aa1-27a8-44a1-957e-199f940c7e90"
+      },
+      "license": {
+        "spdx_identifier": "ODbL-1.0",
+        "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-reseau-dk-bus-de-la-communaute-urbaine-de-dunkerque-gtfs",
+        "share_alike_optional": "no"
+      }
+    },
+    {
       "id": "f-karouest~reunion",
       "spec": "gtfs",
       "urls": {


### PR DESCRIPTION
https://transport.data.gouv.fr/datasets/offre-de-transports-reseau-dk-bus-de-la-communaute-urbaine-de-dunkerque-gtfs