### PR TITLE
Remove Metro North feed from NY Waterways operator

### DIFF
--- a/feeds/s3.amazonaws.com.dmfr.json
+++ b/feeds/s3.amazonaws.com.dmfr.json
@@ -31,10 +31,6 @@
           "website": "http://www.nywaterway.com",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "2",
-              "feed_onestop_id": "f-dr7-mtanyc~metro~north"
-            },
-            {
               "gtfs_agency_id": "NYW",
               "feed_onestop_id": "f-dr7-nywaterway"
             }


### PR DESCRIPTION
This ends up causing the transitland API to return unexpected operator data for MNR railroad routes.

The best explanation I can come up with is some connecting ferry services are listed here, even though that doesn't mean MNR is the operator: https://new.mta.info/agency/metro-north-railroad/connecting-services

Pulling the MNR GTFS feed, the `agency.txt` file only lists a single agency:

```
agency_id,agency_name,agency_url,agency_timezone,agency_phone,agency_lang
1,Metro-North Railroad,http://www.mta.info/mnr,America/New_York,212-532-4900,EN
```

So there is no agency `2` to be found in this feed, which means this should probably be cleaned up.

See these pages to get an idea of why things are a bit messy right now:
* https://www.transit.land/operators/o-dr7-nywaterway (shows MNR rail routes)
* https://www.transit.land/operators/o-dr7-metro~northrailroad (looks OK, also shows MNR rail routes)
* https://www.transit.land/operators/o-dr72w-metro~northrailroad (bus routes only?)

This at least should fix up the first two.