### PR TITLE
Add CARRIS and change Carris Metropolitana history

### DIFF
--- a/feeds/carris.pt.dmfr.json
+++ b/feeds/carris.pt.dmfr.json
@@ -26,5 +26,6 @@
                 }
             ]
         }
-    ]
+    ],
+    "license_spdx_identifier": "CDLA-Permissive-1.0"
 }

--- a/feeds/carris.pt.dmfr.json
+++ b/feeds/carris.pt.dmfr.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
+    "feeds": [
+        {
+            "id": "f-eyckr-carris",
+            "spec": "gtfs",
+            "urls": {
+                "static_current": "https://gateway.carris.pt/gateway/gtfs/api/v2.11/GTFS",
+                "static_historic": [
+                    "http://www.transporlis.pt/Portals/0/OpenData/gtfs/zip/1/gtfs_1.zip"
+                ]
+            },
+            "license": {
+                "url": "https://dadosabertos.cm-lisboa.pt/dataset/informacao-sobre-transportes-publicos-da-cidade-de-lisboa-carris"
+            }
+        }
+    ],
+    "operators": [
+        {
+            "onestop_id": "o-eyckr-carris",
+            "name": "CARRIS",
+            "website": "https://www.carris.pt/",
+            "associated_feeds": [
+                {
+                    "feed_onestop_id": "f-eyckr-carris"
+                }
+            ]
+        }
+    ]
+}

--- a/feeds/carris.pt.dmfr.json
+++ b/feeds/carris.pt.dmfr.json
@@ -1,31 +1,31 @@
 {
-    "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
-    "feeds": [
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
+  "feeds": [
+    {
+      "id": "f-eyckr-carris",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gateway.carris.pt/gateway/gtfs/api/v2.11/GTFS",
+        "static_historic": [
+          "http://www.transporlis.pt/Portals/0/OpenData/gtfs/zip/1/gtfs_1.zip"
+        ]
+      },
+      "license": {
+        "url": "https://dadosabertos.cm-lisboa.pt/dataset/informacao-sobre-transportes-publicos-da-cidade-de-lisboa-carris"
+      }
+    }
+  ],
+  "operators": [
+    {
+      "onestop_id": "o-eyckr-carris",
+      "name": "CARRIS",
+      "website": "https://www.carris.pt/",
+      "associated_feeds": [
         {
-            "id": "f-eyckr-carris",
-            "spec": "gtfs",
-            "urls": {
-                "static_current": "https://gateway.carris.pt/gateway/gtfs/api/v2.11/GTFS",
-                "static_historic": [
-                    "http://www.transporlis.pt/Portals/0/OpenData/gtfs/zip/1/gtfs_1.zip"
-                ]
-            },
-            "license": {
-                "url": "https://dadosabertos.cm-lisboa.pt/dataset/informacao-sobre-transportes-publicos-da-cidade-de-lisboa-carris"
-            }
+          "feed_onestop_id": "f-eyckr-carris"
         }
-    ],
-    "operators": [
-        {
-            "onestop_id": "o-eyckr-carris",
-            "name": "CARRIS",
-            "website": "https://www.carris.pt/",
-            "associated_feeds": [
-                {
-                    "feed_onestop_id": "f-eyckr-carris"
-                }
-            ]
-        }
-    ],
-    "license_spdx_identifier": "CDLA-Permissive-1.0"
+      ]
+    }
+  ],
+  "license_spdx_identifier": "CDLA-Permissive-1.0"
 }

--- a/feeds/carris.pt.dmfr.json
+++ b/feeds/carris.pt.dmfr.json
@@ -2,7 +2,7 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
   "feeds": [
     {
-      "id": "f-eyckr-carris",
+      "id": "f-carris~pt",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://gateway.carris.pt/gateway/gtfs/api/v2.11/GTFS",
@@ -19,12 +19,7 @@
     {
       "onestop_id": "o-eyckr-carris",
       "name": "CARRIS",
-      "website": "https://www.carris.pt/",
-      "associated_feeds": [
-        {
-          "feed_onestop_id": "f-eyckr-carris"
-        }
-      ]
+      "website": "https://www.carris.pt/"
     }
   ],
   "license_spdx_identifier": "CDLA-Permissive-1.0"

--- a/feeds/carrismetropolitana.github.com.dmfr.json
+++ b/feeds/carrismetropolitana.github.com.dmfr.json
@@ -2,7 +2,7 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
   "feeds": [
     {
-      "id": "f~carr",
+      "id": "f~carris~metropolitana~pt",
       "supersedes_ids": [
         "f-eyck-carris",
         "f-sulfertagus",

--- a/feeds/carrismetropolitana.github.com.dmfr.json
+++ b/feeds/carrismetropolitana.github.com.dmfr.json
@@ -1,39 +1,39 @@
 {
-    "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
-    "feeds": [
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
+  "feeds": [
+    {
+      "id": "f-eyck-carris",
+      "supersedes_ids": [
+        "f-sulfertagus",
+        "f-eyce-tst",
+        "f-eyck-rodoviáriadelisboa",
+        "f-eyck-carris~a2",
+        "f-eyck-carris~a3",
+        "f-eyck-carris~a4"
+      ],
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://github.com/carrismetropolitana/gtfs/raw/live/CarrisMetropolitana.zip",
+        "static_historic": [
+          "https://github.com/carrismetropolitana/gtfs/raw/latest/CM_GTFS_A1.zip"
+        ]
+      },
+      "license": {
+        "url": "https://dados.gov.pt/pt/datasets/gtfs-carris-metropolitana/"
+      }
+    }
+  ],
+  "operators": [
+    {
+      "onestop_id": "o-eyck-carris",
+      "name": "Carris Metropolitana",
+      "website": "https://www.carrismetropolitana.pt/",
+      "associated_feeds": [
         {
-            "id": "f-eyck-carris",
-            "supersedes_ids": [
-                "f-sulfertagus",
-                "f-eyce-tst",
-                "f-eyck-rodoviáriadelisboa",
-                "f-eyck-carris~a2",
-                "f-eyck-carris~a3",
-                "f-eyck-carris~a4"
-            ],
-            "spec": "gtfs",
-            "urls": {
-                "static_current": "https://github.com/carrismetropolitana/gtfs/raw/live/CarrisMetropolitana.zip",
-                "static_historic": [
-                    "https://github.com/carrismetropolitana/gtfs/raw/latest/CM_GTFS_A1.zip"
-                ]
-            },
-            "license": {
-                "url": "https://dados.gov.pt/pt/datasets/gtfs-carris-metropolitana/"
-            }
+          "feed_onestop_id": "f-eyck-carris"
         }
-    ],
-    "operators": [
-        {
-            "onestop_id": "o-eyck-carris",
-            "name": "Carris Metropolitana",
-            "website": "https://www.carrismetropolitana.pt/",
-            "associated_feeds": [
-                {
-                    "feed_onestop_id": "f-eyck-carris"
-                }
-            ]
-        }
-    ],
-    "license_spdx_identifier": "CDLA-Permissive-1.0"
+      ]
+    }
+  ],
+  "license_spdx_identifier": "CDLA-Permissive-1.0"
 }

--- a/feeds/carrismetropolitana.github.com.dmfr.json
+++ b/feeds/carrismetropolitana.github.com.dmfr.json
@@ -2,8 +2,9 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
   "feeds": [
     {
-      "id": "f-eyck-carris",
+      "id": "f~carr",
       "supersedes_ids": [
+        "f-eyck-carris",
         "f-sulfertagus",
         "f-eyce-tst",
         "f-eyck-rodoviáriadelisboa",
@@ -27,12 +28,7 @@
     {
       "onestop_id": "o-eyck-carris",
       "name": "Carris Metropolitana",
-      "website": "https://www.carrismetropolitana.pt/",
-      "associated_feeds": [
-        {
-          "feed_onestop_id": "f-eyck-carris"
-        }
-      ]
+      "website": "https://www.carrismetropolitana.pt/"
     }
   ],
   "license_spdx_identifier": "CDLA-Permissive-1.0"

--- a/feeds/carrismetropolitana.github.com.dmfr.json
+++ b/feeds/carrismetropolitana.github.com.dmfr.json
@@ -1,40 +1,39 @@
 {
-  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
-  "feeds": [
-    {
-      "id": "f-eyck-carris",
-      "supersedes_ids": [
-        "f-sulfertagus",
-        "f-eyce-tst",
-        "f-eyck-rodoviáriadelisboa",
-        "f-eyck-carris~a2",
-        "f-eyck-carris~a3",
-        "f-eyck-carris~a4"
-      ],
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://github.com/carrismetropolitana/gtfs/raw/live/CarrisMetropolitana.zip",
-        "static_historic": [
-          "https://github.com/carrismetropolitana/gtfs/raw/latest/CM_GTFS_A1.zip",
-          "http://www.transporlis.pt/Portals/0/OpenData/gtfs/zip/1/gtfs_1.zip"
-        ]
-      },
-      "license": {
-        "url": "https://dados.gov.pt/pt/datasets/gtfs-carris-metropolitana/"
-      }
-    }
-  ],
-  "operators": [
-    {
-      "onestop_id": "o-eyck-carris",
-      "name": "Carris Metropolitana",
-      "website": "https://www.carrismetropolitana.pt/",
-      "associated_feeds": [
+    "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
+    "feeds": [
         {
-          "feed_onestop_id": "f-eyck-carris"
+            "id": "f-eyck-carris",
+            "supersedes_ids": [
+                "f-sulfertagus",
+                "f-eyce-tst",
+                "f-eyck-rodoviáriadelisboa",
+                "f-eyck-carris~a2",
+                "f-eyck-carris~a3",
+                "f-eyck-carris~a4"
+            ],
+            "spec": "gtfs",
+            "urls": {
+                "static_current": "https://github.com/carrismetropolitana/gtfs/raw/live/CarrisMetropolitana.zip",
+                "static_historic": [
+                    "https://github.com/carrismetropolitana/gtfs/raw/latest/CM_GTFS_A1.zip"
+                ]
+            },
+            "license": {
+                "url": "https://dados.gov.pt/pt/datasets/gtfs-carris-metropolitana/"
+            }
         }
-      ]
-    }
-  ],
-  "license_spdx_identifier": "CDLA-Permissive-1.0"
+    ],
+    "operators": [
+        {
+            "onestop_id": "o-eyck-carris",
+            "name": "Carris Metropolitana",
+            "website": "https://www.carrismetropolitana.pt/",
+            "associated_feeds": [
+                {
+                    "feed_onestop_id": "f-eyck-carris"
+                }
+            ]
+        }
+    ],
+    "license_spdx_identifier": "CDLA-Permissive-1.0"
 }

--- a/feeds/carrismetropolitana.github.com.dmfr.json
+++ b/feeds/carrismetropolitana.github.com.dmfr.json
@@ -2,7 +2,7 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
   "feeds": [
     {
-      "id": "f~carris~metropolitana~pt",
+      "id": "f-carris~metropolitana~pt",
       "supersedes_ids": [
         "f-eyck-carris",
         "f-sulfertagus",


### PR DESCRIPTION
Firstly, CARRIS != Carris Metropolitana.

Lisbon (District) is composed of multiple municipalities. CARRIS only operates on one of those municipalities: Lisbon (Municipality) while Carris Metropolitana operates on some of the others (which includes Lisbon (Municipality), but limitedly because CARRIS is on an exclusivity agreement for that part of the district).

The first historical feed url for Carris Metropolitana was actually an old source for CARRIS feeds.

The url to the license I included applies to the old data that was provided via an intermediate, Transporlis.
I imagine the same license applies to the current data. CARRIS moved towards sharing the GTFS feed directly from their systems and do not provide any license info.

Thanks!