### PR TITLE
Update metrotas.com.au.dmfr.json

### DIFF
--- a/feeds/metrotas.com.au.dmfr.json
+++ b/feeds/metrotas.com.au.dmfr.json
@@ -2,22 +2,46 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
   "feeds": [
     {
-      "id": "f-r22-metrotasmania",
+      "id": "f-south-metrotasmania",
       "spec": "gtfs",
       "urls": {
         "static_current": [
-          "http://www.metrotas.com.au/wp-content/uploads/transit/Hobart/google_transit.zip",
-          "http://www.metrotas.com.au/wp-content/uploads/transit/Launceston/google_transit.zip",
+          "http://www.metrotas.com.au/wp-content/uploads/transit/Hobart/google_transit.zip"
+        ]
+      }
+    },
+    {
+      "id": "f-north-metrotasmania",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": [
+          "http://www.metrotas.com.au/wp-content/uploads/transit/Launceston/google_transit.zip"
+        ]
+      }
+    },
+    {
+      "id": "f-northwest-metrotasmania",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": [
           "http://www.metrotas.com.au/wp-content/uploads/transit/Burnie/google_transit.zip"
         ]
-      },
+      }
+    }
+  ],
       "operators": [
         {
-          "onestop_id": "o-r22-metrotasmania",
+          "onestop_id": "o-south-metrotasmania",
           "name": "Metro Tasmania",
           "short_name": "Metro",
           "website": "http://www.metrotas.com.au",
           "associated_feeds": [
+            {
+              "f-north-metrotasmania"
+            },
+            {
+              "f-northwest-metrotasmania"
+            }
             {
               "gtfs_agency_id": "MTS"
             }
@@ -25,6 +49,5 @@
         }
       ]
     }
-  ],
   "license_spdx_identifier": "CDLA-Permissive-1.0"
 }

--- a/feeds/metrotas.com.au.dmfr.json
+++ b/feeds/metrotas.com.au.dmfr.json
@@ -5,7 +5,11 @@
       "id": "f-r22-metrotasmania",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.metrotas.com.au/wp-content/uploads/transit/Hobart/google_transit.zip"
+        "static_current": [
+          "http://www.metrotas.com.au/wp-content/uploads/transit/Hobart/google_transit.zip",
+          "http://www.metrotas.com.au/wp-content/uploads/transit/Launceston/google_transit.zip",
+          "http://www.metrotas.com.au/wp-content/uploads/transit/Burnie/google_transit.zip"
+        ]
       },
       "operators": [
         {

--- a/feeds/metrotas.com.au.dmfr.json
+++ b/feeds/metrotas.com.au.dmfr.json
@@ -29,24 +29,21 @@
       },
       "license": {
         "url": "https://www.metrotas.com.au/community/gtfs/"
-      }
-    }
-  ],
-  "operators": [
-    {
-      "onestop_id": "o-r22-metrotasmania",
-      "name": "Metro Tasmania",
-      "short_name": "Metro",
-      "website": "http://www.metrotas.com.au",
-      "associated_feeds": [
+      },
+      "operators": [
         {
-          "feed_onestop_id": "f-northwest~metrotasmania"
-        },
-        {
-          "feed_onestop_id": "f-north~metrotasmania"
-        },
-        {
-          "feed_onestop_id": "f-r22-metrotasmania"
+          "onestop_id": "o-r22-metrotasmania",
+          "name": "Metro Tasmania",
+          "short_name": "Metro",
+          "website": "http://www.metrotas.com.au",
+          "associated_feeds": [
+            {
+              "feed_onestop_id": "f-northwest~metrotasmania"
+            },
+            {
+              "feed_onestop_id": "f-north~metrotasmania"
+            }
+          ]
         }
       ]
     }

--- a/feeds/metrotas.com.au.dmfr.json
+++ b/feeds/metrotas.com.au.dmfr.json
@@ -2,52 +2,45 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
   "feeds": [
     {
-      "id": "f-south-metrotasmania",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": [
-          "http://www.metrotas.com.au/wp-content/uploads/transit/Hobart/google_transit.zip"
-        ]
-      }
-    },
-    {
       "id": "f-north-metrotasmania",
       "spec": "gtfs",
       "urls": {
-        "static_current": [
-          "http://www.metrotas.com.au/wp-content/uploads/transit/Launceston/google_transit.zip"
-        ]
+        "static_current": "http://www.metrotas.com.au/wp-content/uploads/transit/Launceston/google_transit.zip"
       }
     },
     {
       "id": "f-northwest-metrotasmania",
       "spec": "gtfs",
       "urls": {
-        "static_current": [
-          "http://www.metrotas.com.au/wp-content/uploads/transit/Burnie/google_transit.zip"
-        ]
+        "static_current": "http://www.metrotas.com.au/wp-content/uploads/transit/Burnie/google_transit.zip"
+      }
+    },
+    {
+      "id": "f-south-metrotasmania",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.metrotas.com.au/wp-content/uploads/transit/Hobart/google_transit.zip"
       }
     }
   ],
-      "operators": [
+  "operators": [
+    {
+      "onestop_id": "o-south-metrotasmania",
+      "name": "Metro Tasmania",
+      "short_name": "Metro",
+      "website": "http://www.metrotas.com.au",
+      "associated_feeds": [
         {
-          "onestop_id": "o-south-metrotasmania",
-          "name": "Metro Tasmania",
-          "short_name": "Metro",
-          "website": "http://www.metrotas.com.au",
-          "associated_feeds": [
-            {
-              "f-north-metrotasmania"
-            },
-            {
-              "f-northwest-metrotasmania"
-            }
-            {
-              "gtfs_agency_id": "MTS"
-            }
-          ]
+          "gtfs_agency_id": "MTS"
+        },
+        {
+          "feed_onestop_id": "f-north-metrotasmania"
+        },
+        {
+          "feed_onestop_id": "f-northwest-metrotasmania"
         }
       ]
     }
+  ],
   "license_spdx_identifier": "CDLA-Permissive-1.0"
 }

--- a/feeds/metrotas.com.au.dmfr.json
+++ b/feeds/metrotas.com.au.dmfr.json
@@ -2,42 +2,51 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
   "feeds": [
     {
-      "id": "f-north-metrotasmania",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://www.metrotas.com.au/wp-content/uploads/transit/Launceston/google_transit.zip"
-      }
-    },
-    {
-      "id": "f-northwest-metrotasmania",
+      "id": "f-northwest~metrotasmania",
       "spec": "gtfs",
       "urls": {
         "static_current": "http://www.metrotas.com.au/wp-content/uploads/transit/Burnie/google_transit.zip"
+      },
+      "license": {
+        "url": "https://www.metrotas.com.au/community/gtfs/"
       }
     },
     {
-      "id": "f-south-metrotasmania",
+      "id": "f-north~metrotasmania",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.metrotas.com.au/wp-content/uploads/transit/Launceston/google_transit.zip"
+      },
+      "license": {
+        "url": "https://www.metrotas.com.au/community/gtfs/"
+      }
+    },
+    {
+      "id": "f-r22-metrotasmania",
       "spec": "gtfs",
       "urls": {
         "static_current": "http://www.metrotas.com.au/wp-content/uploads/transit/Hobart/google_transit.zip"
+      },
+      "license": {
+        "url": "https://www.metrotas.com.au/community/gtfs/"
       }
     }
   ],
   "operators": [
     {
-      "onestop_id": "o-south-metrotasmania",
+      "onestop_id": "o-r22-metrotasmania",
       "name": "Metro Tasmania",
       "short_name": "Metro",
       "website": "http://www.metrotas.com.au",
       "associated_feeds": [
         {
-          "gtfs_agency_id": "MTS"
+          "feed_onestop_id": "f-northwest~metrotasmania"
         },
         {
-          "feed_onestop_id": "f-north-metrotasmania"
+          "feed_onestop_id": "f-north~metrotasmania"
         },
         {
-          "feed_onestop_id": "f-northwest-metrotasmania"
+          "feed_onestop_id": "f-r22-metrotasmania"
         }
       ]
     }


### PR DESCRIPTION
Added two additional URLs for Metro Tasmania as they have three current URLs for different parts of the state (the added URLs also include new operators Lee's Coaches, Manion's Coaches, Calow's Coaches, East Tamar Bus Lines and Mersey Link, as well as Redline Coaches and Tassielink, which were already in the exisiting URL)