### PR TITLE
Jacksonville Transport Authority

### DIFF
--- a/feeds/schedules.jtafla.com.dmfr.json
+++ b/feeds/schedules.jtafla.com.dmfr.json
@@ -5,7 +5,8 @@
       "id": "f-djmu-jacksonvilletransportationauthority",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://schedules.jtafla.com/schedulesgtfs/download"
+        "static_current": "https://ride.jtafla.com/gtfs-archive/gtfs.zip",
+        "static_historic": ["https://schedules.jtafla.com/schedulesgtfs/download"]
       },
       "license": {
         "url": "https://ftis.org/FTDEDisclaimer.aspx"

--- a/feeds/schedules.jtafla.com.dmfr.json
+++ b/feeds/schedules.jtafla.com.dmfr.json
@@ -3,7 +3,6 @@
   "feeds": [
     {
       "id": "f-djmu-jacksonvilletransportationauthority",
-      "description": "Transitland has to fetch this feed using a custom script. To manually download the feed go to https://ride.jtafla.com/gtfs-archive",
       "spec": "gtfs",
       "urls": {
         "static_historic": [
@@ -14,7 +13,8 @@
         "url": "https://ftis.org/FTDEDisclaimer.aspx"
       },
       "tags": {
-        "gtfs_data_exchange": "jacksonville-transportation-authority"
+        "gtfs_data_exchange": "jacksonville-transportation-authority",
+        "notes": "Transitland has to fetch this feed using a custom script. To manually download the feed go to https://ride.jtafla.com/gtfs-archive"
       },
       "operators": [
         {

--- a/feeds/schedules.jtafla.com.dmfr.json
+++ b/feeds/schedules.jtafla.com.dmfr.json
@@ -3,10 +3,12 @@
   "feeds": [
     {
       "id": "f-djmu-jacksonvilletransportationauthority",
+      "description": "Transitland has to fetch this feed using a custom script. To manually download the feed go to https://ride.jtafla.com/gtfs-archive",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ride.jtafla.com/gtfs-archive/gtfs.zip",
-        "static_historic": ["https://schedules.jtafla.com/schedulesgtfs/download"]
+        "static_historic": [
+          "https://schedules.jtafla.com/schedulesgtfs/download"
+        ]
       },
       "license": {
         "url": "https://ftis.org/FTDEDisclaimer.aspx"


### PR DESCRIPTION
New source for Jacksonville Transport Authority. Old one doesn't work.