### PR TITLE
remove wrong dart license

### DIFF
--- a/feeds/dart.org.dmfr.json
+++ b/feeds/dart.org.dmfr.json
@@ -7,9 +7,6 @@
       "urls": {
         "static_current": "http://www.dart.org/transitdata/latest/google_transit.zip"
       },
-      "license": {
-        "url": "https://ridedart.com/business-center/developer-resources"
-      },
       "tags": {
         "gtfs_data_exchange": "dallas-area-rapid-transit"
       },


### PR DESCRIPTION
this license is for the wrong DART, (Des Moines Area Regional Transit Authority)