### PR TITLE
Updated feed for I-RIDE Trolley.

### DIFF
--- a/feeds/buswhere.com.dmfr.json
+++ b/feeds/buswhere.com.dmfr.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
+  "feeds": [
+    {
+      "id": "f-djn1-fl~iridetrolley",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://buswhere.com/iridetrolley/gtfs/schedule"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-djn1-fl~iridetrolley",
+          "name": "I-RIDE Trolley",
+          "short_name": "I-RIDE",
+          "website": "https://www.internationaldriveorlando.com/iride-trolley/",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "IRIDE"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "license_spdx_identifier": "CDLA-Permissive-1.0"
+}

--- a/feeds/buswhere.com.dmfr.json
+++ b/feeds/buswhere.com.dmfr.json
@@ -5,19 +5,17 @@
       "id": "f-djn1-fl~iridetrolley",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://buswhere.com/iridetrolley/gtfs/schedule"
+        "static_current": "https://buswhere.com/iridetrolley/gtfs/schedule",
+        "static_historic": [
+          "https://data.omnimodal.io/gtfs/iride-fl-us/iride-fl-us.zip"
+        ]
       },
       "operators": [
         {
           "onestop_id": "o-djn1-fl~iridetrolley",
           "name": "I-RIDE Trolley",
           "short_name": "I-RIDE",
-          "website": "https://www.internationaldriveorlando.com/iride-trolley/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "IRIDE"
-            }
-          ]
+          "website": "https://www.internationaldriveorlando.com/iride-trolley/"
         }
       ]
     }

--- a/feeds/data.omnimodal.io.dmfr.json
+++ b/feeds/data.omnimodal.io.dmfr.json
@@ -2,26 +2,6 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
   "feeds": [
     {
-      "id": "f-djn1-fl~iridetrolley",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.omnimodal.io/gtfs/iride-fl-us/iride-fl-us.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-djn1-fl~iridetrolley",
-          "name": "I-RIDE Trolley",
-          "short_name": "I-RIDE",
-          "website": "http://iridetrolley.com",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "IRIDE"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "f-djn5y-sanfordcommunityredevelopmentagency",
       "spec": "gtfs",
       "urls": {


### PR DESCRIPTION
This PR updates the I-RIDE Trolley feed to be up to date.

The I-RIDE Trolley in the I-Drive Business Improvement District has switched from OmniModal (which is now redirecting to spam/ads) to BusWhere. This PR changes the I-RIDE Trolley to use the new vendor.

Data feed was sourced by staff at the I-Drive Business Improvement District. URL is `https://buswhere.com/iridetrolley/gtfs/schedule`.

The remaining OmniModal service, the [Sanford Community Redevelopment Agency trolley service](https://sanfordfl.gov/residents/free-trolley-service/), uses TSOMobile. I do not have their GTFS feed available; more research (i.e., contacting them) is necessary and is out of scope for this PR.