### PR TITLE
update (unstable) url for: Norwalk Transit District

### DIFF
--- a/feeds/norwalktransit.com.dmfr.json
+++ b/feeds/norwalktransit.com.dmfr.json
@@ -5,10 +5,14 @@
       "id": "f-dr7cc-norwalktransit",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.norwalktransit.com/s/GTFS_Data.zip"
+        "static_current": "https://norwalktransit.com/wp-content/uploads/2023/02/google_transit_Working.zip",
+        "static_historic": [
+          "https://www.norwalktransit.com/s/GTFS_Data.zip"
+        ]
       },
       "tags": {
-        "gtfs_data_exchange": "norwalk-transit"
+        "gtfs_data_exchange": "norwalk-transit",
+        "unstable_url": "true"
       },
       "operators": [
         {


### PR DESCRIPTION
updated from: https://norwalktransit.com/public-information/
