### PR TITLE
New URL for Metra Rail

### DIFF
--- a/feeds/metrarail.com.dmfr.json
+++ b/feeds/metrarail.com.dmfr.json
@@ -5,7 +5,8 @@
       "id": "f-dp3-metra",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gtfsapi.metrarail.com/gtfs/raw/schedule.zip"
+        "static_current": "https://gtfsapi.metrarail.com/gtfs/raw/schedule.zip",
+        "static_historic": ["https://schedules.metrarail.com/gtfs/schedule.zip"]
       },
       "license": {
         "url": "https://metrarail.com/developers",


### PR DESCRIPTION
There is a GTFS download url that is updated every 24 hours and doesn't require a developer API key. I've added it to the "historical url" array