### PR TITLE
update some Gunma prefecture related providers

### DIFF
--- a/feeds/tshimada291.github.com.dmfr.json
+++ b/feeds/tshimada291.github.com.dmfr.json
@@ -2542,7 +2542,10 @@
       "id": "f-gtfs~1001~kanetsu~kotu~jp",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1001.kanetsu_kotu.zip"
+        "static_current": "https://kan-etsu.net/relays/download/193/2807/433//?file=/files/libs/11049/202305261450561282.zip&/file_name=GTFS-JP(kan-etsu)",
+        "static_historic": [
+          "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1001.kanetsu_kotu.zip"
+        ]
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2597,7 +2600,10 @@
       "id": "f-gtfs~1020~takasakishi~com~jp",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1020.takasakishi_com.zip"
+        "static_current": "https://www.city.takasaki.gunma.jp/docs/2020060400037/files/bus-takasaki-gunma-jp_20230414.zip",
+        "static_historic": [
+          "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1020.takasakishi_com.zip"
+        ]
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2608,7 +2614,10 @@
       "id": "f-gtfs~1021~numatashi~com~jp",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1021.numatashi_com.zip"
+        "static_current": "https://www.city.numata.gunma.jp/_res/projects/default_project/_page_/001/013/089/20230322_gtfsjp3.zip",
+        "static_historic": [
+          "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1021.numatashi_com.zip"
+        ]
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2641,7 +2650,10 @@
       "id": "f-gtfs~1025~kiryushi~com~jp",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1025.kiryushi_com.zip"
+        "static_current": "https://www.city.kiryu.lg.jp/_res/common/opendata/1014528/kiryu_orihime_gtfs.zip",
+        "static_historic": [
+          "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1025.kiryushi_com.zip"
+        ]
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2674,7 +2686,10 @@
       "id": "f-gtfs~1028~fujiokashi~com~jp",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1028.fujiokashi_com.zip"
+        "static_current": "https://www.city.fujioka.gunma.jp/material/files/group/7/fujiokaGTFS.zip",
+        "static_historic": [
+          "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1028.fujiokashi_com.zip"
+        ]
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2729,7 +2744,10 @@
       "id": "f-gtfs~1036~shimonitamachi~com~jp",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1036.shimonitamachi_com.zip"
+        "static_current": "https://www.town.shimonita.lg.jp/shimonita-bus/m01/gtfs.20230401.shimonita.zip",
+        "static_historic": [
+          "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1036.shimonitamachi_com.zip"
+        ]
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2806,7 +2824,10 @@
       "id": "f-gtfs~1048~oizumimachi~com~jp",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1048.oizumimachi_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/oizumitown/feeds/kouikikoukyoubasuaozora/files/feed.zip",
+        "static_historic": [
+          "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1048.oizumimachi_com.zip"
+        ]
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",

--- a/feeds/tshimada291.github.com.dmfr.json
+++ b/feeds/tshimada291.github.com.dmfr.json
@@ -2675,7 +2675,10 @@
       "id": "f-gtfs~1027~otashi~com~jp",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1027.otashi_com.zip"
+        "static_current": "https://www.city.ota.gunma.jp/uploaded/attachment/16547.zip",
+        "static_historic": [
+          "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1027.otashi_com.zip"
+        ]
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",


### PR DESCRIPTION
The Gunma prefecture related GTFS files are no longer hosted at: https://gma.jcld.jp/GMA_OPENDATA/GTFS/...
They are in process to re-locate hosting for the GTFS files, some are hosted on the local provider websites some are hosted on one of the centrally hosted data platform sites (ex: https://gtfs-data.jp/, https://ckan.odpt.org/)

Source: https://www.pref.gunma.jp/page/198829.html