### PR TITLE
fix url for: f-tricap~mn~us

### DIFF
--- a/feeds/trilliumtransit.com.dmfr.json
+++ b/feeds/trilliumtransit.com.dmfr.json
@@ -7641,7 +7641,7 @@
       "id": "f-tricap~mn~us",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/tricap-mn-us/tricap-mn-us.zip"
+        "static_current": "https://data.trilliumtransit.com/gtfs/tricap-mn-us/tricap-mn-us--flex-v2.zip"
       }
     },
     {


### PR DESCRIPTION
it seems from here: https://data.trilliumtransit.com/gtfs/tricap-mn-us/
that the tricap-mn-us.zip file does not exists there only the: tricap-mn-us--flex-v2.zip file