### PR TITLE
Add France Isère (38) cars

### DIFF
--- a/feeds/mobilites-m.fr.dmfr.json
+++ b/feeds/mobilites-m.fr.dmfr.json
@@ -13,6 +13,17 @@
       }
     },
     {
+      "id": "f-mobilites~m~c38",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.mobilites-m.fr/api/gtfs/C38"
+      },
+      "license": {
+        "spdx_identifier": "ODbL-1.0",
+        "url": "https://data.mobilites-m.fr/donnees"
+      }
+    },
+    {
       "id": "f-mobilites~m~fun",
       "spec": "gtfs",
       "urls": {
@@ -50,17 +61,6 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://data.mobilites-m.fr/api/gtfs/TPV"
-      },
-      "license": {
-        "spdx_identifier": "ODbL-1.0",
-        "url": "https://data.mobilites-m.fr/donnees"
-      }
-    },
-    {
-      "id": "f-mobilites~m~c38",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.mobilites-m.fr/api/gtfs/C38"
       },
       "license": {
         "spdx_identifier": "ODbL-1.0",

--- a/feeds/mobilites-m.fr.dmfr.json
+++ b/feeds/mobilites-m.fr.dmfr.json
@@ -9,7 +9,7 @@
       },
       "license": {
         "spdx_identifier": "ODbL-1.0",
-        "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-telepherique-de-la-bastille"
+        "url": "https://data.mobilites-m.fr/donnees"
       }
     },
     {
@@ -20,7 +20,7 @@
       },
       "license": {
         "spdx_identifier": "ODbL-1.0",
-        "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-funiculaire-du-plateau-des-petites-roches"
+        "url": "https://data.mobilites-m.fr/donnees"
       }
     },
     {
@@ -31,7 +31,7 @@
       },
       "license": {
         "spdx_identifier": "ODbL-1.0",
-        "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-tougo"
+        "url": "https://data.mobilites-m.fr/donnees"
       }
     },
     {
@@ -42,7 +42,7 @@
       },
       "license": {
         "spdx_identifier": "ODbL-1.0",
-        "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-des-lignes-m-covoit-ligne-plus"
+        "url": "https://data.mobilites-m.fr/donnees"
       }
     },
     {
@@ -53,7 +53,7 @@
       },
       "license": {
         "spdx_identifier": "ODbL-1.0",
-        "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-transport-du-pays-voironnais"
+        "url": "https://data.mobilites-m.fr/donnees"
       }
     },
     {

--- a/feeds/mobilites-m.fr.dmfr.json
+++ b/feeds/mobilites-m.fr.dmfr.json
@@ -57,6 +57,17 @@
       }
     },
     {
+      "id": "f-mobilites~m~c38",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.mobilites-m.fr/api/gtfs/C38"
+      },
+      "license": {
+        "spdx_identifier": "ODbL-1.0",
+        "url": "https://data.mobilites-m.fr/donnees"
+      }
+    },
+    {
       "id": "f-u0h0-tag",
       "spec": "gtfs",
       "urls": {


### PR DESCRIPTION
* License for all the mobilites-m.fr feeds is documented at https://data.mobilites-m.fr/donnees
* There's a missing feed for cars