### PR TITLE
Add invalid_tls_certificate tag

### DIFF
--- a/feeds/trentinotrasporti.it.dmfr.json
+++ b/feeds/trentinotrasporti.it.dmfr.json
@@ -12,6 +12,9 @@
         "url": "https://www.trentinotrasporti.it/open-data/",
         "use_without_attribution": "no",
         "create_derived_product": "yes"
+      },
+      "tags": {
+        "invalid_tls_certificate": "true"
       }
     },
     {
@@ -25,6 +28,9 @@
         "url": "https://www.trentinotrasporti.it/open-data/",
         "use_without_attribution": "no",
         "create_derived_product": "yes"
+      },
+      "tags": {
+        "invalid_tls_certificate": "true"
       }
     }
   ],


### PR DESCRIPTION
With this change, I'm proposing to add such a tag.

I know that at the moment transitland has no use of it, but I think the starting point is adding the tag :).

Also, transitland-atlas is being used by many other project as a data repo, so I think this would still make sense even if for the foreseeable future transitland itself is not able to use it.