### PR TITLE
Update carrismetropolitana with RT feeds

### DIFF
--- a/feeds/carrismetropolitana.github.com.dmfr.json
+++ b/feeds/carrismetropolitana.github.com.dmfr.json
@@ -22,13 +22,37 @@
       "license": {
         "url": "https://dados.gov.pt/pt/datasets/gtfs-carris-metropolitana/"
       }
+    },
+    {
+      "id": "f-carris~metropolitana~pt~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_alerts": "http://api.carrismetropolitana.pt/alerts.pb",
+        "realtime_vehicle_positions": "http://api.carrismetropolitana.pt/vehicles.pb"
+      },
+      "license": {
+        "url": "https://dados.gov.pt/pt/datasets/gtfs-carris-metropolitana/"
+      }
     }
   ],
   "operators": [
     {
       "onestop_id": "o-eyck-carris",
       "name": "Carris Metropolitana",
-      "website": "https://www.carrismetropolitana.pt/"
+      "short_name": "CMetropolitana",
+      "website": "https://www.carrismetropolitana.pt/",
+      "tags": {
+        "wikidata_id": "Q111611112",
+        "twitter_general": "CMetropolitana_"
+      },
+      "associated_feeds": [        
+        {
+          "feed_onestop_id": "f-carris~metropolitana~pt"
+        },
+        {
+          "feed_onestop_id": "f-carris~metropolitana~pt~rt"
+        }
+      ]
     }
   ],
   "license_spdx_identifier": "CDLA-Permissive-1.0"

--- a/feeds/carrismetropolitana.github.com.dmfr.json
+++ b/feeds/carrismetropolitana.github.com.dmfr.json
@@ -27,8 +27,8 @@
       "id": "f-carris~metropolitana~pt~rt",
       "spec": "gtfs-rt",
       "urls": {
-        "realtime_alerts": "http://api.carrismetropolitana.pt/alerts.pb",
-        "realtime_vehicle_positions": "http://api.carrismetropolitana.pt/vehicles.pb"
+        "realtime_vehicle_positions": "http://api.carrismetropolitana.pt/vehicles.pb",
+        "realtime_alerts": "http://api.carrismetropolitana.pt/alerts.pb"
       },
       "license": {
         "url": "https://dados.gov.pt/pt/datasets/gtfs-carris-metropolitana/"
@@ -41,18 +41,18 @@
       "name": "Carris Metropolitana",
       "short_name": "CMetropolitana",
       "website": "https://www.carrismetropolitana.pt/",
-      "tags": {
-        "wikidata_id": "Q111611112",
-        "twitter_general": "CMetropolitana_"
-      },
-      "associated_feeds": [        
+      "associated_feeds": [
         {
           "feed_onestop_id": "f-carris~metropolitana~pt"
         },
         {
           "feed_onestop_id": "f-carris~metropolitana~pt~rt"
         }
-      ]
+      ],
+      "tags": {
+        "twitter_general": "CMetropolitana_",
+        "wikidata_id": "Q111611112"
+      }
     }
   ],
   "license_spdx_identifier": "CDLA-Permissive-1.0"


### PR DESCRIPTION
This change adds the realtime feeds from Carris Metropolitana, and additional metadata (WikiData, short name, twitter).