### PR TITLE
Disambiguate Carris and Carris Metropolitana

### DIFF
--- a/feeds/carris.pt.dmfr.json
+++ b/feeds/carris.pt.dmfr.json
@@ -12,14 +12,18 @@
       },
       "license": {
         "url": "https://dadosabertos.cm-lisboa.pt/dataset/informacao-sobre-transportes-publicos-da-cidade-de-lisboa-carris"
-      }
-    }
-  ],
-  "operators": [
-    {
-      "onestop_id": "o-eyck-carris",
-      "name": "CARRIS",
-      "website": "https://www.carris.pt/"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-eyckr-carris",
+          "name": "Companhia Carris de Ferro de Lisboa",
+          "short_name": "CARRIS",
+          "website": "https://www.carris.pt/",
+          "tags": {
+            "wikidata_id": "Q1045108"
+          }
+        }
+      ]
     }
   ],
   "license_spdx_identifier": "CDLA-Permissive-1.0"

--- a/feeds/carrismetropolitana.github.com.dmfr.json
+++ b/feeds/carrismetropolitana.github.com.dmfr.json
@@ -14,7 +14,7 @@
       ],
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://api.carrismetropolitana.pt/gtfs",
+        "static_current": "https://api.carrismetropolitana.pt/gtfs",
         "static_historic": [
           "https://github.com/carrismetropolitana/gtfs/raw/live/CarrisMetropolitana.zip",
           "https://github.com/carrismetropolitana/gtfs/raw/latest/CM_GTFS_A1.zip"

--- a/feeds/carrismetropolitana.github.com.dmfr.json
+++ b/feeds/carrismetropolitana.github.com.dmfr.json
@@ -35,10 +35,13 @@
         "url": "https://dados.gov.pt/pt/datasets/gtfs-carris-metropolitana/"
       }
     }
-  ],
+],
   "operators": [
     {
       "onestop_id": "o-eyc-carrismetropolitana",
+      "supersedes_ids": [
+        "o-eyck-carris"
+      ],
       "name": "Carris Metropolitana",
       "short_name": "CMetropolitana",
       "website": "https://www.carrismetropolitana.pt/",

--- a/feeds/carrismetropolitana.github.com.dmfr.json
+++ b/feeds/carrismetropolitana.github.com.dmfr.json
@@ -35,7 +35,7 @@
         "url": "https://dados.gov.pt/pt/datasets/gtfs-carris-metropolitana/"
       }
     }
-],
+  ],
   "operators": [
     {
       "onestop_id": "o-eyc-carrismetropolitana",

--- a/feeds/carrismetropolitana.github.com.dmfr.json
+++ b/feeds/carrismetropolitana.github.com.dmfr.json
@@ -14,8 +14,9 @@
       ],
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://github.com/carrismetropolitana/gtfs/raw/live/CarrisMetropolitana.zip",
+        "static_current": "http://api.carrismetropolitana.pt/gtfs",
         "static_historic": [
+          "https://github.com/carrismetropolitana/gtfs/raw/live/CarrisMetropolitana.zip",
           "https://github.com/carrismetropolitana/gtfs/raw/latest/CM_GTFS_A1.zip"
         ]
       },
@@ -37,7 +38,7 @@
   ],
   "operators": [
     {
-      "onestop_id": "o-eyck-carris",
+      "onestop_id": "o-eyc-carrismetropolitana",
       "name": "Carris Metropolitana",
       "short_name": "CMetropolitana",
       "website": "https://www.carrismetropolitana.pt/",


### PR DESCRIPTION
Referring to a different reporter's explanation in: https://github.com/transitland/transitland-atlas/pull/926#issue-1858236772

These are two different operators.

Currently, there are two onestop ids in the website:

o-eyc-carrismetropolitana
o-eyck-carris

The latter currently contains both Carris Metropolitana and Carris, which is wrong.
In this update, I've aligned the onestop IDs present on the website with the onestop IDs in the files, by associating:

o-eyc-carrismetropolitana -> Carris Metropolitana
o-eyck-carris -> Carris

Additionally, I've been told that Carris Metropolitana is now suggesting all users to refer to the API for all feeds, not just RT ones, so I put the new URL in.