### PR TITLE
changing the id to update the file

### DIFF
--- a/feeds/gtfs.mot.gov.il.dmfr.json
+++ b/feeds/gtfs.mot.gov.il.dmfr.json
@@ -2,7 +2,7 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
   "feeds": [
     {
-      "id": "f-sv-גלים~מועצהאזוריתגולן~אפיקים~דןצפון~דןבדרום~דןבארשבע~ירושלים",
+      "id": "f-sv-Israel",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://gtfs.mot.gov.il/gtfsfiles/israel-public-transportation.zip",


### PR DESCRIPTION
Israel GTFS has an error six month ago, i'm updating the file to force fetching
Get "https://gtfs.mot.gov.il/gtfsfiles/israel-public-transportation.zip": tls: failed to verify certificate: x509: certificate signed by unknown authority