### PR TITLE
Updates to Lisbon, Portugal feeds

### DIFF
--- a/feeds/carrismetropolitana.github.com.dmfr.json
+++ b/feeds/carrismetropolitana.github.com.dmfr.json
@@ -3,42 +3,21 @@
   "feeds": [
     {
       "id": "f-eyck-carris",
+      "supersedes_ids": [
+        "f-sulfertagus",
+        "f-eyce-tst",
+        "f-eyck-rodoviáriadelisboa",
+        "f-eyck-carris~a2",
+        "f-eyck-carris~a3",
+        "f-eyck-carris~a4"
+      ],
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://github.com/carrismetropolitana/gtfs/raw/latest/CM_GTFS_A1.zip",
+        "static_current": "https://github.com/carrismetropolitana/gtfs/raw/live/CarrisMetropolitana.zip",
         "static_historic": [
+          "https://github.com/carrismetropolitana/gtfs/raw/latest/CM_GTFS_A1.zip",
           "http://www.transporlis.pt/Portals/0/OpenData/gtfs/zip/1/gtfs_1.zip"
         ]
-      },
-      "license": {
-        "url": "https://dados.gov.pt/pt/datasets/gtfs-carris-metropolitana/"
-      }
-    },
-    {
-      "id": "f-eyck-carris~a2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://github.com/carrismetropolitana/gtfs/raw/latest/CM_GTFS_A2.zip"
-      },
-      "license": {
-        "url": "https://dados.gov.pt/pt/datasets/gtfs-carris-metropolitana/"
-      }
-    },
-    {
-      "id": "f-eyck-carris~a3",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://github.com/carrismetropolitana/gtfs/raw/latest/CM_GTFS_A3.zip"
-      },
-      "license": {
-        "url": "https://dados.gov.pt/pt/datasets/gtfs-carris-metropolitana/"
-      }
-    },
-    {
-      "id": "f-eyck-carris~a4",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://github.com/carrismetropolitana/gtfs/raw/latest/CM_GTFS_A4.zip"
       },
       "license": {
         "url": "https://dados.gov.pt/pt/datasets/gtfs-carris-metropolitana/"
@@ -53,15 +32,6 @@
       "associated_feeds": [
         {
           "feed_onestop_id": "f-eyck-carris"
-        },
-        {
-          "feed_onestop_id": "f-eyck-carris~a2"
-        },
-        {
-          "feed_onestop_id": "f-eyck-carris~a3"
-        },
-        {
-          "feed_onestop_id": "f-eyck-carris~a4"
         }
       ]
     }

--- a/feeds/transporlis.pt.dmfr.json
+++ b/feeds/transporlis.pt.dmfr.json
@@ -2,13 +2,6 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.4.1.json",
   "feeds": [
     {
-      "id": "f-carristur~pt",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.transporlis.pt/desktopmodules/trp_opendata/ajax/downloadFile.ashx?op=71&u=web"
-      }
-    },
-    {
       "id": "f-eyc-cp",
       "spec": "gtfs",
       "urls": {
@@ -33,9 +26,6 @@
     },
     {
       "id": "f-eyce-fertagus",
-      "supersedes_ids": [
-        "f-sulfertagus"
-      ],
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.transporlis.pt/desktopmodules/trp_opendata/ajax/downloadFile.ashx?op=13&u=web",
@@ -51,50 +41,6 @@
           "associated_feeds": [
             {
               "gtfs_agency_id": "13"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "f-eyce-tst",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.transporlis.pt/desktopmodules/trp_opendata/ajax/downloadFile.ashx?op=11&u=web",
-        "static_historic": [
-          "http://www.transporlis.pt/Portals/0/OpenData/gtfs/zip/11/gtfs_11.zip"
-        ]
-      },
-      "operators": [
-        {
-          "onestop_id": "o-eyce-tst",
-          "name": "Transportes Sul do Tejo",
-          "short_name": "TST",
-          "website": "http://www.tsuldotejo.pt/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "11"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "f-eyck-rodoviáriadelisboa",
-      "spec": "gtfs",
-      "urls": {
-        "static_historic": [
-          "http://www.transporlis.pt/Portals/0/OpenData/gtfs/zip/61/gtfs_61.zip"
-        ]
-      },
-      "operators": [
-        {
-          "onestop_id": "o-eyck-rodoviáriadelisboa",
-          "name": "Rodoviária de Lisboa",
-          "website": "http://www.rodoviariadelisboa.pt/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "61"
             }
           ]
         }


### PR DESCRIPTION
Added the joint Carris Metropolitana area feed. Removed per-area (a2,a3,a4) Carris Metropolitana feeds. Removed old Lisbon metro area bus operators that were replaced by Carris Metropolitana. Removed discontinued Carristur airport bus brand.