### PR TITLE
Update tankbus.org.dmfr.json

### DIFF
--- a/feeds/tankbus.org.dmfr.json
+++ b/feeds/tankbus.org.dmfr.json
@@ -5,8 +5,9 @@
       "id": "f-dngy-transitauthorityofnorthernkentucky",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.tankbus.org/wp-content/uploads/2023/04/tank-google-transit.zip",
+        "static_current": "https://tank.rideralerts.com/InfoPoint/GTFS-Zip.ashx",
         "static_historic": [
+          "https://www.tankbus.org/wp-content/uploads/2023/04/tank-google-transit.zip",
           "https://www.tankbus.org/Portals/tankbus/gtfs/tank-google-transit.zip"
         ]
       },


### PR DESCRIPTION
They are now using a vendor called InfoPoint—it seems likely that the URL is no longer unstable. I will make a note and keep an eye on this .