### PR TITLE
City of Avalon (California) no longer operates fixed-route transit

### DIFF
--- a/feeds/alerts.goswift.ly.dmfr.json
+++ b/feeds/alerts.goswift.ly.dmfr.json
@@ -77,21 +77,6 @@
       }
     },
     {
-      "id": "f-avalon~ca~rt~alerts",
-      "spec": "gtfs-rt",
-      "urls": {
-        "realtime_alerts": "https://api.goswift.ly/real-time/avalon/gtfs-rt-alerts"
-      },
-      "license": {
-        "url": "https://www.goswift.ly/api-license"
-      },
-      "authorization": {
-        "type": "header",
-        "param_name": "Authorization",
-        "info_url": "https://goswift.ly/realtime-api-key"
-      }
-    },
-    {
       "id": "f-baytowntrolley~fl~rt~alerts",
       "spec": "gtfs-rt",
       "urls": {

--- a/feeds/trilliumtransit.com.dmfr.json
+++ b/feeds/trilliumtransit.com.dmfr.json
@@ -5,28 +5,18 @@
       "id": "f-9mgve-avalon~ca~us",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/avalon-ca-us/avalon-ca-us.zip"
+        "static_historic": [
+          "https://data.trilliumtransit.com/gtfs/avalon-ca-us/avalon-ca-us.zip"
+        ]
       },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes"
+      "tags": {
+        "status": "archived"
       },
       "operators": [
         {
           "onestop_id": "o-9mgve-avalontransit",
           "name": "Avalon Transit",
           "website": "http://www.cityofavalon.com/transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "622"
-            },
-            {
-              "feed_onestop_id": "f-avalon~ca~rt"
-            },
-            {
-              "feed_onestop_id": "f-avalon~ca~rt~alerts"
-            }
-          ],
           "tags": {
             "twitter_general": "avalongov",
             "us_ntd_id": "90249"

--- a/feeds/tu-vp.goswift.ly.dmfr.json
+++ b/feeds/tu-vp.goswift.ly.dmfr.json
@@ -258,22 +258,6 @@
       }
     },
     {
-      "id": "f-avalon~ca~rt",
-      "spec": "gtfs-rt",
-      "urls": {
-        "realtime_vehicle_positions": "https://api.goswift.ly/real-time/avalon/gtfs-rt-vehicle-positions",
-        "realtime_trip_updates": "https://api.goswift.ly/real-time/avalon/gtfs-rt-trip-updates"
-      },
-      "license": {
-        "url": "https://www.goswift.ly/api-license"
-      },
-      "authorization": {
-        "type": "header",
-        "param_name": "Authorization",
-        "info_url": "https://goswift.ly/realtime-api-key"
-      }
-    },
-    {
       "id": "f-banning~pass~transit~rt",
       "spec": "gtfs-rt",
       "urls": {


### PR DESCRIPTION
thanks to https://github.com/transitland/transitland-atlas/pull/1161