### PR TITLE
Update the mvv's url

### DIFF
--- a/feeds/mvv-muenchen.de.dmfr.json
+++ b/feeds/mvv-muenchen.de.dmfr.json
@@ -5,7 +5,10 @@
       "id": "f-u281z9-mvv",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.mvv-muenchen.de/fileadmin/mediapool/02-Fahrplanauskunft/03-Downloads/openData/mvv_ohneShape_20241004095702.zip"
+        "static_current": "https://www.mvv-muenchen.de/fileadmin/mediapool/02-Fahrplanauskunft/03-Downloads/openData/mvv_ohneShape_20241004095702.zip",
+        "static_historic": [
+          "https://www.mvv-muenchen.de/fileadmin/mediapool/02-Fahrplanauskunft/03-Downloads/openData/mvv_gtfs.zip"
+        ]
       },
       "languages": [
         "de-DE"
@@ -15,6 +18,9 @@
         "use_without_attribution": "no",
         "create_derived_product": "yes",
         "redistribution_allowed": "yes"
+      },
+      "tags": {
+        "unstable_url": "true"
       },
       "operators": [
         {

--- a/feeds/mvv-muenchen.de.dmfr.json
+++ b/feeds/mvv-muenchen.de.dmfr.json
@@ -5,7 +5,7 @@
       "id": "f-u281z9-mvv",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.mvv-muenchen.de/fileadmin/mediapool/02-Fahrplanauskunft/03-Downloads/openData/mvv_gtfs.zip"
+        "static_current": "https://www.mvv-muenchen.de/fileadmin/mediapool/02-Fahrplanauskunft/03-Downloads/openData/mvv_ohneShape_20241004095702.zip"
       },
       "languages": [
         "de-DE"


### PR DESCRIPTION
This fixes the MVVs URL being a 404.

This will need to be updated semi-regularly, to their new arbitrairy timestamp :sigh:

A bit older, but with shapes data exists here:
https://www.govdata.de/suche/daten/soll-fahrplandaten-mvv

Sadly, this is not listed on their website
=> idk what the timestamp is for the ones with shapes