### PR TITLE
Update - Passio Feeds (UNCC, Elon, Jacksonville)

### DIFF
--- a/feeds/passio3.com.dmfr.json
+++ b/feeds/passio3.com.dmfr.json
@@ -272,38 +272,6 @@
       ]
     },
     {
-      "id": "f-dnrm-elonexpress",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://passio3.com/elon/passioTransit/gtfs/google_transit.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dnrm-elonexpress",
-          "name": "Elon University",
-          "short_name": "Elon Express",
-          "website": "https://www.elon.edu/u/fa/transportation/buses-shuttles/elonexpress/",
-          "associated_feeds": [
-            {
-              "feed_onestop_id": "f-dnrm-elonexpress"
-            },
-            {
-              "feed_onestop_id": "f-dnrm-elonexpress~rt"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "f-dnrm-elonexpress~rt",
-      "spec": "gtfs-rt",
-      "urls": {
-        "realtime_vehicle_positions": "https://passio3.com/elon/passioTransit/gtfs/realtime/vehiclePositions",
-        "realtime_trip_updates": "https://passio3.com/elon/passioTransit/gtfs/realtime/tripUpdates",
-        "realtime_alerts": "https://passio3.com/elon/passioTransit/gtfs/realtime/serviceAlerts"
-      }
-    },
-    {
       "id": "f-dnq8-ninertransit",
       "spec": "gtfs",
       "urls": {
@@ -373,6 +341,38 @@
         "realtime_vehicle_positions": "https://passio3.com/concordk/passioTransit/gtfs/realtime/vehiclePositions",
         "realtime_trip_updates": "https://passio3.com/concordk/passioTransit/gtfs/realtime/tripUpdates",
         "realtime_alerts": "https://passio3.com/concordk/passioTransit/gtfs/realtime/serviceAlerts"
+      }
+    },
+    {
+      "id": "f-dnrm-elonexpress",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://passio3.com/elon/passioTransit/gtfs/google_transit.zip"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-dnrm-elonexpress",
+          "name": "Elon University",
+          "short_name": "Elon Express",
+          "website": "https://www.elon.edu/u/fa/transportation/buses-shuttles/elonexpress/",
+          "associated_feeds": [
+            {
+              "feed_onestop_id": "f-dnrm-elonexpress"
+            },
+            {
+              "feed_onestop_id": "f-dnrm-elonexpress~rt"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "f-dnrm-elonexpress~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://passio3.com/elon/passioTransit/gtfs/realtime/vehiclePositions",
+        "realtime_trip_updates": "https://passio3.com/elon/passioTransit/gtfs/realtime/tripUpdates",
+        "realtime_alerts": "https://passio3.com/elon/passioTransit/gtfs/realtime/serviceAlerts"
       }
     },
     {

--- a/feeds/passio3.com.dmfr.json
+++ b/feeds/passio3.com.dmfr.json
@@ -272,6 +272,73 @@
       ]
     },
     {
+      "id": "f-dnrm-elonexpress",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://passio3.com/elon/passioTransit/gtfs/google_transit.zip"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-dnrm-elonexpress",
+          "name": "Elon University",
+          "short_name": "Elon Express",
+          "website": "https://www.elon.edu/u/fa/transportation/buses-shuttles/elonexpress/",
+          "associated_feeds": [
+            {
+              "feed_onestop_id": "f-dnrm-elonexpress"
+            },
+            {
+              "feed_onestop_id": "f-dnrm-elonexpress~rt"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "f-dnrm-elonexpress~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://passio3.com/elon/passioTransit/gtfs/realtime/vehiclePositions",
+        "realtime_trip_updates": "https://passio3.com/elon/passioTransit/gtfs/realtime/tripUpdates",
+        "realtime_alerts": "https://passio3.com/elon/passioTransit/gtfs/realtime/serviceAlerts"
+      }
+    },
+    {
+      "id": "f-dnq8-ninertransit",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://passio3.com/uncc/passioTransit/gtfs/google_transit.zip"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-dnq8-ninertransit",
+          "name": "UNC Charlotte",
+          "short_name": "Niner Transit",
+          "website": "https://pats.charlotte.edu/transportation/niner-transit-bus-service/",
+          "associated_feeds": [
+            {
+              "feed_onestop_id": "f-dnq8-ninertransit"
+            },
+            {
+              "feed_onestop_id": "f-dnq8-ninertransit~rt"
+            }
+          ],
+          "tags": {
+            "twitter_general": "CLT_PATS"
+          }
+        }
+      ]
+    },
+    {
+      "id": "f-dnq8-ninertransit~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://passio3.com/uncc/passioTransit/gtfs/realtime/vehiclePositions",
+        "realtime_trip_updates": "https://passio3.com/uncc/passioTransit/gtfs/realtime/tripUpdates",
+        "realtime_alerts": "https://passio3.com/uncc/passioTransit/gtfs/realtime/serviceAlerts"
+      }
+    },
+    {
       "id": "f-dnq9-ckrider~nc~us",
       "spec": "gtfs",
       "urls": {
@@ -285,7 +352,7 @@
         {
           "onestop_id": "o-dnq9-concordkannapolisareatransit",
           "name": "Concord Kannapolis Area Transit",
-          "short_name": "CKRider",
+          "short_name": "Rider",
           "website": "https://ckrider.com/",
           "associated_feeds": [
             {
@@ -369,11 +436,25 @@
           "name": "City of Jacksonville",
           "short_name": "Jacksonville Transit",
           "website": "https://www.jacksonvillenc.gov/921/Transit",
+          "associated_feeds": [
+            {
+              "feed_onestop_id": "f-dq0v-jacksonvilletransit~rt"
+            }
+          ],
           "tags": {
             "us_ntd_id": "40166"
           }
         }
       ]
+    },
+    {
+      "id": "f-dq0v-jacksonvilletransit~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://passio3.com/jacksonville/passioTransit/gtfs/realtime/vehiclePositions",
+        "realtime_trip_updates": "https://passio3.com/jacksonville/passioTransit/gtfs/realtime/tripUpdates",
+        "realtime_alerts": "https://passio3.com/jacksonville/passioTransit/gtfs/realtime/serviceAlerts"
+      }
     },
     {
       "id": "f-dq259-ncsu~wolfline~nc~us",
@@ -387,7 +468,8 @@
       "operators": [
         {
           "onestop_id": "o-dq259-ncsuwolfline",
-          "name": "NCSU Wolfline",
+          "name": "North Carolina State University",
+          "short_name": "Wolfline",
           "tags": {
             "twitter_general": "NCStateTranspo",
             "us_ntd_id": "40147",

--- a/feeds/wstransit.com.dmfr.json
+++ b/feeds/wstransit.com.dmfr.json
@@ -21,8 +21,7 @@
         }
       ],
       "tags": {
-        "us_ntd_id": "40012",
-        "wikidata_id": "Q00000000"
+        "us_ntd_id": "40012"
       }
     }
   ]


### PR DESCRIPTION
Adding feeds for UNC Charlotte and Elon University (per their websites, both are open to the community/visitors).

Adding realtime feeds for Jacksonville Transit in Jacksonville, NC.

Changing `short_name` for Concord Kannapolis Area Transit to "Rider" ([source](https://www.transit.dot.gov/sites/fta.dot.gov/files/transit_agency_profile_doc/2022/40167.pdf)).

Adding `short_name` attribute for NCSU Wolfline.

Removing inaccurate `Wikidata Entity ID` attribute from Winston-Salem Transit Authority (no Wikidata article found).