### PR TITLE
Assorted small updates

### DIFF
--- a/feeds/lacmta.gitlab.com.dmfr.json
+++ b/feeds/lacmta.gitlab.com.dmfr.json
@@ -49,7 +49,7 @@
     },
     {
       "id": "f-metro~losangeles~alerts",
-      "spec": "gtfs",
+      "spec": "gtfs-rt",
       "urls": {
         "realtime_alerts": "https://s3.amazonaws.com/la-alerts-prod/alerts.pb"
       }

--- a/feeds/massdot.state.ma.us.dmfr.json
+++ b/feeds/massdot.state.ma.us.dmfr.json
@@ -5,7 +5,7 @@
       "id": "f-drm-dattco",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/dattco-ma-us/dattco-ma-us.zip"
+        "static_current": "https://data.trilliumtransit.com/gtfs/dattco-ma-us/dattco-ma-us.zip"
       },
       "operators": [
         {
@@ -125,7 +125,7 @@
       "id": "f-drt3-yankee",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://data.trilliumtransit.com/gtfs/yankeeline-ma-us/yankeeline-ma-us.zip"
+        "static_current": "https://data.trilliumtransit.com/gtfs/yankeeline-ma-us/yankeeline-ma-us.zip"
       },
       "license": {
         "url": "https://www.massdot.state.ma.us/Portals/0/docs/developers/develop_license_agree.pdf",

--- a/feeds/scgov.net.dmfr.json
+++ b/feeds/scgov.net.dmfr.json
@@ -21,7 +21,8 @@
         {
           "onestop_id": "o-dhv-sarasotacountyareatransit",
           "name": "Sarasota County Area Transit",
-          "short_name": "SCAT",
+          "short_name": "Breeze Transit",
+          "website": "https://www.scgov.net/government/breeze-transit",
           "associated_feeds": [
             {
               "feed_onestop_id": "f-dhv-sarasotacountyareatransit"


### PR DESCRIPTION
- https for some feeds
- update name of Breeze Transit (formerly Sarasota County Area Transit)
- fix LA Metro alerts feed spec - reported on https://github.com/transitland/transitland-atlas/pull/933