### PR TITLE
Update transcollines.github.dmfr.json

### DIFF
--- a/feeds/transcollines.github.dmfr.json
+++ b/feeds/transcollines.github.dmfr.json
@@ -21,26 +21,9 @@
           "onestop_id": "o-f244-RITC~Transcollines",
           "name": "Régie intermunicipale de transport des Collines",
           "short_name": "Transcollines",
-          "website": "http://transcollines.ca",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "Transcollines",
-              "feed_onestop_id": "f-f244-RITC~Transcollines"
-            },
-            {
-              "feed_onestop_id": "f-f244-RITC~Transcollines~RT"
-            }
-          ]
+          "website": "http://transcollines.ca"
         }
       ]
-    },
-    {
-      "id": "f-f244-RITC~Transcollines~RT",
-      "spec": "gtfs-rt",
-      "urls": {
-        "realtime_vehicle_positions": "http://67.212.79.244:8080/hermes_st_Transcollines/pb/vehiclePositions.pb",
-        "realtime_trip_updates": "http://67.212.79.244:8080/hermes_st_Transcollines/pb/tripUpdates.pb"
-      }
     }
   ],
   "license_spdx_identifier": "CDLA-Permissive-1.0"

--- a/feeds/transcollines.github.dmfr.json
+++ b/feeds/transcollines.github.dmfr.json
@@ -5,7 +5,8 @@
       "id": "f-f244-RITC~Transcollines",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://github.com/transcollines/gtfs/raw/master/transcollines-qc-ca.zip"
+        "static_current": "https://github.com/transcollines/gtfs/raw/master/transcollines-qc-ca-fares.zip",
+        "static_historic": ["https://github.com/transcollines/gtfs/raw/master/transcollines-qc-ca.zip"]
       },
       "license": {
         "url": "https://github.com/transcollines/GTFS/blob/master/LICENCE.MD",

--- a/feeds/transcollines.github.dmfr.json
+++ b/feeds/transcollines.github.dmfr.json
@@ -6,7 +6,9 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://github.com/transcollines/gtfs/raw/master/transcollines-qc-ca-fares.zip",
-        "static_historic": ["https://github.com/transcollines/gtfs/raw/master/transcollines-qc-ca.zip"]
+        "static_historic": [
+          "https://github.com/transcollines/gtfs/raw/master/transcollines-qc-ca.zip"
+        ]
       },
       "license": {
         "url": "https://github.com/transcollines/GTFS/blob/master/LICENCE.MD",


### PR DESCRIPTION
Change URL to use the Fares-V2 dataset

Interline peeps: the RT URLs have been discontinued for quite some time while Transcollines upgrades to a new CAD/AVL system. I'm not sure how best to go about removing these links. Any assistance would be greatly appreciated.