### PR TITLE
Add new Comboios de Portugal (CP) feed

### DIFF
--- a/feeds/comboiosdeportugal.pt.dmfr.json
+++ b/feeds/comboiosdeportugal.pt.dmfr.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
+  "feeds": [
+    {
+      "id": "f-eyc-cp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://publico.cp.pt/gtfs/gtfs.zip",
+        "static_historic": [
+            "https://www.transporlis.pt/desktopmodules/trp_opendata/ajax/downloadFile.ashx?op=3&u=web",
+            "http://www.transporlis.pt/Portals/0/OpenData/gtfs/zip/3/gtfs_3.zip"
+        ]
+      },
+      "operators": [
+        {
+          "onestop_id": "o-eyc-cp",
+          "name": "Comboios de Portugal",
+          "short_name": "CP",
+          "website": "https://www.cp.pt/",
+          "associated_feeds": [
+            {
+              "feed_onestop_id": "f-eyc-cp",
+              "gtfs_agency_id": "1094_CP"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "license_spdx_identifier": "CDLA-Permissive-1.0"
+}

--- a/feeds/comboiosdeportugal.pt.dmfr.json
+++ b/feeds/comboiosdeportugal.pt.dmfr.json
@@ -7,8 +7,8 @@
       "urls": {
         "static_current": "https://publico.cp.pt/gtfs/gtfs.zip",
         "static_historic": [
-            "https://www.transporlis.pt/desktopmodules/trp_opendata/ajax/downloadFile.ashx?op=3&u=web",
-            "http://www.transporlis.pt/Portals/0/OpenData/gtfs/zip/3/gtfs_3.zip"
+          "https://www.transporlis.pt/desktopmodules/trp_opendata/ajax/downloadFile.ashx?op=3&u=web",
+          "http://www.transporlis.pt/Portals/0/OpenData/gtfs/zip/3/gtfs_3.zip"
         ]
       },
       "operators": [
@@ -26,5 +26,5 @@
         }
       ]
     }
-  ],
+  ]
 }

--- a/feeds/comboiosdeportugal.pt.dmfr.json
+++ b/feeds/comboiosdeportugal.pt.dmfr.json
@@ -19,8 +19,8 @@
           "website": "https://www.cp.pt/",
           "associated_feeds": [
             {
-              "feed_onestop_id": "f-eyc-cp",
-              "gtfs_agency_id": "1094_CP"
+              "gtfs_agency_id": "1094_CP",
+              "feed_onestop_id": "f-eyc-cp"
             }
           ]
         }

--- a/feeds/comboiosdeportugal.pt.dmfr.json
+++ b/feeds/comboiosdeportugal.pt.dmfr.json
@@ -27,5 +27,4 @@
       ]
     }
   ],
-  "license_spdx_identifier": "CDLA-Permissive-1.0"
 }

--- a/feeds/transporlis.pt.dmfr.json
+++ b/feeds/transporlis.pt.dmfr.json
@@ -2,29 +2,6 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
   "feeds": [
     {
-      "id": "f-eyc-cp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.transporlis.pt/desktopmodules/trp_opendata/ajax/downloadFile.ashx?op=3&u=web",
-        "static_historic": [
-          "http://www.transporlis.pt/Portals/0/OpenData/gtfs/zip/3/gtfs_3.zip"
-        ]
-      },
-      "operators": [
-        {
-          "onestop_id": "o-eyc-cp",
-          "name": "Comboios de Portugal",
-          "short_name": "CP",
-          "website": "https://www.cp.pt/",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "3"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "f-eyce-fertagus",
       "spec": "gtfs",
       "urls": {


### PR DESCRIPTION
Hi,

This adds the new Comboios de Portugal feed that is now provided directly by them instead of being served via Transporlis.
I also removed the feed from the Transporlis DMFR file.

Thanks! 🚀 