### PR TITLE
Use official GTFS feed of Polish regional rail operator - Koleje Dolnośląskie

### DIFF
--- a/feeds/kolejedolnoslaskie.pl.dmfr.json
+++ b/feeds/kolejedolnoslaskie.pl.dmfr.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
+  "feeds": [
+    {
+      "id": "f-u3h-koleje~dolnoslaskie",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://kd:Baewongohwug3Ao@gtfs.i.kiedyprzyjedzie.pl/kd/google_transit.zip",
+        "static_historic": [
+	  "https://mkuran.pl/gtfs/kolejedolnoslaskie.zip"
+	]
+      },
+      "authorization": {
+        "type": "basic_auth",
+        "info_url": "https://kolejedolnoslaskie.pl/rozklady-gtfs/"
+      },
+      "license": {
+        "url": "https://www.kolejedolnoslaskie.4bip.pl/index.php?idg=6&id=75&x=99"
+      }
+    },
+    {
+      "id": "f-u3h-koleje~dolnoslaskie~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+	"realtime_vehicle_positions": "https://gtfs.i.kiedyprzyjedzie.pl/rt/279/vehicles"
+      },
+      "authorization": {
+        "type": "basic_auth",
+        "info_url": "https://kolejedolnoslaskie.pl/rozklady-gtfs/"
+      },
+      "license": {
+        "url": "https://www.kolejedolnoslaskie.4bip.pl/index.php?idg=6&id=75&x=99"
+      }
+    }
+  ],
+  "operators": [
+    {
+      "onestop_id": "o-u3h-koleje~dolnoslaskie",
+      "name": "Koleje Dolnośląskie",
+      "short_name": "KD",
+      "website": "https://kolejedolnoslaskie.pl/",
+      "associated_feeds": [
+        {
+          "feed_onestop_id": "f-u3h-koleje~dolnoslaskie"
+        },
+        {
+          "feed_onestop_id": "f-u3h-koleje~dolnoslaskie~rt"
+        }
+      ]
+    }
+  ]
+}

--- a/feeds/kolejedolnoslaskie.pl.dmfr.json
+++ b/feeds/kolejedolnoslaskie.pl.dmfr.json
@@ -5,31 +5,31 @@
       "id": "f-u3h-koleje~dolnoslaskie",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://kd:Baewongohwug3Ao@gtfs.i.kiedyprzyjedzie.pl/kd/google_transit.zip",
+        "static_current": "https://gtfs.i.kiedyprzyjedzie.pl/kd/google_transit.zip",
         "static_historic": [
-	  "https://mkuran.pl/gtfs/kolejedolnoslaskie.zip"
-	]
+          "https://mkuran.pl/gtfs/kolejedolnoslaskie.zip"
+        ]
+      },
+      "license": {
+        "url": "https://www.kolejedolnoslaskie.4bip.pl/index.php?idg=6&id=75&x=99"
       },
       "authorization": {
         "type": "basic_auth",
         "info_url": "https://kolejedolnoslaskie.pl/rozklady-gtfs/"
-      },
-      "license": {
-        "url": "https://www.kolejedolnoslaskie.4bip.pl/index.php?idg=6&id=75&x=99"
       }
     },
     {
       "id": "f-u3h-koleje~dolnoslaskie~rt",
       "spec": "gtfs-rt",
       "urls": {
-	"realtime_vehicle_positions": "https://gtfs.i.kiedyprzyjedzie.pl/rt/279/vehicles"
+        "realtime_vehicle_positions": "https://gtfs.i.kiedyprzyjedzie.pl/rt/279/vehicles"
+      },
+      "license": {
+        "url": "https://www.kolejedolnoslaskie.4bip.pl/index.php?idg=6&id=75&x=99"
       },
       "authorization": {
         "type": "basic_auth",
         "info_url": "https://kolejedolnoslaskie.pl/rozklady-gtfs/"
-      },
-      "license": {
-        "url": "https://www.kolejedolnoslaskie.4bip.pl/index.php?idg=6&id=75&x=99"
       }
     }
   ],

--- a/feeds/mkuran.pl.dmfr.json
+++ b/feeds/mkuran.pl.dmfr.json
@@ -132,29 +132,6 @@
       ]
     },
     {
-      "id": "f-u3h-koleje~dolnoslaskie",
-      "name": "Koleje Dolnośląskie GTFS",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://mkuran.pl/gtfs/kolejedolnoslaskie.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC0-1.0",
-        "url": "https://creativecommons.org/publicdomain/zero/1.0/",
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "commercial_use_allowed": "yes"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-u3h-koleje~dolnoslaskie",
-          "name": "Koleje Dolnośląskie",
-          "short_name": "KD",
-          "website": "https://kolejedolnoslaskie.pl/"
-        }
-      ]
-    },
-    {
       "id": "f-u3ky-bydgoszcz",
       "name": "Bydgoszcz GTFS",
       "spec": "gtfs",


### PR DESCRIPTION
This PR:
1. Removes the unofficial GTFS feed of the Polish regional rail operator, Koleje Dolnośląskie (eng. Lower Silesia Railways) provided by @MKuranowski
2. Replaces it with the official feed from the operator's website: https://kolejedolnoslaskie.pl/rozklady-gtfs/

There are some caveats:
1. The feed needs a username and password to access. The credentials are given in plaintext in the URL that I've shown above (CTRL+f "login" on that page, no need to know Polish). I'm thinking putting the password in public defeats the purpose of having a password in the first place. I assume that transitland doesn't handle storing secrets used to access the .zips, right? The "Authorization" key in the dmfr json is purely informational, right?
2. I'm not sure if I should be removing the mkuran.pl.dmfr.json feed since it works without password. But it's not official. On the other hand, the official one doesn't work out of the box, because it needs the Basic Auth credentials.
3. There's also a GTFS-RT feed mentioned in the page I linked, but you need to write an e-mail to get access and describe why you want it. Can I just get the password and send it to the maintainers here so that transitland atlas uses it under the hood to download the RT data so the feed works? I'm not sure if the transitland atlas website map visualizes GTFS-RT

Closes #1034 

---
Also, contents for due diligence:
agency.txt

```csv
agency_id,agency_name,agency_url,agency_timezone,agency_phone,agency_fare_url
279,Koleje Dolnośląskie S.A.,https://kolejedolnoslaskie.pl/,Europe/Warsaw,+48 76 742 11 12,https://bilet.kolejedolnoslaskie.eu
```

feed_info.txt

```csv
feed_publisher_name,feed_publisher_url,feed_lang,feed_start_date,feed_end_date
kiedyPrzyjedzie.pl,http://kiedyprzyjedzie.pl,pl,20240314,20241214
```