### PR TITLE
reverted VVTA's static to be from transloc

### DIFF
--- a/feeds/syncromatics.com.dmfr.json
+++ b/feeds/syncromatics.com.dmfr.json
@@ -71,39 +71,6 @@
       }
     },
     {
-      "id": "f-9qh-victorville~ca~us",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ontime.vvta.org/gtfs",
-        "static_historic": [
-          "https://data.trilliumtransit.com/gtfs/victorville-ca-us/victorville-ca-us.zip",
-          "https://api.transloc.com/gtfs/vvta.zip"
-        ]
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-3.0",
-        "url": "https://vvta.org/developers/"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qh-victorvalleytransitauthority",
-          "name": "Victor Valley Transit Authority",
-          "short_name": "VVTA",
-          "website": "https://www.vvta.org",
-          "associated_feeds": [
-            {
-              "feed_onestop_id": "f-victorvalleytransitauthority~rt"
-            }
-          ],
-          "tags": {
-            "twitter_general": "VVTransit",
-            "us_ntd_id": "90148",
-            "wikidata_id": "Q7926418"
-          }
-        }
-      ]
-    },
-    {
       "id": "f-countyofkauai~transportationagency~rt",
       "spec": "gtfs-rt",
       "urls": {

--- a/feeds/transloc.com.dmfr.json
+++ b/feeds/transloc.com.dmfr.json
@@ -2,6 +2,38 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
   "feeds": [
     {
+      "id": "f-9qh-victorville~ca~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.transloc.com/gtfs/vvta.zip",
+        "static_historic": [
+          "https://data.trilliumtransit.com/gtfs/victorville-ca-us/victorville-ca-us.zip"
+        ]
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-3.0",
+        "url": "https://vvta.org/developers/"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-9qh-victorvalleytransitauthority",
+          "name": "Victor Valley Transit Authority",
+          "short_name": "VVTA",
+          "website": "https://www.vvta.org",
+          "associated_feeds": [
+            {
+              "feed_onestop_id": "f-victorvalleytransitauthority~rt"
+            }
+          ],
+          "tags": {
+            "twitter_general": "VVTransit",
+            "us_ntd_id": "90148",
+            "wikidata_id": "Q7926418"
+          }
+        }
+      ]
+    },
+    {
       "id": "f-9t9p7-universityofaz~cattran~freeshuttleservice",
       "spec": "gtfs",
       "urls": {


### PR DESCRIPTION
- confirmed with VVTA that the official static GTFS that is for public consumption is the transloc feed
![Screenshot 2024-03-12 at 2 28 44 PM](https://github.com/transitland/transitland-atlas/assets/485944/10cf79d5-2d2d-4124-9c5c-ba679754fdfa)

