### PR TITLE
fix automatic updates of Japanese feed list

### DIFF
--- a/.github/workflows/update-jp.yaml
+++ b/.github/workflows/update-jp.yaml
@@ -1,0 +1,49 @@
+name: Update GBFS
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * *'
+jobs:
+  scheduled:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        pip install pipenv
+        cd scripts && pipenv install
+    - name: Install transitland-lib
+      run: scripts/install-transitland-lib.sh
+    - name: Fetch latest data
+      run: |-
+        cd scripts && pipenv run python convert-jp-list-csv-to-dmfr.py
+    - name: Format in the opinionated DMFR format
+      run: |
+        find ./feeds -type f -name "*.dmfr.json" -exec transitland dmfr format --save {} \;
+    - name: Validate feeds
+      run: cd scripts && python validate-feeds.py
+    - name: "If any changes: Create a branch, commit, and PR"
+      run: |-
+        git config user.name "Automated Bot"
+        git config user.email "info@interline.io"
+        if ! git_status_output="$(git status --porcelain)"; then
+            error_code="$?"
+            echo "'git status' had an error: $error_code" 
+            exit 1
+        elif [ -z "$git_status_output" ]; then
+            echo "Working directory is clean."
+        else
+            echo "Working directory has UNCOMMITTED CHANGES."
+            BRANCH_NAME=gbfs-$(date +%F)
+            git checkout -b ${BRANCH_NAME}
+            git add -A
+            git commit -m "Updated Japanese feeds from This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv at $(date -u)"
+            git push --set-upstream origin ${BRANCH_NAME}
+            gh pr create --title "Automatic update of Japanese GTFS feeds" --fill-verbose
+            gh workflow run validate.yml --ref ${BRANCH_NAME}
+        fi
+      env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/feeds/tshimada291.github.com.dmfr.json
+++ b/feeds/tshimada291.github.com.dmfr.json
@@ -24,50 +24,6 @@
       }
     },
     {
-      "id": "f-10~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/10.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-11~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/11.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-12~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/12.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-131130~gtfs~jp~hachiko~bus~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.shibuya.tokyo.jp/assets/mng/131130_gtfs-jp_hachiko_bus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-133~jp",
       "spec": "gtfs",
       "urls": {
@@ -130,17 +86,6 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-13~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/13.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
       }
     },
@@ -219,13 +164,6 @@
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-20220621gtfs~dia~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.tokachibus.jp/download/20220621GTFS-dia.zip"
       }
     },
     {
@@ -346,17 +284,6 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-27miyawakaiizuka~gtfs~jp~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/341b6046-0030-4a78-a54d-87b1a1335563/resource/5627c6c0-533f-4d4a-926d-a60ec5c9d139/download/27miyawakaiizuka_gtfs-jp.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       }
     },
@@ -713,17 +640,6 @@
       }
     },
     {
-      "id": "f-5340001010554~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5340001010554"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-5360001014132~jp",
       "spec": "gtfs",
       "urls": {
@@ -742,17 +658,6 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-5~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/5.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
       }
     },
@@ -889,17 +794,6 @@
       }
     },
     {
-      "id": "f-9340001004024~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/9340001004024"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-9360001013023~jp",
       "spec": "gtfs",
       "urls": {
@@ -933,17 +827,6 @@
       }
     },
     {
-      "id": "f-9~1~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/9_1.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-9~2~jp",
       "spec": "gtfs",
       "urls": {
@@ -951,17 +834,6 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-abashirikankokotu~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://www.abashiri-kk.com/wp/wp-content/uploads/2019/11/abashirikankokotu.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       }
     },
@@ -985,17 +857,6 @@
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-akaiwa~gtfs~jp~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.akaiwa.lg.jp/material/files/group/5/GTFS.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
       }
     },
     {
@@ -1146,28 +1007,6 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.rosenzu.com/~gtfs/busnettsu/busnettsu_GTFS.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-bus~akitachuoukotsu~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-akita%20chuoukotsu.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-bus~akitacity~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.akita-bus.or.jp/gtfs_jp/bus-akitacity.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -1362,17 +1201,6 @@
       }
     },
     {
-      "id": "f-chutetsu~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://loc.bus-vision.jp/gtfs/chutetsu/gtfsFeed"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-city~hatsukaichi~jp",
       "spec": "gtfs",
       "urls": {
@@ -1410,17 +1238,6 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.city.takaoka.toyama.jp/joho/shise/opendata/documents/city_takaoka_gtfs.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
-      }
-    },
-    {
-      "id": "f-city~tonami~gtfs~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://opendata.pref.toyama.jp/files/city_tonami_gtfs.zip"
       },
       "license": {
         "spdx_identifier": "CC0-1.0",
@@ -1516,17 +1333,6 @@
       }
     },
     {
-      "id": "f-city~uozu~ainori~gtfs~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.uozu.toyama.jp/contents/busdata/city_uozu_ainori_gtfs.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
-      }
-    },
-    {
       "id": "f-city~uozu~shimin~gtfs~jp",
       "spec": "gtfs",
       "urls": {
@@ -1556,17 +1362,6 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-dentetsu~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://km.bus-vision.jp/gtfs/dentetsu/gtfsFeed"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       }
     },
@@ -1692,17 +1487,6 @@
       }
     },
     {
-      "id": "f-f0800103~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.tsukuba.lg.jp/_res/projects/default_project/_page_/001/018/463/GTFS.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-f1301702~jp",
       "spec": "gtfs",
       "urls": {
@@ -1780,17 +1564,6 @@
       }
     },
     {
-      "id": "f-flatbus~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://catalog-data.city.kanazawa.ishikawa.jp/dataset/1196beb4-f9f9-463c-9723-5b38d8127425/resource/191bd7bd-8e97-4919-b3ad-a87757993a79/download/172014-flatbus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-flower~liner~gtfs~jp",
       "spec": "gtfs",
       "urls": {
@@ -1824,32 +1597,10 @@
       }
     },
     {
-      "id": "f-fukuokasiei~tosen~gtfsfeeds~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.fukuoka.lg.jp/data/open/cnt/3/59675/1/fukuokasiei_tosen_GTFSfeeds.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-furano~bus~jp",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/3623aa5b-7d0b-4621-a3c8-b09e55863d27/download/furano_bus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-fureai~bus~gtfs~jp~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.town.kawagoe.mie.jp/wp-content/themes/kawagoecho/images/fureai_bus_gtfs-jp.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -1945,17 +1696,6 @@
       }
     },
     {
-      "id": "f-gtfsjp3~kamiyama~town~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2645/resource/7663/GTFSJP3_kamiyama-town.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-gtfsjp3~kitajima~town~jp",
       "spec": "gtfs",
       "urls": {
@@ -1971,17 +1711,6 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2672/resource/13799/GTFSJP3_matsushige.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfsjp3~minami~town~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2636/resource/7593/GTFSJP3_minami-town.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2132,17 +1861,6 @@
       }
     },
     {
-      "id": "f-gtfsjp~jrbus~localbus~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-JRbus_Localbus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-gtfsjp~konan~city~jp",
       "spec": "gtfs",
       "urls": {
@@ -2169,17 +1887,6 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Kuroiwa-Localbus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfsjp~kvca~my~yubus~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-KVCA_MY-YUbus.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2506,28 +2213,6 @@
       }
     },
     {
-      "id": "f-gtfs~0002~express~gma~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.0002.express.GMA.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~0003~lim~gma~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.0003.lim.GMA.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-gtfs~0211117~jp",
       "spec": "gtfs",
       "urls": {
@@ -2535,358 +2220,6 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1001~kanetsu~kotu~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1001.kanetsu_kotu.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1007~gunma~bus~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1007.gunma_bus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1017~yajima~taxi~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1017.yajima_taxi.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1018~shibukawashi~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1018.shibukawashi_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1019~maebashishi~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1019.maebashishi_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1020~takasakishi~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1020.takasakishi_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1021~numatashi~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1021.numatashi_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1022~minakamimachi~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1022.minakamimachi_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1024~tatebayashishi~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1024.tatebayashishi_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1025~kiryushi~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1025.kiryushi_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1026~isesakishi~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1026.isesakishi_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1027~otashi~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1027.otashi_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1028~fujiokashi~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1028.fujiokashi_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1029~tomiokashi~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1029.tomiokashi_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1030~annakashi~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1030.annakashi_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1031~midorishi~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1031.midorishi_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1034~uenomura~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1034.uenomura_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1036~shimonitamachi~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1036.shimonitamachi_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1037~nanmokumura~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1037.nanmokumura_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1038~nakanojomachi~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1038.nakanojomachi_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1040~gunma~takayamamura~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1040.gunma_takayamamura_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1041~higashiagatsumamachi~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1041.higashiagatsumamachi_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1042~kawabamura~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1042.kawabamura_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1043~showamura~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1043.showamura_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1048~oizumimachi~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1048.oizumimachi_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1049~oramachi~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1049.oramachi_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1051~joshin~kanko~bus~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1051.joshin_kanko_bus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1052~juo~jidousha~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1052.juo_jidousha.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1106~asahi~bus~gma~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1106.asahi_bus.GMA.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1115~seibu~kanko~gma~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1115.seibu_kanko.GMA.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~1302~jr~bus~kanto~gma~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1302.jr_bus_kanto.GMA.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~2002~kusakaru~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.2002.kusakaru.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       }
     },
@@ -2979,28 +2312,6 @@
       }
     },
     {
-      "id": "f-gtfs~eniwashi~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/5f05a49e-1bf0-4de3-918e-de6a1c6255b8/download/gtfs_eniwashi_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~hashikamicho~com~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://opendata.pref.aomori.lg.jp/dataset/1596/resource/16700/gtfs_hashikamicho_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
-      }
-    },
-    {
       "id": "f-gtfs~hekinan~jp",
       "spec": "gtfs",
       "urls": {
@@ -3078,43 +2389,10 @@
       }
     },
     {
-      "id": "f-gtfs~jp~gyoumu~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://www3.unobus.co.jp/opendata/GTFS-JP-GYOUMU.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
-      }
-    },
-    {
       "id": "f-gtfs~jp~kitamibus~jp",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://drive.google.com/uc?export=view&id=13MQ00Oq6pJgHpB2jz5nG1iay0fEyXpAj"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~jp~kitamibus~m~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://drive.google.com/uc?export=view&id=1Pekt6M8SaXCS4iX8Q8u-Q6pRBbKyeqqU"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~jp~nbaux~gunma~jp~gyomu~zip~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.nagai-unyu.net/rosen/GTFS/aux/GTFS-JP_nbaux-gunma-jp_gyomu.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3177,32 +2455,10 @@
       }
     },
     {
-      "id": "f-gtfs~kb~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.kotoden.co.jp/publichtm/gtfs/gtfsdata/gtfs_kb.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-gtfs~kd~jp",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.kotoden.co.jp/publichtm/gtfs/gtfsdata/latest/gtfs_kd.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~kochi~busterminal~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Kochi-BusTerminal.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3265,17 +2521,6 @@
       }
     },
     {
-      "id": "f-gtfs~ot~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ncb.jp/route/GTFS/GTFS(OT).zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-gtfs~regular~line~jp",
       "spec": "gtfs",
       "urls": {
@@ -3316,17 +2561,6 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-gtfs~shichinohecommunitybus~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://www.town.shichinohe.lg.jp/gtfs-ShichinoheCommunityBus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       }
     },
@@ -3400,17 +2634,6 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-hashimoto~gtfsjp~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://www.city.hashimoto.lg.jp/material/files/group/67/hashimoto_gtfsjp.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
       }
     },
@@ -3591,17 +2814,6 @@
       }
     },
     {
-      "id": "f-honjomochida~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://www.docodemo-bus.net/opendata/honjomochida.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-hurue~jp",
       "spec": "gtfs",
       "urls": {
@@ -3741,17 +2953,6 @@
       }
     },
     {
-      "id": "f-i~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.nishio.aichi.jp/_res/projects/default_project/_page_/001/003/763/i.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-joutetsu~jp",
       "spec": "gtfs",
       "urls": {
@@ -3760,6 +2961,20 @@
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-jr四国バス高知支店~大栃線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Jrbus_Localbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
@@ -3822,17 +3037,6 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.rosenzu.com/~gtfs/kaizu/kaizu_GTFS.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-kakobus~gtfs~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://opendata-api-kakogawa.jp/ckan/dataset/e6353d20-66e3-4d17-8cb4-dd91836d8195/resource/5773f858-07dc-4168-a2fc-0879ec273a84/download/_gtfs.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3928,17 +3132,6 @@
       }
     },
     {
-      "id": "f-keiseitransitbus~gtfs~jp~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://www.transitbus.co.jp/web/archive/KeiseiTransitBus_gtfs_jp.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-kibichuo~jp",
       "spec": "gtfs",
       "urls": {
@@ -3983,32 +3176,10 @@
       }
     },
     {
-      "id": "f-kitami~bus~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/ae0e85ab-b317-4acd-b982-2ceda019309f/download/kitami_bus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-kubikijidosha~jp",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://loc.bus-vision.jp/gtfs_v2/kubikijidosha/gtfsFeed"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-kumabus~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://km.bus-vision.jp/gtfs/kumabus/gtfsFeed"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4097,17 +3268,6 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://bus-vision.jp/gtfs_v2/kuwana/gtfsFeed"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-k~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.nishio.aichi.jp/_res/projects/default_project/_page_/001/003/763/k.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4335,17 +3495,6 @@
       }
     },
     {
-      "id": "f-m~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.nishio.aichi.jp/_res/projects/default_project/_page_/001/003/763/m.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-nabari~gtfs~jp",
       "spec": "gtfs",
       "urls": {
@@ -4445,17 +3594,6 @@
       }
     },
     {
-      "id": "f-namioka~current~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.aomori.aomori.jp/n-somu/documents/namioka_current.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-nanki~jp",
       "spec": "gtfs",
       "urls": {
@@ -4544,17 +3682,6 @@
       }
     },
     {
-      "id": "f-nishinihonjr~gtfs~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/supauq0zy11t8iqtqamnbyhqm0l8ylqt.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
-      }
-    },
-    {
       "id": "f-nishin~bus~jp",
       "spec": "gtfs",
       "urls": {
@@ -4581,17 +3708,6 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.rosenzu.com/~gtfs/nisshin/nisshin_GTFS.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-nomi~gtfs~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.nomi.ishikawa.jp/www/contents/1001000000402/simple/nomi_GTFS2021.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4643,17 +3759,6 @@
       }
     },
     {
-      "id": "f-obu~gtfs~current~data~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.obu.aichi.jp/_res/projects/default_project/_page_/001/017/133/obu-gtfs-current-data.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-oe~gtfs~jp",
       "spec": "gtfs",
       "urls": {
@@ -4694,17 +3799,6 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-okaden~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://loc.bus-vision.jp/gtfs/okaden/gtfsFeed"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       }
     },
@@ -4757,28 +3851,6 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/595f0db5-9e55-43a5-8b85-74c3edcd7da7/download/rankoshicho_com.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-rosen~bus~hakui~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.hakui.lg.jp/material/files/group/1/rosen_bus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-ryobi~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://loc.bus-vision.jp/gtfs/ryobi/gtfsFeed"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4841,17 +3913,6 @@
       }
     },
     {
-      "id": "f-sakata~gtfs~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/sakata_gtfs.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-sakegawa~gtfs~jp",
       "spec": "gtfs",
       "urls": {
@@ -4870,28 +3931,6 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-sankobus~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://km.bus-vision.jp/gtfs/sankobus/gtfsFeed"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-sansanbus~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://www.city.aichi-miyoshi.lg.jp/shisei/opendata/documents/sansanbus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       }
     },
@@ -4926,17 +3965,6 @@
       "license": {
         "spdx_identifier": "CC0-1.0",
         "use_without_attribution": "yes"
-      }
-    },
-    {
-      "id": "f-satukik~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.kani.lg.jp/secure/12816/satukik.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
       }
     },
     {
@@ -5127,17 +4155,6 @@
       }
     },
     {
-      "id": "f-shonaikotsu~gtfs~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/shonaikotsu_gtfs.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-shonai~gtfs~jp",
       "spec": "gtfs",
       "urls": {
@@ -5204,17 +4221,6 @@
       }
     },
     {
-      "id": "f-sotogahama~bus~gtfs~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://www.town.sotogahama.lg.jp/gyosei/jouhou/files/sotogahama_bus_gtfs.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-soya~bus~jp",
       "spec": "gtfs",
       "urls": {
@@ -5274,17 +4280,6 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.rosenzu.com/~gtfs/taketoyo/taketoyo_GTFS.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-takushoku~bus~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/3870b272-dabb-4527-9d51-67afc2c9a2d5/download/takushoku_bus.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -5391,32 +4386,10 @@
       }
     },
     {
-      "id": "f-tokachi~bus~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/9ad9de7f-73a9-4695-858f-c09cdf13437a/download/tokachi_bus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-toki~gtfs~jp",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.rosenzu.com/~gtfs/toki/toki_GTFS.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-toshibus~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://km.bus-vision.jp/gtfs/toshibus/gtfsFeed"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -5567,17 +4540,6 @@
       }
     },
     {
-      "id": "f-ugokotsu~data~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/ugokotsu_data.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-uzura~bus~jp",
       "spec": "gtfs",
       "urls": {
@@ -5596,17 +4558,6 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-wakayama~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://loc.bus-vision.jp/gtfs/wakayama/gtfsFeed"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       }
     },
@@ -5831,28 +4782,6 @@
       }
     },
     {
-      "id": "f-yao~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.kani.lg.jp/secure/12816/yao.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-yatsuka~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://www.docodemo-bus.net/opendata/yatsuka.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      }
-    },
-    {
       "id": "f-yk01~tsukinoki~jp",
       "spec": "gtfs",
       "urls": {
@@ -5982,6 +4911,4718 @@
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-あおい交通",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/aoi-komaki/feeds/aoikotsu/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-おおのハートバスささき観光",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/17/latest.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-ことでんバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.kotoden.co.jp/publichtm/gtfs/gtfsdata/latest/gtfs_kb.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-さかわ~おち花＊花ループバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Niyodoblue_Shuttlebus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-たつの市コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tatsunocity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-つくば市~つくバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsukubacity/feeds/TSUKUBUS/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-つくば市~筑波地区支線型バスつくばね号",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.tsukuba.lg.jp/material/files/group/126/GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-つくば市~筑波地区支線型バスつくばね号~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsukubacity/feeds/TSUKUBANEGO/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-つるぎ町コミュニティーバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsurugitown/feeds/tsurugitownbus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-とさでん交通~一般路線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Tosaden-Traffic_Regularbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-ふれあいバス大府市循環バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.obu.aichi.jp/_res/projects/default_project/_page_/001/017/133/bus/obu-gtfs-current-data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-みよし市~さんさんバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.aichi-miyoshi.lg.jp/shisei/opendata/documents/sansanbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-やんばる急行バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yanbaru-expressbus/feeds/yanbaru-express-bus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-バスネット津~ぐるっと~つーバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/busnet-tsu/feeds/guruttotsubus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-フォーブル",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/14/latest.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-フジエクスプレス港区ちぃばす",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gtfs.buskita.com/gtfs/fxc/gtfs.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-ボン~バスエイチ~ディー西広島",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/13/latest.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-マリックスライン~クイーンコーラルプラス~クイーンコーラル８",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.ottop.databed.org/transitfeed/9340001004024"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-マルエーフェリー~鹿児島航路~フェリーあけぼの",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.ottop.databed.org/transitfeed/5340001010554"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-七宗町営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hichisotown/feeds/choeibus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-七戸町コミュニティバス~シャトルバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.town.shichinohe.lg.jp/gtfs-ShichinoheCommunityBus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-万葉線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/manyosen/feeds/manyosen/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-三好市営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-miyoshicity/feeds/miyoshicitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-三条市循環バスぐるっとさん",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sanjocity/feeds/guruttosan/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-三沢市コミュニティバスみーばす",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.misawa.lg.jp/index.cfm/22%2C45535%2Cc%2Chtml/45535/GTFSJP3.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-上勝町営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kamikatsutown/feeds/kamikatsutownbus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-上山市営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaminoyamacity/feeds/KaminoyamaCity/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-上市町~上市町営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kamiichitown/feeds/kamiichi/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-上越市~名立区市営バス~東飛山線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/higashihiyama-line/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-上越市~大島区市営バス~旭線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/asahi-line/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-上越市~大島区市営バス~菖蒲線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/shobu-line/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-上越市~板倉区市営バス~上関田線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/kamisekida-line/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-上越市~板倉区市営バス~山寺薬師~菰立線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/yamaderayakushi-komodate-line/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-上越市~清里区市営バス~櫛池線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/kushiike-line/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-上越市~牧区市営バス~坪山線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/tuboyma-line/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-上越市~牧区市営バス~宇津俣線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/utsunomata-line/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-上越市~牧区市営バス~高谷~平山線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/takatani-tairayama-line/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-上越市~頸城区市営バス~大池線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/oike-line/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-上越市市営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/joetsu/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-上郡町~愛のり号",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kamigoritown/feeds/ainorigo/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-下仁田町~しもにたバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.town.shimonita.lg.jp/shimonita-bus/m01/gtfs.20230324.shimonita.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-下電バス下津井電鉄",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://shimoden.net/busmada/opendata/next/GTFS-JP.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-両備バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://loc.bus-vision.jp/gtfs/ryobi/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-中国ジェイアールバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/15/latest.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-中山町~町営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nakayamatown/feeds/NakayamaTown/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-中津川市コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nakatsugawacity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-中鉄バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://loc.bus-vision.jp/gtfs/chutetsu/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-丸亀市~丸亀コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/marugame-community/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-丹波篠山市~コミバスハートラン",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tambasasayamacity/feeds/communitybusheartrun/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-九州産交バス~産交バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://km.bus-vision.jp/gtfs/sankobus/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-亀の井バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/b9319381-3841-4a1c-a796-33e7953b193a/resource/8d18cbd7-eef0-48c6-9fa3-eae936d56f40/download/gtfs08_kamenoibus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-亀の井バス~高速バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/4e332c7a-3ac9-4c7a-a4b0-f78665e635da/resource/be2e8be4-44d1-4a85-aea6-78c8147f41c5/download/gtfs10_highway03kamenoi.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-二宮町コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ninomiyatown/feeds/Ninomiyatowncommunitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-京成トランジットバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/keisei-transitbus/feeds/keiseitransitbus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-仁淀川町民バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Niyodogawa-Town.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-伊勢市コミュニティバスおかげバス沼木バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/isecity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-伊勢鉄道",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/isetetu/feeds/iserailway/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-佐川町~さかわぐるぐるバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Sakawa-Town.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-佐用町~コミバス佐用",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sayotown/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-佐賀県内バス路線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://opendata.sagabus.info/saga-2023-07-01.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-備北交通",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/12/latest.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-入善町~入善町営バスのらんマイ~カー",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nyuzentown/feeds/noranmaicar/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-入善町~入善町営バスのらんマイ~カー県サイト掲載版",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/5e0royc3l3tun4vpjie0qmqpfbztj08n.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-函館帝産バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/e407ed56-37c0-4d70-92d6-0fdd3a05aac7/download/gtfs_hakodateteisanbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-加古川市~かこバス~かこバスミニ",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kakogawacity/feeds/kakobuskakobusmini/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-加古川市~かこバス~かこバスミニ市サイト版",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata-api-kakogawa.jp/ckan/dataset/e6353d20-66e3-4d17-8cb4-dd91836d8195/resource/5773f858-07dc-4168-a2fc-0879ec273a84/download/gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-加東市~社市街地乗合タクシー",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/katocity/feeds/yashiroshigaichinoriaitaxi/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-加能越バス~氷見市街地周遊バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunouhimi/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-加西市~kasaiねっぴ～号~はっぴーバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kasaicity/feeds/kasaineppihappybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-加越能バス~一般路線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunouippan/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-加越能バス~世界遺産バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunousekaiisan/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-勝央町ふれあいバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shootown/feeds/shoochofureaibus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-北九州市~おでかけ交通~小倉南区東谷地区",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.open-governmentdata.org/dataset/0ae9bb0b-9aea-40e6-9cdf-486b9421bf33/resource/55618aea-0a7a-472d-bc61-d54757d8b35a/download/401005_odekakekotsugtfs_higashitani.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-北島町福祉バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kitajimatown/feeds/kitajimatownfukushibus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-北恵那バス北恵那交通",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kitaena/feeds/kitaena/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-北振バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hokushin-bus/feeds/hokushinbus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-北海道北見バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/ae0e85ab-b317-4acd-b982-2ceda019309f/download/kitami_bus-1.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-北海道拓殖バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/3870b272-dabb-4527-9d51-67afc2c9a2d5/download/gtfs_takushoku_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-北海道拓殖バス~一般路線コミュニティバス音更町~新得町~清水町",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.takubus.com/app/download/11236187979/GTFS_regular_line20230526.zip?t=1685093868"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-北海道拓殖バス~都市間高速バス~帯広空港連絡バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.takubus.com/app/download/11238066179/GTFS_highway_line20230601.zip?t=1685428757"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-十勝バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/9ad9de7f-73a9-4695-858f-c09cdf13437a/download/20211121gtfs-dia.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-十勝バス~一般路線コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.tokachibus.jp/download/20221205GTFS-dia.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-南あわじ市コミュニティバス~らん~らんバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/minamiawajicity/feeds/lanrunbus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-南伊勢町~町営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/minamiisetown/feeds/choeibus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-南砺市~なんバス南砺市営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/u4kmkwax5vbrctr2rshqkh1wzyx6qr9u.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-南砺市~なんバス南砺市営バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nantocity/feeds/nanbus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-南陽市~市内循環バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nanyocity/feeds/NanyoCity/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-可児市~yaoバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.kani.lg.jp/secure/12816/202303_yao_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-可児市~さつきバス~ｋバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.kani.lg.jp/secure/12816/202210_satuki_K_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-吉野川市代替バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yoshinogawacity/feeds/yoshinogawacitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-名張市コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nabaricity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-名鉄東部交通バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiocity/feeds/meitestu_tobu/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-名阪近鉄バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ogakicity/feeds/meihankintetsubus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-呉市~生活バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/18/latest.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-和歌山バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://loc.bus-vision.jp/gtfs/wakayama/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-和気町営バスわけまろ号",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/waketown/feeds/wakechoueibasu/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-四国交通~四交",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2651/resource/7652/source-url"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-四国交通~四交~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yonkoh/feeds/shikokukoutsuu/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-国東観光バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/53ed44a0-0507-4002-aa9e-c4421d290dd4/resource/5469eca7-e04b-4fba-8cdd-208a4538a7e9/download/gtfs05_kunisakikanko.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-土岐市~市民バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokicity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-土浦市~つちまるバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuchiuracity/feeds/tsuchimarubus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-大交北部バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/1e5193a5-c771-419a-9e7a-903d45ced2f3/resource/dd886eca-3abb-4244-a866-a62f676ccb83/download/gtfs07_daikohokubu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-大分バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/6b8c3167-971c-4c3c-ab84-4eae561be553/resource/9c3c2dbb-493a-40be-991d-44923919908c/download/gtfs01_oitabus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-大分バス~高速バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/4e332c7a-3ac9-4c7a-a4b0-f78665e635da/resource/5713d7c2-b881-48e6-86b8-ed4eb0e9006f/download/gtfs10_highway01oitabus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-大分交通",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/09f3116a-418d-42be-9bd5-4d395c7b3467/resource/899d5ccc-75ee-48a8-bc96-e241a6a0c0cd/download/gtfs04_oitakotsu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-大分交通~高速バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/4e332c7a-3ac9-4c7a-a4b0-f78665e635da/resource/3ece7365-9739-4c5d-92a8-f008922325ff/download/gtfs10_highway02oitakotsu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-大月町~まちなか循環線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Otsuki-Town.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-大江町営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/oetown/feeds/Oetown/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-大泉町~千代田町~広域公共バスあおぞら",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/oizumitown/feeds/kouikikoukyoubasuaozora/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-大蔵町~肘折ゆけむりライン",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ohkuravillage/feeds/OhkuraVillage/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-大野竹田バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/82f8e394-562d-4ccf-b279-cf31e2454d13/resource/c9321261-fa35-434a-8a6a-ad0c992b1194/download/gtfs02_oonotaketabus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-天童市~市営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tendocity/feeds/TendoCity/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-姫路市コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/himejicity/feeds/ieshima-boze-yukihiko/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-宇野バス宇野自動車",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/UnoBus/AllLines.zip?date=current"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-宇野バス宇野自動車~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/UnoBus/AllLines.zip?date=next"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-宇野バス宇野自動車~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/UnoBus/AllLines.zip?date=latest"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-安城市~あんくるバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/anjocity/feeds/AnkuruBus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-安芸市観光シャトルバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Aki-Shuttlebus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-宍粟市~しーたんバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shisocity/feeds/shitanbus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-宝塚市~ランランバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/takarazukacity/feeds/runrunbus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-宮若市~飯塚市共同運行コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/341b6046-0030-4a78-a54d-87b1a1335563/resource/93fa1f38-d6d2-45bf-a774-56e1c3856494/download/230315miyawakaiizuka_gtfs-jp.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富士急バス富士五湖と甲府市周辺~山梨県東部エリア",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gtfs.buskita.com/gtfs/fjb/gtfs.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富士急モビリティ御殿場市~裾野市~小山町周辺エリア",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gtfs.buskita.com/gtfs/fmo/gtfs.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富士急湘南バス神奈川県西部エリア",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gtfs.buskita.com/gtfs/fsy/gtfs.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山地鉄バス富山地方鉄道",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/chitetsu/feeds/chitetsubus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山地鉄市内電車",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/chitetsu/feeds/chitetsushinaidensha/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~まいどはやバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/maidohayabus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~まいどはやバス県サイト",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/bcca7lwesg58h55hbg8rxgrhh34thn8h.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~八尾コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/yatsuocommunitybus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~八尾コミュニティバス県サイト",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/x2i6f55uhgavm2f8vcsneyo68bazl1sn.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~呉羽いきいきバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/kurehaikiikibus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~呉羽いきいきバス県サイト",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/9ivamh4rfhcseya2ngpj143qq5c1mv24.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~堀川南地域コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/horikawaminamicommunitybus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~堀川南地域コミュニティバス県サイト",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/fy7q87srgu0a7r3cwuugahucqkpyezsj.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~大山コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/oyamacommunitybus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~大山コミュニティバス県サイト",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/nxd5vxqnlur54ak0mkoi2p8qt8lcrtvn.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~婦中コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/fuchucommunitybus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~婦中コミュニティバス県サイト",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/aapqh2kbpttozqrhoscbjap43kez7dow.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~山田コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/yamadacommunitybus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~山田コミュニティバス県サイト",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/lbkdalq5p8wzy1szvrhmye8otage9q8h.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~水橋ふれあいコミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/mizuhashifureaicommunitybus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~水橋ふれあいコミュニティバス県サイト",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/b724alggd7nnfmscvra8e8qjf0hq85r2.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-寒河江市内循環バススマイル号",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sagaecity/feeds/SagaeCity/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-射水市~きときとバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/imizucity/feeds/imizushi/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-小国町営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-ogunitown/feeds/OguniTown/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-小矢部市~小矢部市営バスメルバス~乗合タクシー",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/8xvzsmuxou6kj8moe999t5r0dah953ov.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-小矢部市~小矢部市営バスメルバス~乗合タクシー~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/oyabecity/feeds/oyabecitybus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-小豆島オリーブバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/ShodoshimaOliveBus/AllLines.zip?date=current"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-小豆島オリーブバス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/ShodoshimaOliveBus/AllLines.zip?date=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-小豆島オリーブバス~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/ShodoshimaOliveBus/AllLines.zip?date=latest"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-小野市コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-ono/feeds/ranranbus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-小野市コミュニティバス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-ono/feeds/ranranbus/files/feed.zip?rid=current"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-尾花沢市路線バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/obanazawacity/feeds/ObanazawaCity/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-山交バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamakobus/feeds/YAMAKOBUS/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-山形市~ベニちゃんバスコミュニティバス高瀬線地域交流バス南部線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-yamagatacity/feeds/YamagataCity/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-山形鉄道",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/flower-liner_gtfs_1.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-山辺町~やまのべコミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamanobetown/feeds/YamanobeTown/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-岡垣コミュニティバスふれあい",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/18581c45-386a-4ddf-b60d-526e43e41046/resource/d8a94e2c-23eb-40d2-b4d1-e822e34e8dea/download/gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-岡電バス岡山電気軌道",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://loc.bus-vision.jp/gtfs/okaden/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-岩国市生活交通バス~由宇地区バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://yamaguchi-opendata.jp/ckan/dataset/2dbaeb43-5134-4880-90a3-62870504f1d3/resource/31d5dd9c-113c-4fc5-bfa6-31d832f830fc/download/352080_gtfs-jp.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-島田市コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shimadacity/feeds/shimada_combus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-川越町~ふれあいバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.town.kawagoe.mie.jp/wp-content/themes/kawagoecho/images/hureaibus202208.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-市川町コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ichikawatown/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-広島バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/9/latest.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-広島交通~広交観光",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/10/latest.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-広電バス広島電鉄",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/8/latest.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-庄内交通",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/syonaikotsu_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-庄内交通~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shonaikotsu/feeds/SHONAIKOTSU/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-庄内町~町営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shonaitown/feeds/ShonaiTown/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-度会町~町営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/wataraitown/feeds/choeibus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-廿日市市~自主運行バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/19/latest.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-徳島バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus/feeds/tokushimabus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-徳島バス南部",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus-nanbu/feeds/tokushimabusnanbu/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-徳島バス阿南",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus-anan/feeds/tokushimabusanan/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-徳島市~上八万コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushimacity/feeds/kamihachimanbus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-徳島市~応神ふれあいバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushimacity/feeds/oujinfureaibus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-徳島市営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2649/url_resource/66/GTFS-JP.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-徳島市営バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-shiei/feeds/tokushimacitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-恵庭市コミュニティ",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/5f05a49e-1bf0-4de3-918e-de6a1c6255b8/download/_gtfs-jp_202141_20211115131545-1.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-恵那市自主運行バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/enacity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-掛川市自主運行バス~市街地循環線北回りジーネット",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/66108/shigaichijyunkan-kita202304.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-掛川市自主運行バス~市街地循環線北回りジーネット~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/65791/shigaichijyunkan-kita.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-掛川市自主運行バス~掛川大須賀線ジーネット",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/65789/kakegawaosuka.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-掛川市自主運行バス~掛川大須賀線ジーネット~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/66106/kakegawaosuka202304.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-掛川市自主運行バス~桜木線~居尻線~倉真線~東山線~粟本線~市街地循環線南回り掛川バスサービス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/65790/sakuragi.ijiri.kurami.higashiyama.awamoto.shigaichijyunkan-minami.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-掛川市自主運行バス~桜木線~居尻線~倉真線~東山線~粟本線~市街地循環線南回り掛川バスサービス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/66109/sakuragi.ijiri.kurami.higashiyama.awamoto.shigaichijyunkan-minami202304.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-揖斐川町~ふれあいバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ibigawatown/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-新庄市~市営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shinjocity/feeds/ShinjoCity/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-新温泉町~町民バス夢つばめ",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shinonsentown/feeds/yumetsubame/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-日光市営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nikkocity/feeds/nikkocity/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-日本中央バス前橋近郊路線空港バス高速バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Maebashi_Area.zip?date=current"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-日本中央バス前橋近郊路線空港バス高速バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Maebashi_Area.zip?date=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-日本中央バス前橋近郊路線空港バス高速バス~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Maebashi_Area.zip?date=latest"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-日本中央バス奥多野線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ncb.jp/route/GTFS/latest/GTFS(OT).zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-日本中央バス奥多野線~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Okutano_Area.zip?date=current"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-日本中央バス奥多野線~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Okutano_Area.zip?date=latest"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-日田バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/2dcbcc0d-6fbb-4c6b-9790-2f54ed41bf4f/resource/e37c6f56-ed8b-4032-a91f-4fc24639a18e/download/gtfs09_hitabus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-日田バス~高速バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/4e332c7a-3ac9-4c7a-a4b0-f78665e635da/resource/17806124-f3bd-4146-b276-675133184953/download/gtfs10_highway04hita.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-日進市巡回バス~くるりんばす",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nisshincity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-日野町営バス県ポータル",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/e3f3ad12-171c-442b-95b5-896f4b50e5a7/resource/e431dddb-dc3a-4699-b570-9d77043306fa/download/gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-早島町コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hayashimatown/feeds/hayashimatowncommunitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-明知鉄道",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/aketetsu/feeds/akechirailway/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-明石市~たこバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/akashicity/feeds/tacobustacobusmini/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-最上川交通",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/mogamigawakotsu/feeds/MOGAMIGAWAKOTSU/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-朝日町~あさひまちバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyama-asahitown/feeds/asahimachibus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-朝日町路線バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-asahitown/feeds/AsahiTown/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-朝来市コミュニティバスアコバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/asagocity/feeds/acobus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-村山市~市営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/murayamacity/feeds/MurayamaCity/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-東みよし町営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/higashimiyoshitown/feeds/hitashimiyoshitownbus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-東京都町田市~コミュニティバス市民バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/MachidaCity/AllLines.zip?date=current"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-東京都町田市~コミュニティバス市民バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/MachidaCity/AllLines.zip?date=next"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-東京都町田市~コミュニティバス市民バス~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/MachidaCity/AllLines.zip?date=latest"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-東根市~市民バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/higashinecity/feeds/HigashineCity/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-東浦町運行バスう~ら~ら",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/higashiuratown/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-東鉄バス東濃鉄道",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tohtetsu/feeds/tohtetsu_ena/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-松江市コミュニティバス~本庄~持田コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.docodemo-bus.net/opendata/honjo-mochida.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-松茂町地域コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/matsushigetown/feeds/matsushigetownbus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-松阪市コミュニティ交通",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/matsusakacity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-桐生市~おりひめバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.kiryu.lg.jp/_res/common/opendata/1014528/20230320_kiryu_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-桑名市~k-バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kuwanacity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-横須賀市~ハマちゃんバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yokosukacity/feeds/hamachanbus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-橋本市コミュニティバス~デマンドタクシー",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.hashimoto.lg.jp/material/files/group/67/hashimoto_gtfsjp.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-武豊町ゆめころん",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/taketoyotown/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-永井バス永井運輸",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.nagai-unyu.net/rosen/GTFS/aux/latest/GTFS-JP_nbaux-gunma-jp.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-永井バス永井運輸~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/AllLines.zip?date=current"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-永井バス永井運輸~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/AllLines.zip?date=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-永井バス永井運輸~3",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/AllLines.zip?date=latest"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-永井バス永井運輸~4",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagai-unyu/feeds/Nagaibus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-永井バス永井運輸独自拡張版gtfs",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.nagai-unyu.net/rosen/GTFS/aux/latest/GTFS-JP_nbaux-gunma-jp_gyomu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-河北町路線バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kahokutown/feeds/KahokuTown/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-津山市~市営阿波バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuyamacity/feeds/bus-tsuyamacity-okayama-jp/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-津市コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsucity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-洲本市コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sumotocity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-流山市~流山ぐりーんバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagareyamacity/feeds/nagareyamagreenbus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-浪岡地区コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.aomori.aomori.jp/n-somu/documents/namiokabus_current.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-海津市コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaizucity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-海陽町営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaiyotown/feeds/kaiyotownbus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-淡路市~あわ神あわ姫バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/awajicity/feeds/awajinawahimebus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-滑川市~のる~my~car",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/jpxqjqmxqrbu47o2f45i84f3m43qkxzi.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-滑川市~のる~my~car~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/namerikawacity/feeds/norumycar/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-濃飛バス一般路線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nouhibus/feeds/nouhibus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-濃飛バス観光路線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nouhibus/feeds/nouhibus_kanko/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-濃飛バス高山周遊バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nouhibus/feeds/takayama_shuyu/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-熊本バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://km.bus-vision.jp/gtfs/kumabus/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-熊本市電",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kumamoto-shiden/feeds/kumamotoshiden/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-熊本都市バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://km.bus-vision.jp/gtfs/toshibus/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-熊本電鉄バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://km.bus-vision.jp/gtfs/dentetsu/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-猪名川町~ふれあいバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/inagawatown/feeds/fureaibus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-玉村町乗合タクシー~たまりん",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.nagai-unyu.net/rosen/GTFS/tamarin/latest/GTFS-JP_tamarin-gunma-jp.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-玉村町乗合タクシー~たまりん~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/Tamarin.zip?date=current"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-玉村町乗合タクシー~たまりん~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/Tamarin.zip?date=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-玉村町乗合タクシー~たまりん~3",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/Tamarin.zip?date=latest"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-玉村町乗合タクシー~たまりん~4",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagai-unyu/feeds/tamarin/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-玖珠観光バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/b90a15f4-9680-4b7c-bcf9-d510d426e210/resource/d99bc99a-4358-4eab-af68-b140c12477a0/download/gtfs06_kusukanko.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-琴参バス坂出営業所",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/sakaide-local/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-琴参バス琴平営業所",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/kotohira-local/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-瑞浪市コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/mizunamicity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-生活バスよっかいち",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/seikatsubus-yokkaichi/feeds/sbusyokkaichi/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-由布市コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/bf767ad7-4651-42f8-a9b1-78874542e046/resource/9b537213-f309-4116-9952-53050ea768ba/download/gtfs11_combus13_yufu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-男鹿市内路線バス全路線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.oga.akita.jp/material/files/group/2/bus-ogacity.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-白山市コミュニティバスめぐーる",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hakusancity/feeds/hakusan_bus_meguru/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-白鷹町~町営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shiratakatown/feeds/ShiratakaTown/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-真室川町路線バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/mamurogawatown/feeds/MamurogawaTown/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-石巻市~住民バス~市民バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://miyagi.dataeye.jp/resource_download/340"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-砺波市~砺波市営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/70l7nwf33az6y13k4hzyc1gw679enkss.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-砺波市~砺波市営バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tonamicity/feeds/tonamishieibasu/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-磐田市生活路線バス浜松バス~掛塚磐田駅線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hamabus/feeds/iwata_seikatsubus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-神戸市垂水区~塩屋コミュニティバスしおかぜ",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kobecity/feeds/kobe-shiokaze/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-神河町コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-kamikawatown/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-福崎町コミュニティバス巡回バスふくひめ号福崎町~加西市連携コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/fukusakitown/feeds/junkai-fukuhime-fukusakikasairenkei/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-秋北バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-shuhokubus202304.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-秋田中央交通",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-akitachuoukotsu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-秋田市マイタウン~バス中心市街地循環バスぐるる県バス協会掲載版",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-akitacity.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-秋田市マイタウン~バス中心市街地循環バスぐるる県バス協会掲載版~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/next/bus-akitacity.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-立山町~立山町営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tateyamatown/feeds/tateyama/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-立山町~立山町営バス県サイト",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/8u3d410n3ioow5juxkce2ocg0vynisw7.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-竹富島交通",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/4360002021665"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-竹田市コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/bf767ad7-4651-42f8-a9b1-78874542e046/resource/0f39370a-d524-43f1-998b-d59c87c4e9ae/download/gtfs11_combus08_taketa.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-笠松町公共施設巡回町民バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kasamatsutown/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-米沢市~市民バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yonezawacity/feeds/Yonezawa/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-紀宝町民バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/kiho/kiho_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-網走バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.abashiribus.com/open_data/gtfs_abashiribus_latest.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-美波町~美波病院連絡バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2636/resource/7707/GTFSJP3_minami-town_20220601.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-美波町~美波病院連絡バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-minamitown/feeds/minabubyoinrenrakubus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-美濃加茂市コミュニティバスあい愛バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/minokamocity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-群馬中央バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/GunmachuoBus/AllLines.zip?date=current"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-群馬中央バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/GunmachuoBus/AllLines.zip?date=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-群馬中央バス~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/GunmachuoBus/AllLines.zip?date=latest"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-羽咋市~市内循環バスるんるんバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.hakui.lg.jp/material/files/group/2/GTFS20230401.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-羽後交通",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/ugo-bus-jp.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-能美市~のみバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.nomi.ishikawa.jp/www/contents/1683514558086/simple/GTFS_nomi_20230401.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-臼杵市コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/bf767ad7-4651-42f8-a9b1-78874542e046/resource/95513da5-7317-4b97-911a-5df29d387900/download/gtfs11_combus06_usuki.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-臼津交通",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/af52f355-1e78-405c-9d89-9df309bbb30f/resource/76e548c5-617e-4273-81f7-23499ec3aafe/download/gtfs03_kyushinkotsu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-芸陽バス広島県バス協会サイト掲載版",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/11/latest.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-藤岡市~めぐるん",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.fujioka.gunma.jp/material/files/group/7/fujiokaGTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-西宮市~さくらやまなみバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinomiyacity/feeds/sakurayamanami/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-西宮市コミュニティ交通ぐるっと生瀬",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinomiyacity/feeds/guruttonamaze/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-西尾市~いっちゃんバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiocity/feeds/ichanbus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-西尾市~六万石くるりんバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiocity/feeds/rokumangokukururinbus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-西川町路線バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishikawatown/feeds/NishikawaTown/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-西日本ジェイアールバス~名金線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinihonjrbus/feeds/meikinsen/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-西脇市コミュニティバスループバスめぐリンおりひめバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiwakicity/feeds/loopbus-orihimebus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-豊山町~とよやまタウンバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyoyamatown/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-豊岡市~市営バスイナカー",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyookacity/feeds/inacar/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-豊岡市~市街地循環バスコバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyookacity/feeds/kobus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-豊田市~とよたおいでんバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyotacity/feeds/kikanbus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-豊田市~地域バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyotacity/feeds/chiikibus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-赤磐市広域路線バス~市民バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.akaiwa.lg.jp/material/files/group/5/GTFS-JP.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-赤磐市広域路線バス~市民バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AkaiwaCity/AllLines.zip?date=current"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-赤磐市広域路線バス~市民バス~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AkaiwaCity/AllLines.zip?date=next"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-赤磐市広域路線バス~市民バス~3",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AkaiwaCity/AllLines.zip?date=latest"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-赤穂市~市内循環バスゆらのすけ",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/akocity/feeds/yuranosuke/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-那賀町営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nakatown/feeds/nakatownbus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-酒田市~るんるんバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sakatacity/feeds/SakataCity/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-金山町町営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-kaneyamatown/feeds/KaneyamaTown/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-金沢ふらっとバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://catalog-data.city.kanazawa.ishikawa.jp/dataset/1196beb4-f9f9-463c-9723-5b38d8127425/resource/191bd7bd-8e97-4919-b3ad-a87757993a79/download/20230401.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-長井市営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagaicity/feeds/NagaiCity/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-長岡市~小国地域生活交通~八王子線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-10.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-長岡市~小国地域生活交通~大貝線オーケーバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-09.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-長岡市~小国地域生活交通~法末線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-11.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-長岡市~山古志地域クローバーバス~小千谷線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-06.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-長岡市~山古志地域クローバーバス~小松倉線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-08.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-長岡市~山古志地域クローバーバス~村松線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-05.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-長岡市~山古志地域クローバーバス~種苧原線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-07.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-長岡市~川口地域バス上川線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-12.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-長岡市~川口地域バス木沢~和南津線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-14.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-長岡市~川口地域バス西川口~田麦山線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-13.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-関越交通",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://kan-etsu.net/relays/download/193/2807/433//?file=/files/libs/11049/202305261450561282.zip&file_name=GTFS-JP(kan-etsu)"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-阿佐海岸鉄道",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/asatetu/feeds/asakaigantetsudo/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-階上町コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.aomori.lg.jp/dataset/1596/resource/16908/gtfs_hashikamicho_com.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-階上町コミュニティバス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.aomori.lg.jp/dataset/1596/resource/19655/gtfs_hashikamicho_com_latest.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-青森市営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AomoriCity/AllLines.zip?date=current"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-青森市営バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AomoriCity/AllLines.zip?date=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-青森市営バス~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AomoriCity/AllLines.zip?date=latest"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-飛騨市おでかけバスひだまる",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hidacity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-養父市コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yabucity/feeds/waiwai-sekimiya-yoka/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-香美町~町民バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-kamitown/feeds/kamichominbus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-高岡市~高岡市公営バス福岡地域",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/takaokacity/feeds/koueibus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-高岡市~高岡市公営バス福岡地域県サイト",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/hjzzrbhbq92r7qli46ygb4qjci7030gy.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-高崎市内循環バスぐるりん~高崎アリーナシャトルバス~よしいバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.takasaki.gunma.jp/docs/2020060400037/files/bus-takasaki-gunma-jp_20230414.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-高知観光コンベンション協会~my遊バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-KVCA_MY-Yubus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-高砂市~じょうとんバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/takasagocity/feeds/jotonbus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-魚津市~予約式あいのりタクシー~おもてなし魚津直行便",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.uozu.toyama.jp/attach/EDIT/062/062570.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-魚津市~予約式あいのりタクシー~おもてなし魚津直行便~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/glzk70eid2g89z8zos927s4emfxdvni4.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-魚津市~予約式あいのりタクシー~おもてなし魚津直行便~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/uozucity/feeds/omotenashi/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-魚津市~魚津市民バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/na9rrq16urut58g79ba13bil9ig1m9rh.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-魚津市~魚津市民バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/uozucity/feeds/junkai/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-鮭川村村営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sakegawavillage/feeds/SakegawaVillage/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-鳥羽市~かもめバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tobacity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-鳥羽市~市営定期船",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tobacity/feeds/teikisen/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-鳴門市営渡船",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/narutocity/feeds/narutocitytosen/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-鳴門市地域バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/narutocity/feeds/narutocitychiikibus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-鶴岡市~羽黒地域市営バス朝日地域市営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/tsuruoka_gtfs_1.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-鶴岡市~羽黒地域市営バス朝日地域市営バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuruokacity/feeds/TsuruokaCity/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-鹿児島市コミュニティバスあいばす",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kagoshimacity/feeds/aibus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-鹿沼市~リーバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kanumacity/feeds/ri-bus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-黒部市~市内路線バス新幹線生地線",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/y8rvyr2h3dtbz1tu0c2hm78teuvwqwcy.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-黒部市~市内路線バス新幹線生地線~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kurobecity/feeds/shinkansenikujisen/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-黒部市~市内路線バス石田三日市線~愛本コミュニティタクシー",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/3vqbuvgk41hq3k47bf8b5iit989vrbbl.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-黒部市~市内路線バス石田三日市線~愛本コミュニティタクシー~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kurobecity/feeds/ishida-aimoto/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     }
   ],

--- a/feeds/tshimada291.github.com.dmfr.json
+++ b/feeds/tshimada291.github.com.dmfr.json
@@ -2,6 +2,2968 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
   "feeds": [
     {
+      "id": "f-0360005005779~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/360005005779"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-1000020472093~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/1000020472093"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-133~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.sano.lg.jp/material/files/group/17/133.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-1360001007585~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/1360001007585"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-1360002020959~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/1360002020959"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-1360003002626~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/1360003002626"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-1360003005018~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/1360003005018"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-1360003007856~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/1360003007856"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-14~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/14.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-16~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/16.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-18~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/18.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-1~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/1.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-2000020473537~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/2000020473537"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-2000020473545~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/2000020473545"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-2000020473553~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/2000020473553"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-20~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/20.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-21~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/21.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-22~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/22.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-232025~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.okazaki.lg.jp/1550/1553/208000/p015630_d/fil/232025_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-2360001000457~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/2360001000457"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-2360001013046~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/2360001013046"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-2360001015810~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/2360001015810"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-2360003002575~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/2360003002575"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-2360003005256~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/2360003005256"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-23~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/23.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-24~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/24.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-29~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/29.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-2~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/2.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-3000020472158~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/3000020472158"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-3360002008754~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/3360002008754"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-342114~gtfs~01koikoi~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://hiroshima-opendata.dataeye.jp/resource_download/10045"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-342114~gtfs~02kuritani~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://hiroshima-opendata.dataeye.jp/resource_download/10046"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-342114~gtfs~03sakaue~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://hiroshima-opendata.dataeye.jp/resource_download/10047"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-4000020473031~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/4000020473031"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-4000020473618~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/4000020473618"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-4000020473758~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/4000020473758"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-401005~odekakekotsugtfs~edamitsu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.open-governmentdata.org/dataset/468dc771-10a2-4bab-aad2-191b0fdaffa0/resource/bdbf46fd-870b-4064-9e7f-7bcedf97b526/download/401005_odekakekotsugtfs_edamitsu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-401005~odekakekotsugtfs~hiraodai~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.open-governmentdata.org/dataset/6d3d2393-ed7b-46eb-9340-dfb45ffc279d/resource/7ea49d9e-be72-4e86-849e-d160ae45bd3c/download/401005_odekakekotsugtfs_hiraodai.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-401005~odekakekotsugtfs~koyanosekusubashihoshigaoka~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.open-governmentdata.org/dataset/e3689c3c-d7e4-40a8-9d21-89aa95311bb8/resource/6185c93d-76cd-4287-a306-428216f7a285/download/401005_odekakekotsugtfs_koyanosekusubashihoshigaoka.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-401005~odekakekotsugtfs~okura~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.open-governmentdata.org/dataset/950b03df-5142-4f34-b976-43dad98a9540/resource/91059af4-fc56-45e1-8ecd-fd4bcb5e2df1/download/401005_odekakekotsugtfs_okura.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-401005~odekakekotsugtfs~omadobaru~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.open-governmentdata.org/dataset/ccbc3e6b-d85f-4541-8d6f-2c40d065f836/resource/8d32347f-00a4-497c-b88e-51f413b4b49e/download/401005_odekakekotsugtfs_omadobaru.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-401005~odekakekotsugtfs~tashirokawachi~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.open-governmentdata.org/dataset/42e62bc8-cfe8-4f66-9e89-decffff56f23/resource/41dfa7d1-cb07-47b4-b509-5fcbe5c79765/download/401005_odekakekotsugtfs_tashirokawachi.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-401005~odekakekotsugtfs~tsunemikitaku~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.open-governmentdata.org/dataset/6d387baa-dcfd-431d-a229-13b8670e07bf/resource/eaa79093-a1f8-4dbe-9bfd-ca7183419c72/download/401005_odekakekotsugtfs_tsunemikitaku.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-402257~ukihabasu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/be02305f-43ab-40b7-b8e2-1d460f5756d1/resource/2aa2b7c6-2671-472f-87f2-b6e5cc06e2e2/download/402257_ukihabasu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-402303tosengtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/2a380e2b-f584-425b-9385-24926b328296/resource/53252038-b26e-49c1-9de1-1fec6811e01a/download/402303tosengtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-4360001000447~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/4360001000447"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-4360001000835~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/4360001000835"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-4360002020964~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/4360002020964"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-4~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/4.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-5000020472107~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5000020472107"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-5000020472115~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5000020472115"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-5000020472131~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5000020472131"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-5000020473014~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5000020473014"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-5000020473154~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5000020473154"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-5000020473278~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5000020473278"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-5000020473286~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5000020473286"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-5000020473600~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5000020473600"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-5290801024676~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5290801024676"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-5360001014132~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5360001014132"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-5360003005096~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5360003005096"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-6360001013190~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/6360001013190"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-6360002013009~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/6360002013009"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-6360003005178~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/6360003005178"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-63~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/63.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-7000020473243~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/7000020473243"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-7000020473821~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/7000020473821"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-7011501003070~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/7011501003070"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-7360001012407~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/7360001012407"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-7360001012745~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/7360001012745"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-7360003005301~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/7360003005301"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-8360003004772~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/8360003004772"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-9000020473596~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/9000020473596"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-9360001013023~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/9360001013023"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-9360001013238~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/9360001013238"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-9360003005217~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/9360003005217"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-9~2~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/9_2.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-abashiri~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/c84abf64-f7ba-4d22-8cc1-acac7adbdc6f/download/abashiri_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-abiracho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/7f011237-1284-4063-8c55-ba4945031793/download/abiracho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-akan~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/e3bb6e27-d2bb-4925-a42c-adb5f49bb924/download/akan_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-akechirailway~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/akechirailway/akechirailway_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-ama~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.ama.aichi.jp/_res/projects/default_project/_page_/001/002/512/ama_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-aoikotsu~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/aoikotsu/aoikotsu_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-asahikawa~denki~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/41ea2ac6-c6e4-47b2-9c1c-b482feaee17c/download/asahikawa_denki.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-asahi~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/asahi_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-atsuma~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/40e699d6-03c7-4191-b328-5e9c13841ab2/download/atsuma_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-awara~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/awara_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-b01~buzen~nakatsu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/B01_Buzen_Nakatsu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-bankei~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/889906b8-eb1a-41c3-a7b3-75cd69aa891f/download/bankei_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-betsukaicho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/469a1a00-020d-49f7-b5c1-e52dc9a6961e/download/betsukaicho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-bihoku~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/12/current_data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-bonbus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/13/current_data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-busnettsu~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/busnettsu/busnettsu_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-bus~city~semboku~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-city-semboku.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-bus~city~yuzawa01~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-city-yuzawa01.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-bus~city~yuzawa02~komachi~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-city-yuzawa02-komachi.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-bus~hakusancity~ishikawa~jp~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.hakusan.lg.jp/_res/projects/default_project/_page_/001/003/950/bus-hakusancity-ishikawa-jp.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-bus~ikawatown~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-ikawatown.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-bus~kagoshimacity~kagoshima~jp~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.kagoshima.lg.jp/ict/documents/bus-kagoshimacity-kagoshima-jp.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-bus~katagamicity~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-katagamicity.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-bus~nansyu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-nansyu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-bus~nikaho~akita~jp~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-nikaho-akita-jp.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-bus~noshirocity~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-noshirocity.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-bus~ogacity~2~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.oga.akita.jp/material/files/group/2/bus-ogacity-2.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-bus~yokotecity~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-yokotecity.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-bus~yurihonjyocity~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-yurihonjyocity.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-chitetsu~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/96fo9k5gmz6qwlk8xfjz0bo8vl6mhta9.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-chitetsu~tram~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/asr4jglw9sm038qq20h1pqxdg7eqk669.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-chugoku~jr~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/15/current_data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-chusei~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://bus-vision.jp/gtfs_v2/chusei/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-city~hatsukaichi~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/19/current_data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-city~kure~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/18/current_data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-city~namerikawa~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.namerikawa.toyama.jp/material/files/group/10/city_namerikawa_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-city~takaoka~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.takaoka.toyama.jp/joho/shise/opendata/documents/city_takaoka_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-city~toyama~fuchu~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opdt.city.toyama.lg.jp/dataset/8de65493-0af7-49d3-aab6-b495fc3ea2b0/resource/61a024ce-a377-4dd3-a3c0-b46183896597/download/city-toyama-fuchu-gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-city~toyama~horikawaminami~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opdt.city.toyama.lg.jp/dataset/8de65493-0af7-49d3-aab6-b495fc3ea2b0/resource/5cb228a9-8a44-4db5-bbe5-3dcbabf1c1f6/download/city-toyama-horikawaminami-gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-city~toyama~kureha~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opdt.city.toyama.lg.jp/dataset/8de65493-0af7-49d3-aab6-b495fc3ea2b0/resource/26db7690-aa7e-41b2-8596-0d8bdcd5c885/download/city-toyama-kureha-gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-city~toyama~maidohaya~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opdt.city.toyama.lg.jp/dataset/8de65493-0af7-49d3-aab6-b495fc3ea2b0/resource/43903d9f-1d9c-42f0-bd01-8a5fc1cb828c/download/city-toyama-maidohaya-gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-city~toyama~mizuhashi~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opdt.city.toyama.lg.jp/dataset/8de65493-0af7-49d3-aab6-b495fc3ea2b0/resource/ff01c4dd-14e7-4dbc-acea-09bff6b7d40e/download/city-toyama-mizuhashi-gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-city~toyama~oyama~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opdt.city.toyama.lg.jp/dataset/8de65493-0af7-49d3-aab6-b495fc3ea2b0/resource/378bcf3e-8f32-477a-857d-2d3917b6e84d/download/city-toyama-oyama-gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-city~toyama~yamada~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opdt.city.toyama.lg.jp/dataset/8de65493-0af7-49d3-aab6-b495fc3ea2b0/resource/665ab7b2-e434-4a4a-8175-32a433b60008/download/city-toyama-yamada-gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-city~toyama~yatsuo~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opdt.city.toyama.lg.jp/dataset/8de65493-0af7-49d3-aab6-b495fc3ea2b0/resource/927992fb-e889-43cb-aa55-3bc3cab2e0aa/download/city-toyama-yatsuo-gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-city~uozu~shimin~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.uozu.toyama.jp/contents/busdata/city_uozu_shimin_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-current~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/6d93f594-6b28-417b-a1df-931e93690a78/resource/6a0eaa15-185b-4156-8b98-9b680a65ad93/download/current_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-daiwa~kotsu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/yamato_kotsu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-dohoku~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/a89a7707-f346-45e7-8f98-0da0f3332531/download/dohoku_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-dounan~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/a70d369c-405c-4c25-996c-c70aa53682bc/download/dounan_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-easthokkaido~expressbus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/4215a2dd-3491-4005-bf66-10fda633d1af/download/easthokkaido_expressbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-echigokotsu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://loc.bus-vision.jp/gtfs_v2/echigokotsu/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-echizensi~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/echizensi_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-eiheiji~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/eiheiji_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-ena~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/ena/ena_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-engan~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/0dd30c37-4d45-4a23-8f86-12b74f6e65e1/download/engan_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-engarucho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/cc6d76a4-3576-480e-a073-ef1bfa62eafa/download/engarucho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-etajima~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gtfs-st.busit.jp/api/etajimabus"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-f0100801~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.hakodate.hokkaido.jp/docs/2020052700015/files/GTFS-JP.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-f1301702~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://shibuya-data.maps.arcgis.com/sharing/rest/content/items/185d0dbc980443b8b60e135349e2ae5e/data"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-f1600302~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/df1tjqcd97nqdl41rm7bal2fxv7gpe90.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-f1601102~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/endsdhfeo2xhkrx4pghgflixbj9zy35i.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-f1601402~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/etmkuksc9ynw52uhu4lr9bgfehxthea6.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-f1601801~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/hc26ot69inx8rzcfukozh69tklqodlnt.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-f3500301~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.sentetsu.biz-web.jp/GTFS-JP.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-f3701203~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.kagawa.lg.jp/dataset/543/resource/7280/GTFS-JP.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-flower~liner~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/flower-liner_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-forble~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/14/current_data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-fukagawashi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/2d439886-69ec-4bf9-9a12-9ee4014e3f3c/download/fukagawashi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-furano~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/3623aa5b-7d0b-4621-a3c8-b09e55863d27/download/furano_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-geiyo~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/11/current_data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-gifu~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/gifu/gifu_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsdate~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.city.komaki.aichi.jp/material/files/group/88/gtfsdate.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp3~dmv~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2652/resource/7651/GTFSJP3_DMV.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp3~higashimiyoshi~cho~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2620/resource/13826/GTFSJP_Higashimiyoshi-cho.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp3~kaiyo~town~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2669/resource/7705/GTFSJP3_kaiyo-town.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp3~kamihachiman~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2639/resource/7597/GTFSJP3_kamihachiman.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp3~kamikatsu~town~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2642/resource/7635/GTFSJP3_kamikatsu-town.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp3~kitajima~town~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2641/resource/7634/GTFSJP3_kitajima-town.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp3~matsushige~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2672/resource/13799/GTFSJP3_matsushige.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp3~miyoshi~city~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2643/resource/7636/GTFSJP3_miyoshi-city.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp3~naka~town~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2644/resource/7643/GTFSJP3_naka-town.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp3~naruto~city~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2635/resource/7591/GTFSJP3_naruto-city.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp3~naruto~city~tosen~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2635/resource/7592/GTFSJP3_naruto-city_tosen.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp3~oujin~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2640/resource/7598/GTFSJP3_oujin.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp3~tokushimabus~anan~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2647/resource/7646/GTFSJP3_tokushimabus_anan.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp3~tokushimabus~nanbu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2648/resource/7647/GTFSJP3_tokushimabus_nanbu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp3~tsurugi~town~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2637/resource/7594/GTFSJP3_tsurugi-town.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp3~yoshinogawa~city~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2638/resource/7596/GTFSJP3_yoshinogawa-city.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~aki~genkibus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Aki-Genkibus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~geisei~village~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Geisei-Village.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~hokubu~traffic~localbus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Hokubu-Traffic_Localbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~ino~inoloop~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Ino-InoLoop.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~konan~city~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Konan-City.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~koryo~traffic~localbus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Koryo-Traffic_Localbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~kuroiwa~localbus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Kuroiwa-Localbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~mihara~miharabus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Mihara-Miharabus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~motoyama~town~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Motoyama-Town.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~muroto~city~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Muroto-City.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~nakatosa~town~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Nakatosa-Town.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~nankoku~city~zip~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Nankoku-City.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~pref~ferry~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Pref-Ferry.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~reihoku~kanko~localbus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Reihoku-Kanko_Localbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~seinan~expressbus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Seinan-Expressbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~seinan~localbus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Seinan-Localbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~seinan~riverbus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Seinan-Riverbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~seinan~shimaashi~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Seinan-Shimaashi.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~seinan~trolleybus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Seinan-Trolleybus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~shimanto~city~demand~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Shimanto-City-Demand.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~shimanto~city~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Shimanto-City.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~shimanto~town~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Shimanto-Town.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~shimanto~traffic~feeder~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Shimanto-Traffic_Feeder.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~shimanto~traffic~localbus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Shimanto-Traffic_Localbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~sukumo~ferry~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Sukumo-Ferry.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~sukumo~hanachan~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Sukumo-Hanachan.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~sukumo~yururin~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Sukumo-Yururin-Bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~susaki~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Susaki-Bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~susaki~ferry~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Susaki-Ferry.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~tano~town~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Tano-Town.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~tobu~traffic~localbus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Tobu-Traffic_Localbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~tosashimizu~odekake~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Tosashimizu-Odekake.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~tosa~city~dragonbus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Tosa-City-Dragonbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~tsuno~town~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Tsuno-Town.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~yasuda~town~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Yasuda-Town.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfstubame~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.city.sendai.jp/kokyo/documents/gtfstubame.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~0211117~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/gtfs_0211117.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~abashiribus~current~data~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.abashiribus.com/open_data/gtfs_abashiribus_current_data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~abibus~nedo~root~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.abiko.chiba.jp/shisei/opendata/GTFS-JP.files/gtfs_Abibus_nedo_root.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~abibus~other~root~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.abiko.chiba.jp/shisei/opendata/GTFS-JP.files/gtfs_Abibus_other_root.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~aibus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.abiko.chiba.jp/shisei/opendata/GTFS-JP.files/gtfs_Aibus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~data~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.chiryu.aichi.jp/ikkrwebBrowse/material/files/group/4/gtfs_data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~data~shika~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.town.shika.lg.jp/data/open/cnt/3/4031/1/gtfs_data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~data~zip~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.suzaka.nagano.jp/opendata/file/gtfs_data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~echizenchou~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/gtfs_echizenchou_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~hekinan~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.hekinan.lg.jp/material/files/group/3/GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~highway~line~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.takubus.com/app/download/11135470279/GTFS_highway_line.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~hokan~takeyakotsu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.takeyakoutu.jp/assets/gtfs-hokan-takeyakotsu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/a0b5a3ab-5207-4974-94aa-7886afb138fc/download/gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~jpgeiyobus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.geiyo.co.jp/Unyu/gtfs/GTFS-JPgeiyobus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~jp~akanbus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.akanbus.co.jp/gtfs/GTFS-JP-akanbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~jp~gunbus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.gunbus.co.jp/GTFS/GTFS-JP_gunbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~jp~kitamibus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://drive.google.com/uc?export=view&id=13MQ00Oq6pJgHpB2jz5nG1iay0fEyXpAj"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~jp~nbaux~gunma~jp~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.nagai-unyu.net/rosen/GTFS/aux/GTFS-JP_nbaux-gunma-jp.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~jp~sendaicitybus~current~data~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.city.sendai.jp/joho-kikaku/shise/security/kokai/documents/gtfs-jp_sendaicitybus_current_data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~jp~tamarin~gunma~jp~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.nagai-unyu.net/rosen/GTFS/tamarin/GTFS-JP_tamarin-gunma-jp.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~jp~tokushima~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.city.tokushima.tokushima.jp/shisei/open-data/living/gtfs-jp.files/GTFS-JP.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~katsuyamashi~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/gtfs_katsuyamashi.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~kd~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.kotoden.co.jp/publichtm/gtfs/gtfsdata/latest/gtfs_kd.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~kumano~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.wakayama.lg.jp/prefg/062500/kotsu/opendata_d/fil/GTFS_kumano.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~mb~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ncb.jp/route/GTFS/GTFS(MB).zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~meiko~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.wakayama.lg.jp/prefg/062500/kotsu/opendata_d/fil/GTFS_meiko.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~nakatsu~city~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/GTFS_Nakatsu_city.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~obamashi~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/gtfs_obamashi.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~regular~line~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.takubus.com/app/download/10941479479/GTFS_regular_line.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~rinkan~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.wakayama.lg.jp/prefg/062500/kotsu/opendata_d/fil/GTFS_rinkan.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~ryujin~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.wakayama.lg.jp/prefg/062500/kotsu/opendata_d/fil/GTFS_ryujin.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~sabae~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/gtfs_sabae.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~tokaicity~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.city.tokai.aichi.jp/secure/47255/gtfs.zip"
+      }
+    },
+    {
+      "id": "f-gtfs~tokushimabus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2646/resource/7704/GTFS_tokushimabus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~tosaden~traffic~airportbus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Tosaden-Traffic_Airportbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~yonkoh~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://yonkoh.co.jp/wp/gtfs/gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gunkanjima~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/c507ab86-fa09-4ee6-91cd-d0a865a31229/resource/54ebdbe4-63ae-4f04-b2a3-094f9a04aee0/download/gunkanjima.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-haborocho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/635cdd26-246c-4bd7-a095-6705c1eebb91/download/haborocho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-haboro~enkai~ferry~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/b1535cdf-9798-4990-afe2-5c5c5bcdfdfa/download/haboro-enkai-ferry.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-heart~land~ferry~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/677e45d0-45d1-4eaf-a679-319cdbfaa89e/download/heart-land-ferry.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-hehigashitani~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/HEHigashitani.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-hichiso~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/hichiso/hichiso_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-hida~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/hida/hida_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-higashine~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/higashine_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-higashiura~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/higashiura/higashiura_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-higashi~izumo~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.docodemo-bus.net/opendata/higashi-izumo.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-hirobus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/9/current_data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-hiroden~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/8/current_data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-hiroko~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/10/current_data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-hokkaido~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/19e47509-3dac-4607-a595-61447226fa3b/download/hokkaido_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-hokkaido~chuo~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/dbadfccc-670e-49b9-be77-c3f346ee3160/download/hokkaido_chuo.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-hokkaido~express~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/ccfd2358-c804-4cfe-b4fe-278c3f035c64/download/hokkaido-express_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-hokkaido~ikedacho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/bbeb17c6-b127-4437-a457-cff8969f5949/download/hokkaido_ikedacho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-hokkaido~kamikawacho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/59c9f350-2419-46ce-9bab-4e86e21f396b/download/hokkaido_kamikawacho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-hokumon~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/226fe0ae-79af-4971-b15f-332770cdc9c1/download/hokumon_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-hurue~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.docodemo-bus.net/opendata/hurue.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-hwnishitani~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/HWNishitani.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-hyyakata~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/HYYakata.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-ibigawa~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/ibigawa/ibigawa_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-iga~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/iga/iga_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-iga~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://bus-vision.jp/gtfs_v2/iga/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-ikalliance~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://loc.bus-vision.jp/gtfs_v2/ikalliance/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-inbe~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.docodemo-bus.net/opendata/inbe.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-iserailway~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/iserailway/iserailway_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-ise~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/ise/ise_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-ise~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://bus-vision.jp/gtfs_v2/ise/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-iwanaicho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/a3be17ab-40ab-4b7d-9051-03562baf2ed4/download/iwanaicho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-iyoshi~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.iyo.lg.jp/keizaikoyou/matidukuri/documents/gtfs.zip"
+      }
+    },
+    {
+      "id": "f-joutetsu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/fef98fef-6fe2-472f-bde3-9d4f0a509a4a/download/joutetsu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-jr四国バス高知支店~大栃線",
       "spec": "gtfs",
       "urls": {
@@ -16,10 +2978,1946 @@
       }
     },
     {
+      "id": "f-kaetsunou~gtfs~himi~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/tdu8l9t46rifwo2vx8a5o1qede4g3xhc.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-kaetsunou~gtfs~ippan~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/ufgq55b2oxb6i0b15r9ih9q82w3q3jj5.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-kaetsunou~gtfs~sekaiisan~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/ix5so7pza4m5d5yo3ikbfv4xk4tms80x.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-kahoku~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/kahoku_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kaigan~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/kaigan_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kaizu~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/kaizu/kaizu_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kameyama~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/kameyama/kameyama_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kaminoyama~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/kaminoyama_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kanbaratetsudo~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://loc.bus-vision.jp/gtfs_v2/kanbaratetsudo/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kaneyama~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/kaneyama_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kariya~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/kariya/kariya_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kasamatsu~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/kasamatsu/kasamatsu_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kashima~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.docodemo-bus.net/opendata/kashima.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-keifuku~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/keifuku_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kibichuo~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://loc.bus-vision.jp/gtfs_v2/kibichuo/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kimobetsucho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/7727a55e-856d-4a49-aaa4-4ae4a605ba47/download/kimobetsucho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kitaena~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/kitaena/kitaena_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kitamishi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/d4ecb0d3-4b28-4fff-897f-f56979e9b5c9/download/kitamishi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kubikijidosha~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://loc.bus-vision.jp/gtfs_v2/kubikijidosha/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kumano~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/kumano/kumano_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kumano~shuyu~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/kumano_shuyu/kumano_shuyu_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kuriyamacho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/2365427f-ee06-40cc-a7d0-364a31d7afc8/download/kuriyamacho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kururin~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.city.nisshin.lg.jp/material/files/group/108/kururin-gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kushiro~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/dd2557d2-39f9-4e03-8703-117c64eaabe2/download/kushiro_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kutchancho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/bd408ce3-8910-48bc-bf4c-1135cac7070a/download/kutchancho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kuwana~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/kuwana/kuwana_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kuwana~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://bus-vision.jp/gtfs_v2/kuwana/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-m1~miho~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/M1_Miho.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-makubetsucho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/95c715ca-21de-4206-a345-b781e0952dd0/download/makubetsucho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-mamurogawa~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/mamurogawa_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-matsusaka~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/matsusaka/matsusaka_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-matsusaka~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://bus-vision.jp/gtfs_v2/matsusaka/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-meishi~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/4bddd9a6-5edf-4887-82aa-b61cb93afc9e/download/meishi_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-memurocho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/2a15bf71-a472-4e7b-9722-1e304ba8e400/download/memurocho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-mihama~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/mihama_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-mihonoseki~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.docodemo-bus.net/opendata/mihonoseki.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-miike~shimabara~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/2b03e4b2-83a1-4c53-b884-22c05e53da9a/resource/ea3aa42e-f03f-471b-850a-daa87c07e61b/download/miike-shimabara.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-mikasashi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/b529697a-82c2-4f78-b6b1-19fce6c9c3dc/download/mikasashi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-minamiise~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/minamiise/minamiise_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-minokamo~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/minokamo/minokamo_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-mitake~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/mitake/mitake_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-miyama~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/miyama_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-mizunami~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/mizunami/mizunami_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-mogamigawakotsu~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/mogamigawakotsu_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-moritan~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/moritan_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-motosu~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/motosu/motosu_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-murayama~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/murayama_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-nabari~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/nabari/nabari_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-nagai~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/nagai_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-nagakute~nbus~gtfs~current~data~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.nagakute.lg.jp/material/files/group/4/Nagakute_Nbus_gtfs_current_data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-naganumacho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/16e0d070-789e-41ae-bc2a-0d0f7f63c80f/download/naganumacho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-nagiso~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/nagiso/nagiso_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-naiecho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/af325038-7d05-485d-9b71-85c19a3d96e7/download/naiecho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-nakashibetsucho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/75e1e2db-ab48-4dfb-9514-1ebbc898791a/download/nakashibetsucho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-nakatsugawa~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/nakatsugawa/nakatsugawa_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-nakayama~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/nakayama_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-nanki~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://bus-vision.jp/gtfs_v2/nanki/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-nanyo~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/nanyo_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-nayoroshi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/4abe45b3-7390-4d7d-8bf1-e8c7230ab962/download/nayoroshi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-nebutango~current~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.aomori.aomori.jp/toshi-seisaku/opendata/documents/nebutango_current.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-niigatakotsukanko~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://loc.bus-vision.jp/gtfs_v2/niigatakotsukanko/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-niigatakotsu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://loc.bus-vision.jp/gtfs_v2/niigatakotsu/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-niseko~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/c46f9cd8-4c92-42eb-89a5-26e3fabb1dce/download/niseko_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-nishikawa~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/nishikawa_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-nishin~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/nishin_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-nishiwaga~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://mc.bus-vision.jp/gtfs/nishiwaga/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-nisshin~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/nisshin/nisshin_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-noriaitaxi~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/noriaitaxi.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-notty~current~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.nonoichi.lg.jp/img/opendata/notty_current.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-obanazawa~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/obanazawa_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-obiun~kanko~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/edc6b615-7308-4bd0-bfe4-6b3a510f9fc0/download/obiun-kanko.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-oe~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/oe_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-oguni~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/oguni_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-ohkura~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/ohkura_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-okabo~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/okabo_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-okoppecho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/9f741a86-60e2-42b2-89d8-384be8bf50ba/download/okoppecho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-onoshiei~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/onoshiei_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-onosi~machinaka~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/onosi_machinaka_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-otofukecho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/2d430e06-7e0b-4ef7-86f3-64ccb709d270/download/otofukecho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-rankoshicho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/595f0db5-9e55-43a5-8b85-74c3edcd7da7/download/rankoshicho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-sagae~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/sagae_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-saga~current~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://opendata.sagabus.info/saga-current.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-sakaide~city~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.sakaide.lg.jp/uploaded/library/sakaide_city_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-sakaide~kotosan~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.sakaide.lg.jp/uploaded/library/sakaide_kotosan_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-sakaisi~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/sakaisi_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-sakegawa~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/sakegawa_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-sakou~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/sakou_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-sanuki~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.sanuki.kagawa.jp/wp-content/uploads/2022/11/sanuki_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-saromacho~com~zip~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/be66e348-db27-423f-8668-8b90b828c871/download/saromacho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-sasakikanko~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/17/current_data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-sbusyokkaichi~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/sbusyokkaichi/sbusyokkaichi_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-seikan~ferry~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/16a31295-1709-4e5e-abcf-fa17ae7853b7/download/seikan_ferry.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-seisankanko~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/seisankanko/seisankanko_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-sharicho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/e59d88f1-2236-41bb-ba8c-75fd4754af1a/download/sharicho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-shibetsu~kido~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/a5702fbb-eac7-401c-8dff-e7675091fd26/download/shibetsu_kido.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-shibus~current~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.aomori.aomori.jp/toshi-seisaku/opendata/documents/shibus_current.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-shihorocho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/3c8f82fe-c997-45c8-9307-c904b206a450/download/shihorocho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-shimane~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.docodemo-bus.net/opendata/shimane.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-shima~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://bus-vision.jp/gtfs_v2/shima/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-shimodengtfs~jp~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://shimoden.net/busmada/opendata/GTFS-JP.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-shimokawacho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/fc98f52c-5dd9-4c55-b089-288eeba92044/download/shimokawacho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-shinji~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.docodemo-bus.net/opendata/shinji.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-shinjo~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/shinjo_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-shinshinotsu~kotsu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/ceb69900-431d-4bb7-9605-a3b74e829b56/download/shinshinotsu_kotsu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-shiranukacho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/f4f6deb3-e9ad-469e-aa39-38279bdbfeb0/download/shiranukacho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-shiraoicho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/120a024f-c2b5-4183-aa90-802398e010fd/download/shiraoicho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-shirataka~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/shirataka_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-shonai~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/shonai_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-simizu~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/simizu_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-snh01~chokokuji~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/SNH01_Chokokuji.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-snn01~nishimagusakouminkan~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/SNN01_Nishimagusakouminkan.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-sorachi~chuo~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/671debb1-44c5-4dea-99eb-be693911c50c/download/sorachi_chuo_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-sorachi~kotsu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/9a28fbf9-69fe-4a5c-8d26-b12fc2440074/download/sorachi_kotsu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-soya~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/04e3efd7-29fd-4295-ab8d-d27933f94bbc/download/soya_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-sugitogtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.saitama.lg.jp/data/dataset/ae39c95f-917a-4f60-80ef-6341c0783092/resource/6fbd7a95-2759-4ee3-8d2a-e1e2b55f4002/download/sugitogtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-syari~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/d93cb12c-390f-4215-891d-c250db8f26d0/download/syari_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-taikicho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/aa50ca49-dc3b-4c34-89ca-79749aeaaa21/download/taikicho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-tainoura~nagasaki~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/80da3e1f-5e26-4b85-a9f1-61fa560b91b1/resource/5acda669-d9be-4610-9df0-0d82a098b579/download/tainoura-nagasaki_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-taketoyo~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/taketoyo/taketoyo_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-tamayu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.docodemo-bus.net/opendata/tamayu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-tendo~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/tendo_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-tengakajika~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/tengakajika_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-toba~bus~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/toba_bus/toba_bus_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-toba~ship~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/toba_ship/toba_ship_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-tobetsucho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/a3603010-da90-4228-8095-a42a31adf855/download/tobetsucho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-toeibus~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/Toei/data/ToeiBus-GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-togo~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/togo_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-tohtetsu~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/tohtetsu/tohtetsu_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-toki~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/toki/toki_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-town~nyuzen~noran~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.town.nyuzen.toyama.jp/material/files/group/3/town_nyuzen_noran_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-toyoake~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.toyoake.lg.jp/secure/5217/toyoake.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-toyota~chiiki~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/toyota_chiiki/toyota_chiiki_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-toyota~kikan~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/toyota/toyota_kikan_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-toyotetsu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://loc.bus-vision.jp/gtfs/toyotetsu/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-toyouracho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/c9fe757b-0756-424b-a8da-e3438798dd55/download/toyouracho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-toyoyama~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/toyoyama/toyoyama_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-tozawa~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/tozawa_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-tsuairportline~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/tsuairportline/tsuairportline_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-tsukigatacho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/d5e7795d-6c36-4468-ac2c-245e7f3378e1/download/tsukigatacho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-tsuruga~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/tsuruga_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-tsuruoka~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/tsuruoka_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-tsu~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/tsu/tsu_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-uzura~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/uzura_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-wakasa~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/wakasa_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-watarai~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/watarai/watarai_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-y010~kawaraguchi~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y010_Kawaraguchi.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-y021~kaminogouchi~masaki~for~masaki~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y021_Kaminogouchi_Masaki_for_Masaki.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-y022~kaminogouchi~masaki~for~kaminogouchi~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y022_Kaminogouchi_Masaki_for_Kaminogouchi.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-y031~hiyamaji~kamagi~for~hiyamaji~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y031_Hiyamaji_Kamagi_for_Hiyamaji.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-y032~hiyamaji~kamagi~for~kamagi~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y032_Hiyamaji_Kamagi_for_Kamagi.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-y051~ohshimadai~kanayoshi~for~kanayoshi~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y051_Ohshimadai_Kanayoshi_for_Kanayoshi.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-y052~ohshimadai~kanayoshi~for~ohshimadai~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y052_Ohshimadai_Kanayoshi_for_Ohshimadai.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-y060~ohshima~ifuku~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y060_Ohshima_Ifuku.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-y080~shin~yaba~west~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y080_Shin-Yaba_West.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-y090~yamautsuri~north~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y090_Yamautsuri_North.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-y100~yamautsuri~south~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y100_Yamautsuri_South.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-y110~tsutami~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y110_Tsutami.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-y121~urayabakei~for~kakisaka~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y121_Urayabakei_for_Kakisaka.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-y122~urayabakei~for~hiyamaji~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y122_Urayabakei_for_Hiyamaji.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-yakumo~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.docodemo-bus.net/opendata/yakumo.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-yamagata~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/yamagata_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-yamakobus~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/yamakobus_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-yamanobe~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/yamanobe_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-yanbaru~express~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://yanbaru-expressbus.com/wp-content/themes/ykb/download/gtfs/statics.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-yk01~tsukinoki~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/YK01_Tsukinoki.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-yk02~tokoro~ono~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/YK02_Tokoro-ono.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-yk03~ichibira~okudani~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/YK03_Ichibira_Okudani.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-yk04~nagaono~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/YK04_Nagaono.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-yk05~fukebaru~ohishitohge~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/YK05_Fukebaru_Ohishitohge.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-yk06~moromiya~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/YK06_Moromiya.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-ykk1~kii~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/YKK1_Kii.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-yokkaichi~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://bus-vision.jp/gtfs_v2/yokkaichi/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-yokosuka~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.yokosuka.kanagawa.jp/0830/opendata/documents/gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-yonezawa~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/yonezawa_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-ysw1~shinyabahigashi~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/YSW1_Shinyabahigashi.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-yutetsu~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/594c9dd3-d356-4445-98e2-c480d49c9d65/download/yutetsu_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-あおい交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/aoi-komaki/feeds/aoikotsu/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/aoi-komaki/feeds/aoikotsu/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -30,10 +4928,10 @@
       }
     },
     {
-      "id": "f-あおい交通",
+      "id": "f-あおい交通~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/aoi-komaki/feeds/aoikotsu/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/aoi-komaki/feeds/aoikotsu/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -85,7 +4983,7 @@
       "id": "f-たつの市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tatsunocity/feeds/communitybus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tatsunocity/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -96,10 +4994,10 @@
       }
     },
     {
-      "id": "f-たつの市コミュニティバス",
+      "id": "f-たつの市コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tatsunocity/feeds/communitybus/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tatsunocity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -124,7 +5022,7 @@
       }
     },
     {
-      "id": "f-つくば市~つくバス",
+      "id": "f-つくば市~つくバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/tsukubacity/feeds/TSUKUBUS/files/feed.zip?rid=next"
@@ -152,7 +5050,7 @@
       }
     },
     {
-      "id": "f-つくば市~筑波地区支線型バスつくばね号",
+      "id": "f-つくば市~筑波地区支線型バスつくばね号~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/tsukubacity/feeds/TSUKUBANEGO/files/feed.zip"
@@ -166,7 +5064,7 @@
       }
     },
     {
-      "id": "f-つくば市~筑波地区支線型バスつくばね号",
+      "id": "f-つくば市~筑波地区支線型バスつくばね号~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/tsukubacity/feeds/TSUKUBANEGO/files/feed.zip?rid=next"
@@ -183,7 +5081,7 @@
       "id": "f-つるぎ町コミュニティーバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsurugitown/feeds/tsurugitownbus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsurugitown/feeds/tsurugitownbus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -194,10 +5092,10 @@
       }
     },
     {
-      "id": "f-つるぎ町コミュニティーバス",
+      "id": "f-つるぎ町コミュニティーバス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsurugitown/feeds/tsurugitownbus/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsurugitown/feeds/tsurugitownbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -264,7 +5162,7 @@
       }
     },
     {
-      "id": "f-やんばる急行バス",
+      "id": "f-やんばる急行バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/yanbaru-expressbus/feeds/yanbaru-express-bus/files/feed.zip?rid=next"
@@ -292,7 +5190,7 @@
       }
     },
     {
-      "id": "f-バスネット津~ぐるっと~つーバス",
+      "id": "f-バスネット津~ぐるっと~つーバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/busnet-tsu/feeds/guruttotsubus/files/feed.zip?rid=next"
@@ -367,7 +5265,7 @@
       "id": "f-七宗町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hichisotown/feeds/choeibus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hichisotown/feeds/choeibus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -378,10 +5276,10 @@
       }
     },
     {
-      "id": "f-七宗町営バス",
+      "id": "f-七宗町営バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hichisotown/feeds/choeibus/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hichisotown/feeds/choeibus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -416,7 +5314,7 @@
       }
     },
     {
-      "id": "f-万葉線",
+      "id": "f-万葉線~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/manyosen/feeds/manyosen/files/feed.zip?rid=next"
@@ -429,7 +5327,7 @@
       "id": "f-三好市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-miyoshicity/feeds/miyoshicitybus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-miyoshicity/feeds/miyoshicitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -440,10 +5338,10 @@
       }
     },
     {
-      "id": "f-三好市営バス",
+      "id": "f-三好市営バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-miyoshicity/feeds/miyoshicitybus/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-miyoshicity/feeds/miyoshicitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -468,7 +5366,7 @@
       }
     },
     {
-      "id": "f-三条市循環バスぐるっとさん",
+      "id": "f-三条市循環バスぐるっとさん~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/sanjocity/feeds/guruttosan/files/feed.zip?rid=next"
@@ -499,20 +5397,6 @@
       "id": "f-上勝町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kamikatsutown/feeds/kamikatsutownbus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上勝町営バス",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/kamikatsutown/feeds/kamikatsutownbus/files/feed.zip"
       },
       "license": {
@@ -524,10 +5408,10 @@
       }
     },
     {
-      "id": "f-上山市営バス",
+      "id": "f-上勝町営バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaminoyamacity/feeds/KaminoyamaCity/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kamikatsutown/feeds/kamikatsutownbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -552,6 +5436,20 @@
       }
     },
     {
+      "id": "f-上山市営バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaminoyamacity/feeds/KaminoyamaCity/files/feed.zip?rid=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
       "id": "f-上市町~上市町営バス",
       "spec": "gtfs",
       "urls": {
@@ -562,7 +5460,7 @@
       }
     },
     {
-      "id": "f-上市町~上市町営バス",
+      "id": "f-上市町~上市町営バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/kamiichitown/feeds/kamiichi/files/feed.zip?rid=next"
@@ -575,7 +5473,7 @@
       "id": "f-上越市~名立区市営バス~東飛山線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/higashihiyama-line/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/higashihiyama-line/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -586,10 +5484,10 @@
       }
     },
     {
-      "id": "f-上越市~名立区市営バス~東飛山線",
+      "id": "f-上越市~名立区市営バス~東飛山線~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/higashihiyama-line/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/higashihiyama-line/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -614,24 +5512,10 @@
       }
     },
     {
-      "id": "f-上越市~大島区市営バス~旭線",
+      "id": "f-上越市~大島区市営バス~旭線~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/asahi-line/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~大島区市営バス~菖蒲線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/shobu-line/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -656,6 +5540,20 @@
       }
     },
     {
+      "id": "f-上越市~大島区市営バス~菖蒲線~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/shobu-line/files/feed.zip?rid=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
       "id": "f-上越市~板倉区市営バス~上関田線",
       "spec": "gtfs",
       "urls": {
@@ -670,24 +5568,10 @@
       }
     },
     {
-      "id": "f-上越市~板倉区市営バス~上関田線",
+      "id": "f-上越市~板倉区市営バス~上関田線~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/kamisekida-line/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~板倉区市営バス~山寺薬師~菰立線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/yamaderayakushi-komodate-line/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -712,10 +5596,10 @@
       }
     },
     {
-      "id": "f-上越市~清里区市営バス~櫛池線",
+      "id": "f-上越市~板倉区市営バス~山寺薬師~菰立線~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/kushiike-line/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/yamaderayakushi-komodate-line/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -740,10 +5624,10 @@
       }
     },
     {
-      "id": "f-上越市~牧区市営バス~坪山線",
+      "id": "f-上越市~清里区市営バス~櫛池線~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/tuboyma-line/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/kushiike-line/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -768,10 +5652,10 @@
       }
     },
     {
-      "id": "f-上越市~牧区市営バス~宇津俣線",
+      "id": "f-上越市~牧区市営バス~坪山線~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/utsunomata-line/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/tuboyma-line/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -796,10 +5680,10 @@
       }
     },
     {
-      "id": "f-上越市~牧区市営バス~高谷~平山線",
+      "id": "f-上越市~牧区市営バス~宇津俣線~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/takatani-tairayama-line/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/utsunomata-line/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -824,10 +5708,10 @@
       }
     },
     {
-      "id": "f-上越市~頸城区市営バス~大池線",
+      "id": "f-上越市~牧区市営バス~高谷~平山線~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/oike-line/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/takatani-tairayama-line/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -852,10 +5736,10 @@
       }
     },
     {
-      "id": "f-上越市市営バス",
+      "id": "f-上越市~頸城区市営バス~大池線~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/joetsu/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/oike-line/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -880,6 +5764,20 @@
       }
     },
     {
+      "id": "f-上越市市営バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/joetsu/files/feed.zip?rid=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
       "id": "f-上郡町~愛のり号",
       "spec": "gtfs",
       "urls": {
@@ -894,7 +5792,7 @@
       }
     },
     {
-      "id": "f-上郡町~愛のり号",
+      "id": "f-上郡町~愛のり号~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/kamigoritown/feeds/ainorigo/files/feed.zip?rid=next"
@@ -974,7 +5872,7 @@
       }
     },
     {
-      "id": "f-中山町~町営バス",
+      "id": "f-中山町~町営バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nakayamatown/feeds/NakayamaTown/files/feed.zip?rid=next"
@@ -1002,7 +5900,7 @@
       }
     },
     {
-      "id": "f-中津川市コミュニティバス",
+      "id": "f-中津川市コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nakatsugawacity/feeds/communitybus/files/feed.zip"
@@ -1016,7 +5914,7 @@
       }
     },
     {
-      "id": "f-中津川市コミュニティバス",
+      "id": "f-中津川市コミュニティバス~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nakatsugawacity/feeds/communitybus/files/feed.zip?rid=next"
@@ -1058,7 +5956,7 @@
       }
     },
     {
-      "id": "f-丸亀市~丸亀コミュニティバス",
+      "id": "f-丸亀市~丸亀コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/marugame-community/files/feed.zip?rid=next"
@@ -1075,7 +5973,7 @@
       "id": "f-丹波篠山市~コミバスハートラン",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tambasasayamacity/feeds/communitybusheartrun/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tambasasayamacity/feeds/communitybusheartrun/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -1086,10 +5984,10 @@
       }
     },
     {
-      "id": "f-丹波篠山市~コミバスハートラン",
+      "id": "f-丹波篠山市~コミバスハートラン~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tambasasayamacity/feeds/communitybusheartrun/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tambasasayamacity/feeds/communitybusheartrun/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -1156,7 +6054,7 @@
       }
     },
     {
-      "id": "f-二宮町コミュニティバス",
+      "id": "f-二宮町コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/ninomiyatown/feeds/Ninomiyatowncommunitybus/files/feed.zip?rid=next"
@@ -1184,7 +6082,7 @@
       }
     },
     {
-      "id": "f-京成トランジットバス",
+      "id": "f-京成トランジットバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/keisei-transitbus/feeds/keiseitransitbus/files/feed.zip?rid=next"
@@ -1215,20 +6113,6 @@
       "id": "f-伊勢市コミュニティバスおかげバス沼木バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/isecity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-伊勢市コミュニティバスおかげバス沼木バス",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://www.rosenzu.com/~gtfs/ise/ise_GTFS_next.zip"
       },
       "license": {
@@ -1240,7 +6124,21 @@
       }
     },
     {
-      "id": "f-伊勢市コミュニティバスおかげバス沼木バス",
+      "id": "f-伊勢市コミュニティバスおかげバス沼木バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/isecity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-伊勢市コミュニティバスおかげバス沼木バス~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/isecity/feeds/communitybus/files/feed.zip?rid=next"
@@ -1257,7 +6155,7 @@
       "id": "f-伊勢鉄道",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/isetetu/feeds/iserailway/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/isetetu/feeds/iserailway/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -1268,10 +6166,10 @@
       }
     },
     {
-      "id": "f-伊勢鉄道",
+      "id": "f-伊勢鉄道~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/isetetu/feeds/iserailway/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/isetetu/feeds/iserailway/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -1324,7 +6222,7 @@
       }
     },
     {
-      "id": "f-佐用町~コミバス佐用",
+      "id": "f-佐用町~コミバス佐用~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/sayotown/feeds/communitybus/files/feed.zip"
@@ -1372,7 +6270,7 @@
       }
     },
     {
-      "id": "f-入善町~入善町営バスのらんマイ~カー",
+      "id": "f-入善町~入善町営バスのらんマイ~カー~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nyuzentown/feeds/noranmaicar/files/feed.zip?rid=next"
@@ -1409,7 +6307,7 @@
       "id": "f-加古川市~かこバス~かこバスミニ",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kakogawacity/feeds/kakobuskakobusmini/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kakogawacity/feeds/kakobuskakobusmini/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -1420,10 +6318,10 @@
       }
     },
     {
-      "id": "f-加古川市~かこバス~かこバスミニ",
+      "id": "f-加古川市~かこバス~かこバスミニ~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kakogawacity/feeds/kakobuskakobusmini/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kakogawacity/feeds/kakobuskakobusmini/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -1462,7 +6360,7 @@
       }
     },
     {
-      "id": "f-加東市~社市街地乗合タクシー",
+      "id": "f-加東市~社市街地乗合タクシー~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/katocity/feeds/yashiroshigaichinoriaitaxi/files/feed.zip?rid=next"
@@ -1479,16 +6377,6 @@
       "id": "f-加能越バス~氷見市街地周遊バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunouhimi/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-加能越バス~氷見市街地周遊バス",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunouhimi/files/feed.zip"
       },
       "tags": {
@@ -1496,14 +6384,10 @@
       }
     },
     {
-      "id": "f-加西市~kasaiねっぴ～号~はっぴーバス",
+      "id": "f-加能越バス~氷見市街地周遊バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kasaicity/feeds/kasaineppihappybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunouhimi/files/feed.zip?rid=next"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -1524,10 +6408,14 @@
       }
     },
     {
-      "id": "f-加越能バス~一般路線",
+      "id": "f-加西市~kasaiねっぴ～号~はっぴーバス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunouippan/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kasaicity/feeds/kasaineppihappybus/files/feed.zip?rid=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -1544,10 +6432,10 @@
       }
     },
     {
-      "id": "f-加越能バス~世界遺産バス",
+      "id": "f-加越能バス~一般路線~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunousekaiisan/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunouippan/files/feed.zip?rid=next"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -1564,10 +6452,10 @@
       }
     },
     {
-      "id": "f-勝央町ふれあいバス",
+      "id": "f-加越能バス~世界遺産バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shootown/feeds/shoochofureaibus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunousekaiisan/files/feed.zip?rid=next"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -1578,6 +6466,16 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/shootown/feeds/shoochofureaibus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-勝央町ふれあいバス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shootown/feeds/shoochofureaibus/files/feed.zip?rid=next"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -1612,38 +6510,10 @@
       }
     },
     {
-      "id": "f-北島町福祉バス",
+      "id": "f-北島町福祉バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/kitajimatown/feeds/kitajimatownfukushibus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-北恵那バス北恵那交通",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kitaena/feeds/kitaena/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-北恵那バス北恵那交通",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kitaena/feeds/kitaena/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -1668,6 +6538,34 @@
       }
     },
     {
+      "id": "f-北恵那バス北恵那交通~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kitaena/feeds/kitaena/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-北恵那バス北恵那交通~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kitaena/feeds/kitaena/files/feed.zip?rid=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
       "id": "f-北振バス",
       "spec": "gtfs",
       "urls": {
@@ -1678,7 +6576,7 @@
       }
     },
     {
-      "id": "f-北振バス",
+      "id": "f-北振バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/hokushin-bus/feeds/hokushinbus/files/feed.zip?rid=next"
@@ -1782,7 +6680,7 @@
       }
     },
     {
-      "id": "f-南あわじ市コミュニティバス~らん~らんバス",
+      "id": "f-南あわじ市コミュニティバス~らん~らんバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/minamiawajicity/feeds/lanrunbus/files/feed.zip?rid=next"
@@ -1799,6 +6697,20 @@
       "id": "f-南伊勢町~町営バス",
       "spec": "gtfs",
       "urls": {
+        "static_current": "https://www.rosenzu.com/~gtfs/minamiise/minamiise_GTFS_next.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-南伊勢町~町営バス~1",
+      "spec": "gtfs",
+      "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/minamiisetown/feeds/choeibus/files/feed.zip"
       },
       "license": {
@@ -1810,24 +6722,10 @@
       }
     },
     {
-      "id": "f-南伊勢町~町営バス",
+      "id": "f-南伊勢町~町営バス~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/minamiisetown/feeds/choeibus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-南伊勢町~町営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/minamiise/minamiise_GTFS_next.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -1855,6 +6753,16 @@
       "id": "f-南砺市~なんバス南砺市営バス",
       "spec": "gtfs",
       "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/u4kmkwax5vbrctr2rshqkh1wzyx6qr9u.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-南砺市~なんバス南砺市営バス~1",
+      "spec": "gtfs",
+      "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nantocity/feeds/nanbus/files/feed.zip"
       },
       "tags": {
@@ -1862,20 +6770,10 @@
       }
     },
     {
-      "id": "f-南砺市~なんバス南砺市営バス",
+      "id": "f-南砺市~なんバス南砺市営バス~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nantocity/feeds/nanbus/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-南砺市~なんバス南砺市営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/u4kmkwax5vbrctr2rshqkh1wzyx6qr9u.zip"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -1896,7 +6794,7 @@
       }
     },
     {
-      "id": "f-南陽市~市内循環バス",
+      "id": "f-南陽市~市内循環バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nanyocity/feeds/NanyoCity/files/feed.zip?rid=next"
@@ -1941,7 +6839,7 @@
       "id": "f-吉野川市代替バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yoshinogawacity/feeds/yoshinogawacitybus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yoshinogawacity/feeds/yoshinogawacitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -1952,10 +6850,10 @@
       }
     },
     {
-      "id": "f-吉野川市代替バス",
+      "id": "f-吉野川市代替バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yoshinogawacity/feeds/yoshinogawacitybus/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yoshinogawacity/feeds/yoshinogawacitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -1980,7 +6878,7 @@
       }
     },
     {
-      "id": "f-名張市コミュニティバス",
+      "id": "f-名張市コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nabaricity/feeds/communitybus/files/feed.zip?rid=next"
@@ -2008,7 +6906,7 @@
       }
     },
     {
-      "id": "f-名鉄東部交通バス",
+      "id": "f-名鉄東部交通バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiocity/feeds/meitestu_tobu/files/feed.zip?rid=next"
@@ -2025,7 +6923,7 @@
       "id": "f-名阪近鉄バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/ogakicity/feeds/meihankintetsubus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ogakicity/feeds/meihankintetsubus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2036,10 +6934,10 @@
       }
     },
     {
-      "id": "f-名阪近鉄バス",
+      "id": "f-名阪近鉄バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/ogakicity/feeds/meihankintetsubus/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ogakicity/feeds/meihankintetsubus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2084,7 +6982,7 @@
       }
     },
     {
-      "id": "f-和気町営バスわけまろ号",
+      "id": "f-和気町営バスわけまろ号~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/waketown/feeds/wakechoueibasu/files/feed.zip?rid=next"
@@ -2097,7 +6995,7 @@
       "id": "f-四国交通~四交",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yonkoh/feeds/shikokukoutsuu/files/feed.zip?rid=next"
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2651/resource/7652/source-url"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2108,7 +7006,7 @@
       }
     },
     {
-      "id": "f-四国交通~四交",
+      "id": "f-四国交通~四交~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/yonkoh/feeds/shikokukoutsuu/files/feed.zip"
@@ -2122,10 +7020,10 @@
       }
     },
     {
-      "id": "f-四国交通~四交",
+      "id": "f-四国交通~四交~2",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2651/resource/7652/source-url"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yonkoh/feeds/shikokukoutsuu/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2164,7 +7062,7 @@
       }
     },
     {
-      "id": "f-土岐市~市民バス",
+      "id": "f-土岐市~市民バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/tokicity/feeds/communitybus/files/feed.zip?rid=next"
@@ -2192,7 +7090,7 @@
       }
     },
     {
-      "id": "f-土浦市~つちまるバス",
+      "id": "f-土浦市~つちまるバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuchiuracity/feeds/tsuchimarubus/files/feed.zip?rid=next"
@@ -2304,7 +7202,7 @@
       }
     },
     {
-      "id": "f-大江町営バス",
+      "id": "f-大江町営バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/oetown/feeds/Oetown/files/feed.zip?rid=next"
@@ -2332,7 +7230,7 @@
       }
     },
     {
-      "id": "f-大泉町~千代田町~広域公共バスあおぞら",
+      "id": "f-大泉町~千代田町~広域公共バスあおぞら~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/oizumitown/feeds/kouikikoukyoubasuaozora/files/feed.zip?rid=next"
@@ -2349,7 +7247,7 @@
       "id": "f-大蔵町~肘折ゆけむりライン",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/ohkuravillage/feeds/OhkuraVillage/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ohkuravillage/feeds/OhkuraVillage/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2360,10 +7258,10 @@
       }
     },
     {
-      "id": "f-大蔵町~肘折ゆけむりライン",
+      "id": "f-大蔵町~肘折ゆけむりライン~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/ohkuravillage/feeds/OhkuraVillage/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ohkuravillage/feeds/OhkuraVillage/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2391,20 +7289,6 @@
       "id": "f-天童市~市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tendocity/feeds/TendoCity/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-天童市~市営バス",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/tendocity/feeds/TendoCity/files/feed.zip"
       },
       "license": {
@@ -2416,13 +7300,13 @@
       }
     },
     {
-      "id": "f-姫路市コミュニティバス",
+      "id": "f-天童市~市営バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/himejicity/feeds/ieshima-boze-yukihiko/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tendocity/feeds/TendoCity/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       },
       "tags": {
@@ -2444,10 +7328,14 @@
       }
     },
     {
-      "id": "f-宇野バス宇野自動車",
+      "id": "f-姫路市コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/UnoBus/AllLines.zip?date=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/himejicity/feeds/ieshima-boze-yukihiko/files/feed.zip?rid=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -2464,7 +7352,17 @@
       }
     },
     {
-      "id": "f-宇野バス宇野自動車",
+      "id": "f-宇野バス宇野自動車~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/UnoBus/AllLines.zip?date=next"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-宇野バス宇野自動車~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/UnoBus/AllLines.zip?date=latest"
@@ -2477,7 +7375,7 @@
       "id": "f-安城市~あんくるバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/anjocity/feeds/AnkuruBus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/anjocity/feeds/AnkuruBus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2488,10 +7386,10 @@
       }
     },
     {
-      "id": "f-安城市~あんくるバス",
+      "id": "f-安城市~あんくるバス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/anjocity/feeds/AnkuruBus/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/anjocity/feeds/AnkuruBus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2530,7 +7428,7 @@
       }
     },
     {
-      "id": "f-宍粟市~しーたんバス",
+      "id": "f-宍粟市~しーたんバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/shisocity/feeds/shitanbus/files/feed.zip?rid=next"
@@ -2558,7 +7456,7 @@
       }
     },
     {
-      "id": "f-宝塚市~ランランバス",
+      "id": "f-宝塚市~ランランバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/takarazukacity/feeds/runrunbus/files/feed.zip?rid=next"
@@ -2626,7 +7524,7 @@
       }
     },
     {
-      "id": "f-富山地鉄バス富山地方鉄道",
+      "id": "f-富山地鉄バス富山地方鉄道~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/chitetsu/feeds/chitetsubus/files/feed.zip?rid=next"
@@ -2646,7 +7544,7 @@
       }
     },
     {
-      "id": "f-富山地鉄市内電車",
+      "id": "f-富山地鉄市内電車~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/chitetsu/feeds/chitetsushinaidensha/files/feed.zip?rid=next"
@@ -2666,7 +7564,7 @@
       }
     },
     {
-      "id": "f-富山市~まいどはやバス",
+      "id": "f-富山市~まいどはやバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/maidohayabus/files/feed.zip?rid=next"
@@ -2696,7 +7594,7 @@
       }
     },
     {
-      "id": "f-富山市~八尾コミュニティバス",
+      "id": "f-富山市~八尾コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/yatsuocommunitybus/files/feed.zip?rid=next"
@@ -2719,17 +7617,17 @@
       "id": "f-富山市~呉羽いきいきバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/kurehaikiikibus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/kurehaikiikibus/files/feed.zip"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-富山市~呉羽いきいきバス",
+      "id": "f-富山市~呉羽いきいきバス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/kurehaikiikibus/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/kurehaikiikibus/files/feed.zip?rid=next"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -2749,17 +7647,17 @@
       "id": "f-富山市~堀川南地域コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/horikawaminamicommunitybus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/horikawaminamicommunitybus/files/feed.zip"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-富山市~堀川南地域コミュニティバス",
+      "id": "f-富山市~堀川南地域コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/horikawaminamicommunitybus/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/horikawaminamicommunitybus/files/feed.zip?rid=next"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -2779,17 +7677,17 @@
       "id": "f-富山市~大山コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/oyamacommunitybus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/oyamacommunitybus/files/feed.zip"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-富山市~大山コミュニティバス",
+      "id": "f-富山市~大山コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/oyamacommunitybus/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/oyamacommunitybus/files/feed.zip?rid=next"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -2816,7 +7714,7 @@
       }
     },
     {
-      "id": "f-富山市~婦中コミュニティバス",
+      "id": "f-富山市~婦中コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/fuchucommunitybus/files/feed.zip?rid=next"
@@ -2846,7 +7744,7 @@
       }
     },
     {
-      "id": "f-富山市~山田コミュニティバス",
+      "id": "f-富山市~山田コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/yamadacommunitybus/files/feed.zip?rid=next"
@@ -2876,7 +7774,7 @@
       }
     },
     {
-      "id": "f-富山市~水橋ふれあいコミュニティバス",
+      "id": "f-富山市~水橋ふれあいコミュニティバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/mizuhashifureaicommunitybus/files/feed.zip?rid=next"
@@ -2899,7 +7797,7 @@
       "id": "f-寒河江市内循環バススマイル号",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/sagaecity/feeds/SagaeCity/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sagaecity/feeds/SagaeCity/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2910,10 +7808,10 @@
       }
     },
     {
-      "id": "f-寒河江市内循環バススマイル号",
+      "id": "f-寒河江市内循環バススマイル号~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/sagaecity/feeds/SagaeCity/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sagaecity/feeds/SagaeCity/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2934,7 +7832,7 @@
       }
     },
     {
-      "id": "f-射水市~きときとバス",
+      "id": "f-射水市~きときとバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/imizucity/feeds/imizushi/files/feed.zip?rid=next"
@@ -2958,7 +7856,7 @@
       }
     },
     {
-      "id": "f-小国町営バス",
+      "id": "f-小国町営バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-ogunitown/feeds/OguniTown/files/feed.zip?rid=next"
@@ -2975,14 +7873,14 @@
       "id": "f-小矢部市~小矢部市営バスメルバス~乗合タクシー",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/oyabecity/feeds/oyabecitybus/files/feed.zip?rid=next"
+        "static_current": "https://toyama-pref.box.com/shared/static/8xvzsmuxou6kj8moe999t5r0dah953ov.zip"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-小矢部市~小矢部市営バスメルバス~乗合タクシー",
+      "id": "f-小矢部市~小矢部市営バスメルバス~乗合タクシー~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/oyabecity/feeds/oyabecitybus/files/feed.zip"
@@ -2992,10 +7890,10 @@
       }
     },
     {
-      "id": "f-小矢部市~小矢部市営バスメルバス~乗合タクシー",
+      "id": "f-小矢部市~小矢部市営バスメルバス~乗合タクシー~2",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/8xvzsmuxou6kj8moe999t5r0dah953ov.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/oyabecity/feeds/oyabecitybus/files/feed.zip?rid=next"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -3016,7 +7914,7 @@
       }
     },
     {
-      "id": "f-小豆島オリーブバス",
+      "id": "f-小豆島オリーブバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/ShodoshimaOliveBus/AllLines.zip?date=next"
@@ -3030,7 +7928,7 @@
       }
     },
     {
-      "id": "f-小豆島オリーブバス",
+      "id": "f-小豆島オリーブバス~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/ShodoshimaOliveBus/AllLines.zip?date=latest"
@@ -3058,7 +7956,7 @@
       }
     },
     {
-      "id": "f-小野市コミュニティバス",
+      "id": "f-小野市コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-ono/feeds/ranranbus/files/feed.zip?rid=current"
@@ -3072,7 +7970,7 @@
       }
     },
     {
-      "id": "f-小野市コミュニティバス",
+      "id": "f-小野市コミュニティバス~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-ono/feeds/ranranbus/files/feed.zip?rid=next"
@@ -3100,7 +7998,7 @@
       }
     },
     {
-      "id": "f-尾花沢市路線バス",
+      "id": "f-尾花沢市路線バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/obanazawacity/feeds/ObanazawaCity/files/feed.zip?rid=next"
@@ -3128,7 +8026,7 @@
       }
     },
     {
-      "id": "f-山交バス",
+      "id": "f-山交バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/yamakobus/feeds/YAMAKOBUS/files/feed.zip?rid=next"
@@ -3145,7 +8043,7 @@
       "id": "f-山形市~ベニちゃんバスコミュニティバス高瀬線地域交流バス南部線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-yamagatacity/feeds/YamagataCity/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-yamagatacity/feeds/YamagataCity/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3156,10 +8054,10 @@
       }
     },
     {
-      "id": "f-山形市~ベニちゃんバスコミュニティバス高瀬線地域交流バス南部線",
+      "id": "f-山形市~ベニちゃんバスコミュニティバス高瀬線地域交流バス南部線~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-yamagatacity/feeds/YamagataCity/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-yamagatacity/feeds/YamagataCity/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3198,7 +8096,7 @@
       }
     },
     {
-      "id": "f-山辺町~やまのべコミュニティバス",
+      "id": "f-山辺町~やまのべコミュニティバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/yamanobetown/feeds/YamanobeTown/files/feed.zip?rid=next"
@@ -3271,7 +8169,7 @@
       "id": "f-島田市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shimadacity/feeds/shimada_combus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shimadacity/feeds/shimada_combus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3282,10 +8180,10 @@
       }
     },
     {
-      "id": "f-島田市コミュニティバス",
+      "id": "f-島田市コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shimadacity/feeds/shimada_combus/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shimadacity/feeds/shimada_combus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3324,7 +8222,7 @@
       }
     },
     {
-      "id": "f-市川町コミュニティバス",
+      "id": "f-市川町コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/ichikawatown/feeds/communitybus/files/feed.zip?rid=next"
@@ -3371,20 +8269,6 @@
       "id": "f-庄内交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shonaikotsu/feeds/SHONAIKOTSU/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-庄内交通",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://www.pref.yamagata.jp/documents/20978/syonaikotsu_gtfs.zip"
       },
       "license": {
@@ -3396,10 +8280,24 @@
       }
     },
     {
-      "id": "f-庄内交通",
+      "id": "f-庄内交通~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/shonaikotsu/feeds/SHONAIKOTSU/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-庄内交通~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shonaikotsu/feeds/SHONAIKOTSU/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3424,7 +8322,7 @@
       }
     },
     {
-      "id": "f-庄内町~町営バス",
+      "id": "f-庄内町~町営バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/shonaitown/feeds/ShonaiTown/files/feed.zip?rid=next"
@@ -3452,7 +8350,7 @@
       }
     },
     {
-      "id": "f-度会町~町営バス",
+      "id": "f-度会町~町営バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/wataraitown/feeds/choeibus/files/feed.zip?rid=next"
@@ -3479,20 +8377,6 @@
       "id": "f-徳島バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus/feeds/tokushimabus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-徳島バス",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus/feeds/tokushimabus/files/feed.zip"
       },
       "license": {
@@ -3504,10 +8388,10 @@
       }
     },
     {
-      "id": "f-徳島バス南部",
+      "id": "f-徳島バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus-nanbu/feeds/tokushimabusnanbu/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus/feeds/tokushimabus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3532,6 +8416,20 @@
       }
     },
     {
+      "id": "f-徳島バス南部~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus-nanbu/feeds/tokushimabusnanbu/files/feed.zip?rid=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
       "id": "f-徳島バス阿南",
       "spec": "gtfs",
       "urls": {
@@ -3546,24 +8444,10 @@
       }
     },
     {
-      "id": "f-徳島バス阿南",
+      "id": "f-徳島バス阿南~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus-anan/feeds/tokushimabusanan/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-徳島市~上八万コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushimacity/feeds/kamihachimanbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3588,10 +8472,10 @@
       }
     },
     {
-      "id": "f-徳島市~応神ふれあいバス",
+      "id": "f-徳島市~上八万コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushimacity/feeds/oujinfureaibus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushimacity/feeds/kamihachimanbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3616,24 +8500,10 @@
       }
     },
     {
-      "id": "f-徳島市営バス",
+      "id": "f-徳島市~応神ふれあいバス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-shiei/feeds/tokushimacitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-徳島市営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-shiei/feeds/tokushimacitybus/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushimacity/feeds/oujinfureaibus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3648,6 +8518,34 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2649/url_resource/66/GTFS-JP.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-徳島市営バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-shiei/feeds/tokushimacitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-徳島市営バス~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-shiei/feeds/tokushimacitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3675,7 +8573,7 @@
       "id": "f-恵那市自主運行バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/enacity/feeds/communitybus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/enacity/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3686,10 +8584,10 @@
       }
     },
     {
-      "id": "f-恵那市自主運行バス",
+      "id": "f-恵那市自主運行バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/enacity/feeds/communitybus/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/enacity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3714,7 +8612,7 @@
       }
     },
     {
-      "id": "f-掛川市自主運行バス~市街地循環線北回りジーネット",
+      "id": "f-掛川市自主運行バス~市街地循環線北回りジーネット~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/65791/shigaichijyunkan-kita.zip"
@@ -3742,7 +8640,7 @@
       }
     },
     {
-      "id": "f-掛川市自主運行バス~掛川大須賀線ジーネット",
+      "id": "f-掛川市自主運行バス~掛川大須賀線ジーネット~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/66106/kakegawaosuka202304.zip"
@@ -3770,24 +8668,10 @@
       }
     },
     {
-      "id": "f-掛川市自主運行バス~桜木線~居尻線~倉真線~東山線~粟本線~市街地循環線南回り掛川バスサービス",
+      "id": "f-掛川市自主運行バス~桜木線~居尻線~倉真線~東山線~粟本線~市街地循環線南回り掛川バスサービス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/66109/sakuragi.ijiri.kurami.higashiyama.awamoto.shigaichijyunkan-minami202304.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-揖斐川町~ふれあいバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/ibigawatown/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3812,7 +8696,21 @@
       }
     },
     {
-      "id": "f-揖斐川町~ふれあいバス",
+      "id": "f-揖斐川町~ふれあいバス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ibigawatown/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-揖斐川町~ふれあいバス~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/ibigawatown/feeds/communitybus/files/feed.zip?rid=next"
@@ -3829,7 +8727,7 @@
       "id": "f-新庄市~市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shinjocity/feeds/ShinjoCity/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shinjocity/feeds/ShinjoCity/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3840,10 +8738,10 @@
       }
     },
     {
-      "id": "f-新庄市~市営バス",
+      "id": "f-新庄市~市営バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shinjocity/feeds/ShinjoCity/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shinjocity/feeds/ShinjoCity/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3882,24 +8780,10 @@
       }
     },
     {
-      "id": "f-日光市営バス",
+      "id": "f-日光市営バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nikkocity/feeds/nikkocity/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-日本中央バス前橋近郊路線空港バス高速バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Maebashi_Area.zip?date=latest"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3924,10 +8808,24 @@
       }
     },
     {
-      "id": "f-日本中央バス前橋近郊路線空港バス高速バス",
+      "id": "f-日本中央バス前橋近郊路線空港バス高速バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Maebashi_Area.zip?date=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-日本中央バス前橋近郊路線空港バス高速バス~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Maebashi_Area.zip?date=latest"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3952,7 +8850,7 @@
       }
     },
     {
-      "id": "f-日本中央バス奥多野線",
+      "id": "f-日本中央バス奥多野線~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Okutano_Area.zip?date=current"
@@ -3966,7 +8864,7 @@
       }
     },
     {
-      "id": "f-日本中央バス奥多野線",
+      "id": "f-日本中央バス奥多野線~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Okutano_Area.zip?date=latest"
@@ -4022,7 +8920,7 @@
       }
     },
     {
-      "id": "f-日進市巡回バス~くるりんばす",
+      "id": "f-日進市巡回バス~くるりんばす~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nisshincity/feeds/communitybus/files/feed.zip"
@@ -4036,7 +8934,7 @@
       }
     },
     {
-      "id": "f-日進市巡回バス~くるりんばす",
+      "id": "f-日進市巡回バス~くるりんばす~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nisshincity/feeds/communitybus/files/feed.zip?rid=next"
@@ -4067,7 +8965,7 @@
       "id": "f-早島町コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hayashimatown/feeds/hayashimatowncommunitybus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hayashimatown/feeds/hayashimatowncommunitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4078,10 +8976,10 @@
       }
     },
     {
-      "id": "f-早島町コミュニティバス",
+      "id": "f-早島町コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hayashimatown/feeds/hayashimatowncommunitybus/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hayashimatown/feeds/hayashimatowncommunitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4106,7 +9004,7 @@
       }
     },
     {
-      "id": "f-明知鉄道",
+      "id": "f-明知鉄道~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/aketetsu/feeds/akechirailway/files/feed.zip?rid=next"
@@ -4134,27 +9032,13 @@
       }
     },
     {
-      "id": "f-明石市~たこバス",
+      "id": "f-明石市~たこバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/akashicity/feeds/tacobustacobusmini/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-最上川交通",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/mogamigawakotsu/feeds/MOGAMIGAWAKOTSU/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       },
       "tags": {
@@ -4176,10 +9060,14 @@
       }
     },
     {
-      "id": "f-朝日町~あさひまちバス",
+      "id": "f-最上川交通~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyama-asahitown/feeds/asahimachibus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/mogamigawakotsu/feeds/MOGAMIGAWAKOTSU/files/feed.zip?rid=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -4190,6 +9078,16 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/toyama-asahitown/feeds/asahimachibus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-朝日町~あさひまちバス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyama-asahitown/feeds/asahimachibus/files/feed.zip?rid=next"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -4210,24 +9108,10 @@
       }
     },
     {
-      "id": "f-朝日町路線バス",
+      "id": "f-朝日町路線バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-asahitown/feeds/AsahiTown/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-朝来市コミュニティバスアコバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/asagocity/feeds/acobus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4252,10 +9136,10 @@
       }
     },
     {
-      "id": "f-村山市~市営バス",
+      "id": "f-朝来市コミュニティバスアコバス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/murayamacity/feeds/MurayamaCity/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/asagocity/feeds/acobus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4280,6 +9164,20 @@
       }
     },
     {
+      "id": "f-村山市~市営バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/murayamacity/feeds/MurayamaCity/files/feed.zip?rid=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
       "id": "f-東みよし町営バス",
       "spec": "gtfs",
       "urls": {
@@ -4294,7 +9192,7 @@
       }
     },
     {
-      "id": "f-東みよし町営バス",
+      "id": "f-東みよし町営バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/higashimiyoshitown/feeds/hitashimiyoshitownbus/files/feed.zip?rid=next"
@@ -4311,16 +9209,6 @@
       "id": "f-東京都町田市~コミュニティバス市民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/MachidaCity/AllLines.zip?date=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-東京都町田市~コミュニティバス市民バス",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/MachidaCity/AllLines.zip?date=current"
       },
       "tags": {
@@ -4328,7 +9216,17 @@
       }
     },
     {
-      "id": "f-東京都町田市~コミュニティバス市民バス",
+      "id": "f-東京都町田市~コミュニティバス市民バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/MachidaCity/AllLines.zip?date=next"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-東京都町田市~コミュニティバス市民バス~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/MachidaCity/AllLines.zip?date=latest"
@@ -4341,7 +9239,7 @@
       "id": "f-東根市~市民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/higashinecity/feeds/HigashineCity/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/higashinecity/feeds/HigashineCity/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4352,10 +9250,10 @@
       }
     },
     {
-      "id": "f-東根市~市民バス",
+      "id": "f-東根市~市民バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/higashinecity/feeds/HigashineCity/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/higashinecity/feeds/HigashineCity/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4380,7 +9278,7 @@
       }
     },
     {
-      "id": "f-東浦町運行バスう~ら~ら",
+      "id": "f-東浦町運行バスう~ら~ら~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/higashiuratown/feeds/communitybus/files/feed.zip"
@@ -4394,7 +9292,7 @@
       }
     },
     {
-      "id": "f-東浦町運行バスう~ら~ら",
+      "id": "f-東浦町運行バスう~ら~ら~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/higashiuratown/feeds/communitybus/files/feed.zip?rid=next"
@@ -4411,7 +9309,7 @@
       "id": "f-東鉄バス東濃鉄道",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tohtetsu/feeds/tohtetsu_ena/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tohtetsu/feeds/tohtetsu_ena/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4422,10 +9320,10 @@
       }
     },
     {
-      "id": "f-東鉄バス東濃鉄道",
+      "id": "f-東鉄バス東濃鉄道~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tohtetsu/feeds/tohtetsu_ena/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tohtetsu/feeds/tohtetsu_ena/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4464,7 +9362,7 @@
       }
     },
     {
-      "id": "f-松茂町地域コミュニティバス",
+      "id": "f-松茂町地域コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/matsushigetown/feeds/matsushigetownbus/files/feed.zip?rid=next"
@@ -4492,7 +9390,7 @@
       }
     },
     {
-      "id": "f-松阪市コミュニティ交通",
+      "id": "f-松阪市コミュニティ交通~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/matsusakacity/feeds/communitybus/files/feed.zip?rid=next"
@@ -4523,34 +9421,6 @@
       "id": "f-桑名市~k-バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kuwanacity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-桑名市~k-バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kuwanacity/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-桑名市~k-バス",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://www.rosenzu.com/~gtfs/kuwana/kuwana_GTFS_next.zip"
       },
       "license": {
@@ -4562,10 +9432,24 @@
       }
     },
     {
-      "id": "f-横須賀市~ハマちゃんバス",
+      "id": "f-桑名市~k-バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yokosukacity/feeds/hamachanbus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kuwanacity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-桑名市~k-バス~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kuwanacity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4580,6 +9464,20 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/yokosukacity/feeds/hamachanbus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-横須賀市~ハマちゃんバス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yokosukacity/feeds/hamachanbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4607,7 +9505,7 @@
       "id": "f-武豊町ゆめころん",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/taketoyotown/feeds/communitybus/files/feed.zip?rid=next"
+        "static_current": "https://www.rosenzu.com/~gtfs/taketoyo/taketoyo_GTFS_next.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4618,7 +9516,7 @@
       }
     },
     {
-      "id": "f-武豊町ゆめころん",
+      "id": "f-武豊町ゆめころん~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/taketoyotown/feeds/communitybus/files/feed.zip"
@@ -4632,10 +9530,10 @@
       }
     },
     {
-      "id": "f-武豊町ゆめころん",
+      "id": "f-武豊町ゆめころん~2",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/taketoyo/taketoyo_GTFS_next.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/taketoyotown/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4660,49 +9558,7 @@
       }
     },
     {
-      "id": "f-永井バス永井運輸",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/AllLines.zip?date=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-永井バス永井運輸",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/AllLines.zip?date=latest"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-永井バス永井運輸",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagai-unyu/feeds/Nagaibus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-永井バス永井運輸",
+      "id": "f-永井バス永井運輸~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/AllLines.zip?date=current"
@@ -4716,10 +9572,52 @@
       }
     },
     {
-      "id": "f-永井バス永井運輸",
+      "id": "f-永井バス永井運輸~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/AllLines.zip?date=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-永井バス永井運輸~3",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/AllLines.zip?date=latest"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-永井バス永井運輸~4",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nagai-unyu/feeds/Nagaibus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-永井バス永井運輸~5",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagai-unyu/feeds/Nagaibus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4747,7 +9645,7 @@
       "id": "f-河北町路線バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kahokutown/feeds/KahokuTown/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kahokutown/feeds/KahokuTown/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4758,10 +9656,10 @@
       }
     },
     {
-      "id": "f-河北町路線バス",
+      "id": "f-河北町路線バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kahokutown/feeds/KahokuTown/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kahokutown/feeds/KahokuTown/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4789,20 +9687,6 @@
       "id": "f-津山市~市営阿波バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuyamacity/feeds/bus-tsuyamacity-okayama-jp/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-津山市~市営阿波バス",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuyamacity/feeds/bus-tsuyamacity-okayama-jp/files/feed.zip"
       },
       "license": {
@@ -4814,24 +9698,10 @@
       }
     },
     {
-      "id": "f-津市コミュニティバス",
+      "id": "f-津山市~市営阿波バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsucity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-津市コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsucity/feeds/communitybus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuyamacity/feeds/bus-tsuyamacity-okayama-jp/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4856,13 +9726,27 @@
       }
     },
     {
-      "id": "f-洲本市コミュニティバス",
+      "id": "f-津市コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/sumotocity/feeds/communitybus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsucity/feeds/communitybus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-津市コミュニティバス~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsucity/feeds/communitybus/files/feed.zip?rid=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       },
       "tags": {
@@ -4874,6 +9758,20 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/sumotocity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-洲本市コミュニティバス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sumotocity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -4898,7 +9796,7 @@
       }
     },
     {
-      "id": "f-流山市~流山ぐりーんバス",
+      "id": "f-流山市~流山ぐりーんバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nagareyamacity/feeds/nagareyamagreenbus/files/feed.zip"
@@ -4912,7 +9810,7 @@
       }
     },
     {
-      "id": "f-流山市~流山ぐりーんバス",
+      "id": "f-流山市~流山ぐりーんバス~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nagareyamacity/feeds/nagareyamagreenbus/files/feed.zip?rid=next"
@@ -4943,20 +9841,6 @@
       "id": "f-海津市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaizucity/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-海津市コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://www.rosenzu.com/~gtfs/kaizu/kaizu_GTFS_next.zip"
       },
       "license": {
@@ -4968,10 +9852,24 @@
       }
     },
     {
-      "id": "f-海津市コミュニティバス",
+      "id": "f-海津市コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/kaizucity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-海津市コミュニティバス~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaizucity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4996,7 +9894,7 @@
       }
     },
     {
-      "id": "f-海陽町営バス",
+      "id": "f-海陽町営バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/kaiyotown/feeds/kaiyotownbus/files/feed.zip?rid=next"
@@ -5024,7 +9922,7 @@
       }
     },
     {
-      "id": "f-淡路市~あわ神あわ姫バス",
+      "id": "f-淡路市~あわ神あわ姫バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/awajicity/feeds/awajinawahimebus/files/feed.zip?rid=next"
@@ -5041,6 +9939,16 @@
       "id": "f-滑川市~のる~my~car",
       "spec": "gtfs",
       "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/jpxqjqmxqrbu47o2f45i84f3m43qkxzi.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-滑川市~のる~my~car~1",
+      "spec": "gtfs",
+      "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/namerikawacity/feeds/norumycar/files/feed.zip"
       },
       "tags": {
@@ -5048,20 +9956,10 @@
       }
     },
     {
-      "id": "f-滑川市~のる~my~car",
+      "id": "f-滑川市~のる~my~car~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/namerikawacity/feeds/norumycar/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-滑川市~のる~my~car",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/jpxqjqmxqrbu47o2f45i84f3m43qkxzi.zip"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -5127,7 +10025,7 @@
       "id": "f-熊本市電",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kumamoto-shiden/feeds/kumamotoshiden/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kumamoto-shiden/feeds/kumamotoshiden/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -5138,10 +10036,10 @@
       }
     },
     {
-      "id": "f-熊本市電",
+      "id": "f-熊本市電~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kumamoto-shiden/feeds/kumamotoshiden/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kumamoto-shiden/feeds/kumamotoshiden/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -5194,7 +10092,7 @@
       }
     },
     {
-      "id": "f-猪名川町~ふれあいバス",
+      "id": "f-猪名川町~ふれあいバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/inagawatown/feeds/fureaibus/files/feed.zip?rid=next"
@@ -5211,6 +10109,20 @@
       "id": "f-玉村町乗合タクシー~たまりん",
       "spec": "gtfs",
       "urls": {
+        "static_current": "https://www.nagai-unyu.net/rosen/GTFS/tamarin/latest/GTFS-JP_tamarin-gunma-jp.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-玉村町乗合タクシー~たまりん~1",
+      "spec": "gtfs",
+      "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/Tamarin.zip?date=current"
       },
       "license": {
@@ -5222,49 +10134,7 @@
       }
     },
     {
-      "id": "f-玉村町乗合タクシー~たまりん",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagai-unyu/feeds/tamarin/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-玉村町乗合タクシー~たまりん",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/Tamarin.zip?date=latest"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-玉村町乗合タクシー~たまりん",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagai-unyu/feeds/tamarin/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-玉村町乗合タクシー~たまりん",
+      "id": "f-玉村町乗合タクシー~たまりん~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/Tamarin.zip?date=next"
@@ -5278,10 +10148,38 @@
       }
     },
     {
-      "id": "f-玉村町乗合タクシー~たまりん",
+      "id": "f-玉村町乗合タクシー~たまりん~3",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.nagai-unyu.net/rosen/GTFS/tamarin/latest/GTFS-JP_tamarin-gunma-jp.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/Tamarin.zip?date=latest"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-玉村町乗合タクシー~たまりん~4",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagai-unyu/feeds/tamarin/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-玉村町乗合タクシー~たまりん~5",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagai-unyu/feeds/tamarin/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -5309,20 +10207,6 @@
       "id": "f-琴参バス坂出営業所",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/sakaide-local/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-琴参バス坂出営業所",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/sakaide-local/files/feed.zip"
       },
       "license": {
@@ -5334,10 +10218,10 @@
       }
     },
     {
-      "id": "f-琴参バス琴平営業所",
+      "id": "f-琴参バス坂出営業所~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/kotohira-local/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/sakaide-local/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -5362,24 +10246,10 @@
       }
     },
     {
-      "id": "f-瑞浪市コミュニティバス",
+      "id": "f-琴参バス琴平営業所~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/mizunamicity/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-瑞浪市コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/mizunamicity/feeds/communitybus/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/kotohira-local/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -5404,6 +10274,34 @@
       }
     },
     {
+      "id": "f-瑞浪市コミュニティバス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/mizunamicity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-瑞浪市コミュニティバス~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/mizunamicity/feeds/communitybus/files/feed.zip?rid=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
       "id": "f-生活バスよっかいち",
       "spec": "gtfs",
       "urls": {
@@ -5418,7 +10316,7 @@
       }
     },
     {
-      "id": "f-生活バスよっかいち",
+      "id": "f-生活バスよっかいち~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/seikatsubus-yokkaichi/feeds/sbusyokkaichi/files/feed.zip?rid=next"
@@ -5474,7 +10372,7 @@
       }
     },
     {
-      "id": "f-白山市コミュニティバスめぐーる",
+      "id": "f-白山市コミュニティバスめぐーる~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/hakusancity/feeds/hakusan_bus_meguru/files/feed.zip?rid=next"
@@ -5502,7 +10400,7 @@
       }
     },
     {
-      "id": "f-白鷹町~町営バス",
+      "id": "f-白鷹町~町営バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/shiratakatown/feeds/ShiratakaTown/files/feed.zip?rid=next"
@@ -5530,7 +10428,7 @@
       }
     },
     {
-      "id": "f-真室川町路線バス",
+      "id": "f-真室川町路線バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/mamurogawatown/feeds/MamurogawaTown/files/feed.zip?rid=next"
@@ -5561,6 +10459,16 @@
       "id": "f-砺波市~砺波市営バス",
       "spec": "gtfs",
       "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/70l7nwf33az6y13k4hzyc1gw679enkss.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-砺波市~砺波市営バス~1",
+      "spec": "gtfs",
+      "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/tonamicity/feeds/tonamishieibasu/files/feed.zip"
       },
       "tags": {
@@ -5568,20 +10476,10 @@
       }
     },
     {
-      "id": "f-砺波市~砺波市営バス",
+      "id": "f-砺波市~砺波市営バス~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/tonamicity/feeds/tonamishieibasu/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-砺波市~砺波市営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/70l7nwf33az6y13k4hzyc1gw679enkss.zip"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -5605,20 +10503,6 @@
       "id": "f-神戸市垂水区~塩屋コミュニティバスしおかぜ",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kobecity/feeds/kobe-shiokaze/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-神戸市垂水区~塩屋コミュニティバスしおかぜ",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/kobecity/feeds/kobe-shiokaze/files/feed.zip"
       },
       "license": {
@@ -5630,13 +10514,13 @@
       }
     },
     {
-      "id": "f-神河町コミュニティバス",
+      "id": "f-神戸市垂水区~塩屋コミュニティバスしおかぜ~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-kamikawatown/feeds/communitybus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kobecity/feeds/kobe-shiokaze/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
       },
       "tags": {
@@ -5648,6 +10532,20 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-kamikawatown/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-神河町コミュニティバス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-kamikawatown/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -5672,7 +10570,7 @@
       }
     },
     {
-      "id": "f-福崎町コミュニティバス巡回バスふくひめ号福崎町~加西市連携コミュニティバス",
+      "id": "f-福崎町コミュニティバス巡回バスふくひめ号福崎町~加西市連携コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/fukusakitown/feeds/junkai-fukuhime-fukusakikasairenkei/files/feed.zip?rid=next"
@@ -5717,20 +10615,6 @@
       "id": "f-秋田市マイタウン~バス中心市街地循環バスぐるる県バス協会掲載版",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/next/bus-akitacity.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-秋田市マイタウン~バス中心市街地循環バスぐるる県バス協会掲載版",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-akitacity.zip"
       },
       "license": {
@@ -5742,10 +10626,14 @@
       }
     },
     {
-      "id": "f-立山町~立山町営バス",
+      "id": "f-秋田市マイタウン~バス中心市街地循環バスぐるる県バス協会掲載版~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tateyamatown/feeds/tateyama/files/feed.zip?rid=next"
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/next/bus-akitacity.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -5756,6 +10644,16 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/tateyamatown/feeds/tateyama/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-立山町~立山町営バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tateyamatown/feeds/tateyama/files/feed.zip?rid=next"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -5803,7 +10701,7 @@
       "id": "f-笠松町公共施設巡回町民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kasamatsutown/feeds/communitybus/files/feed.zip?rid=next"
+        "static_current": "https://www.rosenzu.com/~gtfs/kasamatsu/kasamatsu_GTFS_next.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -5814,7 +10712,7 @@
       }
     },
     {
-      "id": "f-笠松町公共施設巡回町民バス",
+      "id": "f-笠松町公共施設巡回町民バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/kasamatsutown/feeds/communitybus/files/feed.zip"
@@ -5828,24 +10726,10 @@
       }
     },
     {
-      "id": "f-笠松町公共施設巡回町民バス",
+      "id": "f-笠松町公共施設巡回町民バス~2",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/kasamatsu/kasamatsu_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-米沢市~市民バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yonezawacity/feeds/Yonezawa/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kasamatsutown/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -5860,6 +10744,20 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/yonezawacity/feeds/Yonezawa/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-米沢市~市民バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yonezawacity/feeds/Yonezawa/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -5912,7 +10810,7 @@
       }
     },
     {
-      "id": "f-美波町~美波病院連絡バス",
+      "id": "f-美波町~美波病院連絡バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-minamitown/feeds/minabubyoinrenrakubus/files/feed.zip"
@@ -5926,7 +10824,7 @@
       }
     },
     {
-      "id": "f-美波町~美波病院連絡バス",
+      "id": "f-美波町~美波病院連絡バス~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-minamitown/feeds/minabubyoinrenrakubus/files/feed.zip?rid=next"
@@ -5943,7 +10841,7 @@
       "id": "f-美濃加茂市コミュニティバスあい愛バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/minokamocity/feeds/communitybus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/minokamocity/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -5954,10 +10852,10 @@
       }
     },
     {
-      "id": "f-美濃加茂市コミュニティバスあい愛バス",
+      "id": "f-美濃加茂市コミュニティバスあい愛バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/minokamocity/feeds/communitybus/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/minokamocity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -5985,6 +10883,20 @@
       "id": "f-群馬中央バス",
       "spec": "gtfs",
       "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/GunmachuoBus/AllLines.zip?date=current"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-群馬中央バス~1",
+      "spec": "gtfs",
+      "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/GunmachuoBus/AllLines.zip?date=next"
       },
       "license": {
@@ -5996,24 +10908,10 @@
       }
     },
     {
-      "id": "f-群馬中央バス",
+      "id": "f-群馬中央バス~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/GunmachuoBus/AllLines.zip?date=latest"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-群馬中央バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/GunmachuoBus/AllLines.zip?date=current"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -6132,7 +11030,7 @@
       }
     },
     {
-      "id": "f-西宮市~さくらやまなみバス",
+      "id": "f-西宮市~さくらやまなみバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinomiyacity/feeds/sakurayamanami/files/feed.zip?rid=next"
@@ -6160,7 +11058,7 @@
       }
     },
     {
-      "id": "f-西宮市コミュニティ交通ぐるっと生瀬",
+      "id": "f-西宮市コミュニティ交通ぐるっと生瀬~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinomiyacity/feeds/guruttonamaze/files/feed.zip?rid=next"
@@ -6184,7 +11082,7 @@
       }
     },
     {
-      "id": "f-西尾市~いっちゃんバス",
+      "id": "f-西尾市~いっちゃんバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiocity/feeds/ichanbus/files/feed.zip?rid=next"
@@ -6204,7 +11102,7 @@
       }
     },
     {
-      "id": "f-西尾市~六万石くるりんバス",
+      "id": "f-西尾市~六万石くるりんバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiocity/feeds/rokumangokukururinbus/files/feed.zip?rid=next"
@@ -6228,7 +11126,7 @@
       }
     },
     {
-      "id": "f-西川町路線バス",
+      "id": "f-西川町路線バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nishikawatown/feeds/NishikawaTown/files/feed.zip?rid=next"
@@ -6245,16 +11143,6 @@
       "id": "f-西日本ジェイアールバス~名金線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinihonjrbus/feeds/meikinsen/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-西日本ジェイアールバス~名金線",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinihonjrbus/feeds/meikinsen/files/feed.zip"
       },
       "tags": {
@@ -6262,14 +11150,10 @@
       }
     },
     {
-      "id": "f-西脇市コミュニティバスループバスめぐリンおりひめバス",
+      "id": "f-西日本ジェイアールバス~名金線~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiwakicity/feeds/loopbus-orihimebus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinihonjrbus/feeds/meikinsen/files/feed.zip?rid=next"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -6280,6 +11164,20 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiwakicity/feeds/loopbus-orihimebus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-西脇市コミュニティバスループバスめぐリンおりひめバス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiwakicity/feeds/loopbus-orihimebus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -6304,7 +11202,7 @@
       }
     },
     {
-      "id": "f-豊山町~とよやまタウンバス",
+      "id": "f-豊山町~とよやまタウンバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/toyoyamatown/feeds/communitybus/files/feed.zip?rid=next"
@@ -6321,7 +11219,7 @@
       "id": "f-豊岡市~市営バスイナカー",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyookacity/feeds/inacar/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyookacity/feeds/inacar/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -6332,10 +11230,10 @@
       }
     },
     {
-      "id": "f-豊岡市~市営バスイナカー",
+      "id": "f-豊岡市~市営バスイナカー~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyookacity/feeds/inacar/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyookacity/feeds/inacar/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -6360,41 +11258,13 @@
       }
     },
     {
-      "id": "f-豊岡市~市街地循環バスコバス",
+      "id": "f-豊岡市~市街地循環バスコバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/toyookacity/feeds/kobus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-豊田市~とよたおいでんバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyotacity/feeds/kikanbus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-豊田市~とよたおいでんバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyotacity/feeds/kikanbus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       },
       "tags": {
@@ -6416,10 +11286,24 @@
       }
     },
     {
-      "id": "f-豊田市~地域バス",
+      "id": "f-豊田市~とよたおいでんバス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyotacity/feeds/chiikibus/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyotacity/feeds/kikanbus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-豊田市~とよたおいでんバス~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyotacity/feeds/kikanbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -6444,7 +11328,21 @@
       }
     },
     {
-      "id": "f-豊田市~地域バス",
+      "id": "f-豊田市~地域バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyotacity/feeds/chiikibus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-豊田市~地域バス~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/toyotacity/feeds/chiikibus/files/feed.zip?rid=next"
@@ -6461,6 +11359,16 @@
       "id": "f-赤磐市広域路線バス~市民バス",
       "spec": "gtfs",
       "urls": {
+        "static_current": "https://www.city.akaiwa.lg.jp/material/files/group/5/GTFS-JP.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-赤磐市広域路線バス~市民バス~1",
+      "spec": "gtfs",
+      "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AkaiwaCity/AllLines.zip?date=current"
       },
       "tags": {
@@ -6468,17 +11376,7 @@
       }
     },
     {
-      "id": "f-赤磐市広域路線バス~市民バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AkaiwaCity/AllLines.zip?date=latest"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-赤磐市広域路線バス~市民バス",
+      "id": "f-赤磐市広域路線バス~市民バス~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AkaiwaCity/AllLines.zip?date=next"
@@ -6488,10 +11386,10 @@
       }
     },
     {
-      "id": "f-赤磐市広域路線バス~市民バス",
+      "id": "f-赤磐市広域路線バス~市民バス~3",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.akaiwa.lg.jp/material/files/group/5/GTFS-JP.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AkaiwaCity/AllLines.zip?date=latest"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -6515,7 +11413,7 @@
       "id": "f-那賀町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nakatown/feeds/nakatownbus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nakatown/feeds/nakatownbus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -6526,10 +11424,10 @@
       }
     },
     {
-      "id": "f-那賀町営バス",
+      "id": "f-那賀町営バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nakatown/feeds/nakatownbus/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nakatown/feeds/nakatownbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -6554,7 +11452,7 @@
       }
     },
     {
-      "id": "f-酒田市~るんるんバス",
+      "id": "f-酒田市~るんるんバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/sakatacity/feeds/SakataCity/files/feed.zip?rid=next"
@@ -6571,7 +11469,7 @@
       "id": "f-金山町町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-kaneyamatown/feeds/KaneyamaTown/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-kaneyamatown/feeds/KaneyamaTown/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -6582,10 +11480,10 @@
       }
     },
     {
-      "id": "f-金山町町営バス",
+      "id": "f-金山町町営バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-kaneyamatown/feeds/KaneyamaTown/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-kaneyamatown/feeds/KaneyamaTown/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -6613,7 +11511,7 @@
       "id": "f-長井市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagaicity/feeds/NagaiCity/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagaicity/feeds/NagaiCity/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -6624,10 +11522,10 @@
       }
     },
     {
-      "id": "f-長井市営バス",
+      "id": "f-長井市営バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagaicity/feeds/NagaiCity/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagaicity/feeds/NagaiCity/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -6806,7 +11704,7 @@
       }
     },
     {
-      "id": "f-阿佐海岸鉄道",
+      "id": "f-阿佐海岸鉄道~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/asatetu/feeds/asakaigantetsudo/files/feed.zip?rid=next"
@@ -6823,16 +11721,6 @@
       "id": "f-階上町コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.aomori.lg.jp/dataset/1596/resource/19655/gtfs_hashikamicho_com_latest.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-階上町コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://opendata.pref.aomori.lg.jp/dataset/1596/resource/16908/gtfs_hashikamicho_com.zip"
       },
       "tags": {
@@ -6840,28 +11728,10 @@
       }
     },
     {
-      "id": "f-青森市営バス",
+      "id": "f-階上町コミュニティバス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AomoriCity/AllLines.zip?date=latest"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-青森市営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AomoriCity/AllLines.zip?date=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+        "static_current": "https://opendata.pref.aomori.lg.jp/dataset/1596/resource/19655/gtfs_hashikamicho_com_latest.zip"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -6882,10 +11752,24 @@
       }
     },
     {
-      "id": "f-飛騨市おでかけバスひだまる",
+      "id": "f-青森市営バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hidacity/feeds/communitybus/files/feed.zip?rid=next"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AomoriCity/AllLines.zip?date=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-青森市営バス~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AomoriCity/AllLines.zip?date=latest"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -6910,7 +11794,7 @@
       }
     },
     {
-      "id": "f-飛騨市おでかけバスひだまる",
+      "id": "f-飛騨市おでかけバスひだまる~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/hidacity/feeds/communitybus/files/feed.zip"
@@ -6924,13 +11808,13 @@
       }
     },
     {
-      "id": "f-養父市コミュニティバス",
+      "id": "f-飛騨市おでかけバスひだまる~2",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yabucity/feeds/waiwai-sekimiya-yoka/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hidacity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       },
       "tags": {
@@ -6942,6 +11826,20 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/yabucity/feeds/waiwai-sekimiya-yoka/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-養父市コミュニティバス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yabucity/feeds/waiwai-sekimiya-yoka/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
@@ -6966,7 +11864,7 @@
       }
     },
     {
-      "id": "f-香美町~町民バス",
+      "id": "f-香美町~町民バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-kamitown/feeds/kamichominbus/files/feed.zip?rid=next"
@@ -6990,7 +11888,7 @@
       }
     },
     {
-      "id": "f-高岡市~高岡市公営バス福岡地域",
+      "id": "f-高岡市~高岡市公営バス福岡地域~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/takaokacity/feeds/koueibus/files/feed.zip?rid=next"
@@ -7041,7 +11939,7 @@
       "id": "f-高砂市~じょうとんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/takasagocity/feeds/jotonbus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/takasagocity/feeds/jotonbus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -7052,10 +11950,10 @@
       }
     },
     {
-      "id": "f-高砂市~じょうとんバス",
+      "id": "f-高砂市~じょうとんバス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/takasagocity/feeds/jotonbus/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/takasagocity/feeds/jotonbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -7076,7 +11974,7 @@
       }
     },
     {
-      "id": "f-魚津市~予約式あいのりタクシー~おもてなし魚津直行便",
+      "id": "f-魚津市~予約式あいのりタクシー~おもてなし魚津直行便~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://toyama-pref.box.com/shared/static/glzk70eid2g89z8zos927s4emfxdvni4.zip"
@@ -7086,20 +11984,20 @@
       }
     },
     {
-      "id": "f-魚津市~予約式あいのりタクシー~おもてなし魚津直行便",
+      "id": "f-魚津市~予約式あいのりタクシー~おもてなし魚津直行便~2",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/uozucity/feeds/omotenashi/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/uozucity/feeds/omotenashi/files/feed.zip"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-魚津市~予約式あいのりタクシー~おもてなし魚津直行便",
+      "id": "f-魚津市~予約式あいのりタクシー~おもてなし魚津直行便~3",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/uozucity/feeds/omotenashi/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/uozucity/feeds/omotenashi/files/feed.zip?rid=next"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -7116,7 +12014,7 @@
       }
     },
     {
-      "id": "f-魚津市~魚津市民バス",
+      "id": "f-魚津市~魚津市民バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/uozucity/feeds/junkai/files/feed.zip"
@@ -7126,24 +12024,10 @@
       }
     },
     {
-      "id": "f-魚津市~魚津市民バス",
+      "id": "f-魚津市~魚津市民バス~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/uozucity/feeds/junkai/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鮭川村村営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/sakegawavillage/feeds/SakegawaVillage/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -7164,24 +12048,10 @@
       }
     },
     {
-      "id": "f-鳥羽市~かもめバス",
+      "id": "f-鮭川村村営バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tobacity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鳥羽市~かもめバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tobacity/feeds/communitybus/files/feed.zip?rid=next"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sakegawavillage/feeds/SakegawaVillage/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -7206,6 +12076,34 @@
       }
     },
     {
+      "id": "f-鳥羽市~かもめバス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tobacity/feeds/communitybus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-鳥羽市~かもめバス~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tobacity/feeds/communitybus/files/feed.zip?rid=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
       "id": "f-鳥羽市~市営定期船",
       "spec": "gtfs",
       "urls": {
@@ -7220,7 +12118,7 @@
       }
     },
     {
-      "id": "f-鳥羽市~市営定期船",
+      "id": "f-鳥羽市~市営定期船~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/tobacity/feeds/teikisen/files/feed.zip?rid=next"
@@ -7248,7 +12146,7 @@
       }
     },
     {
-      "id": "f-鳴門市営渡船",
+      "id": "f-鳴門市営渡船~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/narutocity/feeds/narutocitytosen/files/feed.zip?rid=next"
@@ -7276,38 +12174,10 @@
       }
     },
     {
-      "id": "f-鳴門市地域バス",
+      "id": "f-鳴門市地域バス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/narutocity/feeds/narutocitychiikibus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鶴岡市~羽黒地域市営バス朝日地域市営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuruokacity/feeds/TsuruokaCity/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鶴岡市~羽黒地域市営バス朝日地域市営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuruokacity/feeds/TsuruokaCity/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -7332,6 +12202,34 @@
       }
     },
     {
+      "id": "f-鶴岡市~羽黒地域市営バス朝日地域市営バス~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuruokacity/feeds/TsuruokaCity/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-鶴岡市~羽黒地域市営バス朝日地域市営バス~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuruokacity/feeds/TsuruokaCity/files/feed.zip?rid=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
       "id": "f-鹿児島市コミュニティバスあいばす",
       "spec": "gtfs",
       "urls": {
@@ -7346,7 +12244,7 @@
       }
     },
     {
-      "id": "f-鹿児島市コミュニティバスあいばす",
+      "id": "f-鹿児島市コミュニティバスあいばす~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/kagoshimacity/feeds/aibus/files/feed.zip?rid=next"
@@ -7374,7 +12272,7 @@
       }
     },
     {
-      "id": "f-鹿沼市~リーバス",
+      "id": "f-鹿沼市~リーバス~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/kanumacity/feeds/ri-bus/files/feed.zip?rid=next"
@@ -7391,14 +12289,14 @@
       "id": "f-黒部市~市内路線バス新幹線生地線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kurobecity/feeds/shinkansenikujisen/files/feed.zip?rid=next"
+        "static_current": "https://toyama-pref.box.com/shared/static/y8rvyr2h3dtbz1tu0c2hm78teuvwqwcy.zip"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-黒部市~市内路線バス新幹線生地線",
+      "id": "f-黒部市~市内路線バス新幹線生地線~1",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/kurobecity/feeds/shinkansenikujisen/files/feed.zip"
@@ -7408,30 +12306,10 @@
       }
     },
     {
-      "id": "f-黒部市~市内路線バス新幹線生地線",
+      "id": "f-黒部市~市内路線バス新幹線生地線~2",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/y8rvyr2h3dtbz1tu0c2hm78teuvwqwcy.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-黒部市~市内路線バス石田三日市線~愛本コミュニティタクシー",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kurobecity/feeds/ishida-aimoto/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-黒部市~市内路線バス石田三日市線~愛本コミュニティタクシー",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kurobecity/feeds/ishida-aimoto/files/feed.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kurobecity/feeds/shinkansenikujisen/files/feed.zip?rid=next"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
@@ -7442,6 +12320,26 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://toyama-pref.box.com/shared/static/3vqbuvgk41hq3k47bf8b5iit989vrbbl.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-黒部市~市内路線バス石田三日市線~愛本コミュニティタクシー~1",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kurobecity/feeds/ishida-aimoto/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-黒部市~市内路線バス石田三日市線~愛本コミュニティタクシー~2",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kurobecity/feeds/ishida-aimoto/files/feed.zip?rid=next"
       },
       "tags": {
         "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"

--- a/feeds/tshimada291.github.com.dmfr.json
+++ b/feeds/tshimada291.github.com.dmfr.json
@@ -5464,20 +5464,6 @@
       }
     },
     {
-      "id": "f-下電バス下津井電鉄",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://shimoden.net/busmada/opendata/next/GTFS-JP.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
       "id": "f-両備バス",
       "spec": "gtfs",
       "urls": {
@@ -6429,16 +6415,6 @@
       "id": "f-宇野バス宇野自動車~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/UnoBus/AllLines.zip?date=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-宇野バス宇野自動車~2",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/UnoBus/AllLines.zip?date=latest"
       },
       "tags": {
@@ -6799,20 +6775,6 @@
     },
     {
       "id": "f-小豆島オリーブバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/ShodoshimaOliveBus/AllLines.zip?date=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-小豆島オリーブバス~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/ShodoshimaOliveBus/AllLines.zip?date=latest"
@@ -7387,20 +7349,6 @@
       "id": "f-日本中央バス前橋近郊路線空港バス高速バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Maebashi_Area.zip?date=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-日本中央バス前橋近郊路線空港バス高速バス~2",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Maebashi_Area.zip?date=latest"
       },
       "license": {
@@ -7645,16 +7593,6 @@
       "id": "f-東京都町田市~コミュニティバス市民バス~1",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/MachidaCity/AllLines.zip?date=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-東京都町田市~コミュニティバス市民バス~2",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/MachidaCity/AllLines.zip?date=latest"
       },
       "tags": {
@@ -7847,20 +7785,6 @@
       "id": "f-永井バス永井運輸~2",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/AllLines.zip?date=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-永井バス永井運輸~3",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/AllLines.zip?date=latest"
       },
       "license": {
@@ -7872,7 +7796,7 @@
       }
     },
     {
-      "id": "f-永井バス永井運輸~4",
+      "id": "f-永井バス永井運輸~3",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nagai-unyu/feeds/Nagaibus/files/feed.zip"
@@ -8189,20 +8113,6 @@
       "id": "f-玉村町乗合タクシー~たまりん~2",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/Tamarin.zip?date=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-玉村町乗合タクシー~たまりん~3",
-      "spec": "gtfs",
-      "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/Tamarin.zip?date=latest"
       },
       "license": {
@@ -8214,7 +8124,7 @@
       }
     },
     {
-      "id": "f-玉村町乗合タクシー~たまりん~4",
+      "id": "f-玉村町乗合タクシー~たまりん~3",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api.gtfs-data.jp/v2/organizations/nagai-unyu/feeds/tamarin/files/feed.zip"
@@ -8500,20 +8410,6 @@
       }
     },
     {
-      "id": "f-秋田市マイタウン~バス中心市街地循環バスぐるる県バス協会掲載版~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/next/bus-akitacity.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
       "id": "f-立山町~立山町営バス",
       "spec": "gtfs",
       "urls": {
@@ -8675,20 +8571,6 @@
     },
     {
       "id": "f-群馬中央バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/GunmachuoBus/AllLines.zip?date=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-群馬中央バス~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/GunmachuoBus/AllLines.zip?date=latest"
@@ -8973,16 +8855,6 @@
     },
     {
       "id": "f-赤磐市広域路線バス~市民バス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AkaiwaCity/AllLines.zip?date=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-赤磐市広域路線バス~市民バス~3",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AkaiwaCity/AllLines.zip?date=latest"
@@ -9279,20 +9151,6 @@
     },
     {
       "id": "f-青森市営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AomoriCity/AllLines.zip?date=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-青森市営バス~2",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AomoriCity/AllLines.zip?date=latest"

--- a/feeds/tshimada291.github.com.dmfr.json
+++ b/feeds/tshimada291.github.com.dmfr.json
@@ -2,5986 +2,7449 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
   "feeds": [
     {
-      "id": "f-0360005005779~jp",
+      "id": "f-jr四国バス高知支店~大栃線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/360005005779"
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Jrbus_Localbus.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-1000020472093~jp",
+      "id": "f-あおい交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/1000020472093"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/aoi-komaki/feeds/aoikotsu/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-10~jp",
+      "id": "f-あおい交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/10.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/aoi-komaki/feeds/aoikotsu/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-11~jp",
+      "id": "f-おおのハートバスささき観光",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/11.zip"
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/17/latest.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-12~jp",
+      "id": "f-ことでんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/12.zip"
+        "static_current": "https://www.kotoden.co.jp/publichtm/gtfs/gtfsdata/latest/gtfs_kb.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-131130~gtfs~jp~hachiko~bus~jp",
+      "id": "f-さかわ~おち花＊花ループバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.shibuya.tokyo.jp/assets/mng/131130_gtfs-jp_hachiko_bus.zip"
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Niyodoblue_Shuttlebus.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-133~jp",
+      "id": "f-たつの市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.sano.lg.jp/material/files/group/17/133.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tatsunocity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-1360001007585~jp",
+      "id": "f-たつの市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/1360001007585"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tatsunocity/feeds/communitybus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-1360002020959~jp",
+      "id": "f-つくば市~つくバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/1360002020959"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsukubacity/feeds/TSUKUBUS/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-1360003002626~jp",
+      "id": "f-つくば市~つくバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/1360003002626"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsukubacity/feeds/TSUKUBUS/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-1360003005018~jp",
+      "id": "f-つくば市~筑波地区支線型バスつくばね号",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/1360003005018"
+        "static_current": "https://www.city.tsukuba.lg.jp/material/files/group/126/GTFS.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-1360003007856~jp",
+      "id": "f-つくば市~筑波地区支線型バスつくばね号",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/1360003007856"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsukubacity/feeds/TSUKUBANEGO/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-13~jp",
+      "id": "f-つくば市~筑波地区支線型バスつくばね号",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/13.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsukubacity/feeds/TSUKUBANEGO/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-14~jp",
+      "id": "f-つるぎ町コミュニティーバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/14.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsurugitown/feeds/tsurugitownbus/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-16~jp",
+      "id": "f-つるぎ町コミュニティーバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/16.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsurugitown/feeds/tsurugitownbus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-18~jp",
+      "id": "f-とさでん交通~一般路線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/18.zip"
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Tosaden-Traffic_Regularbus.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-1~jp",
+      "id": "f-ふれあいバス大府市循環バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/1.zip"
+        "static_current": "https://www.city.obu.aichi.jp/_res/projects/default_project/_page_/001/017/133/bus/obu-gtfs-current-data.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-2000020473537~jp",
+      "id": "f-みよし市~さんさんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/2000020473537"
+        "static_current": "https://www.city.aichi-miyoshi.lg.jp/shisei/opendata/documents/sansanbus.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-2000020473545~jp",
+      "id": "f-やんばる急行バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/2000020473545"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yanbaru-expressbus/feeds/yanbaru-express-bus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-2000020473553~jp",
+      "id": "f-やんばる急行バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/2000020473553"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yanbaru-expressbus/feeds/yanbaru-express-bus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-20220621gtfs~dia~jp",
+      "id": "f-バスネット津~ぐるっと~つーバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.tokachibus.jp/download/20220621GTFS-dia.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/busnet-tsu/feeds/guruttotsubus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-20~jp",
+      "id": "f-バスネット津~ぐるっと~つーバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/20.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/busnet-tsu/feeds/guruttotsubus/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-21~jp",
+      "id": "f-フォーブル",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/21.zip"
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/14/latest.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-22~jp",
+      "id": "f-フジエクスプレス港区ちぃばす",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/22.zip"
+        "static_current": "https://gtfs.buskita.com/gtfs/fxc/gtfs.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-232025~gtfs~jp",
+      "id": "f-ボン~バスエイチ~ディー西広島",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.okazaki.lg.jp/1550/1553/208000/p015630_d/fil/232025_gtfs.zip"
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/13/latest.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-2360001000457~jp",
+      "id": "f-マリックスライン~クイーンコーラルプラス~クイーンコーラル８",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/2360001000457"
+        "static_current": "https://www.ottop.databed.org/transitfeed/9340001004024"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-2360001013046~jp",
+      "id": "f-マルエーフェリー~鹿児島航路~フェリーあけぼの",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/2360001013046"
+        "static_current": "https://www.ottop.databed.org/transitfeed/5340001010554"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-2360001015810~jp",
+      "id": "f-七宗町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/2360001015810"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hichisotown/feeds/choeibus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-2360003002575~jp",
+      "id": "f-七宗町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/2360003002575"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hichisotown/feeds/choeibus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-2360003005256~jp",
+      "id": "f-七戸町コミュニティバス~シャトルバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/2360003005256"
+        "static_current": "https://www.town.shichinohe.lg.jp/gtfs-ShichinoheCommunityBus.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-23~jp",
+      "id": "f-万葉線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/23.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/manyosen/feeds/manyosen/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-24~jp",
+      "id": "f-万葉線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/24.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/manyosen/feeds/manyosen/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-27miyawakaiizuka~gtfs~jp~jp",
+      "id": "f-三好市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://data.bodik.jp/dataset/341b6046-0030-4a78-a54d-87b1a1335563/resource/5627c6c0-533f-4d4a-926d-a60ec5c9d139/download/27miyawakaiizuka_gtfs-jp.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-miyoshicity/feeds/miyoshicitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-29~jp",
+      "id": "f-三好市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/29.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-miyoshicity/feeds/miyoshicitybus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-2~jp",
+      "id": "f-三条市循環バスぐるっとさん",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/2.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sanjocity/feeds/guruttosan/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-3000020472158~jp",
+      "id": "f-三条市循環バスぐるっとさん",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/3000020472158"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sanjocity/feeds/guruttosan/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-3360002008754~jp",
+      "id": "f-三沢市コミュニティバスみーばす",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/3360002008754"
+        "static_current": "https://www.city.misawa.lg.jp/index.cfm/22%2C45535%2Cc%2Chtml/45535/GTFSJP3.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-342114~gtfs~01koikoi~jp",
+      "id": "f-上勝町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://hiroshima-opendata.dataeye.jp/resource_download/10045"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kamikatsutown/feeds/kamikatsutownbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-342114~gtfs~02kuritani~jp",
+      "id": "f-上勝町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://hiroshima-opendata.dataeye.jp/resource_download/10046"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kamikatsutown/feeds/kamikatsutownbus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-342114~gtfs~03sakaue~jp",
+      "id": "f-上山市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://hiroshima-opendata.dataeye.jp/resource_download/10047"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaminoyamacity/feeds/KaminoyamaCity/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-4000020473031~jp",
+      "id": "f-上山市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/4000020473031"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaminoyamacity/feeds/KaminoyamaCity/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-4000020473618~jp",
+      "id": "f-上市町~上市町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/4000020473618"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kamiichitown/feeds/kamiichi/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-4000020473758~jp",
+      "id": "f-上市町~上市町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/4000020473758"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kamiichitown/feeds/kamiichi/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-401005~odekakekotsugtfs~edamitsu~jp",
+      "id": "f-上越市~名立区市営バス~東飛山線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.open-governmentdata.org/dataset/468dc771-10a2-4bab-aad2-191b0fdaffa0/resource/bdbf46fd-870b-4064-9e7f-7bcedf97b526/download/401005_odekakekotsugtfs_edamitsu.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/higashihiyama-line/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-401005~odekakekotsugtfs~hiraodai~jp",
+      "id": "f-上越市~名立区市営バス~東飛山線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.open-governmentdata.org/dataset/6d3d2393-ed7b-46eb-9340-dfb45ffc279d/resource/7ea49d9e-be72-4e86-849e-d160ae45bd3c/download/401005_odekakekotsugtfs_hiraodai.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/higashihiyama-line/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-401005~odekakekotsugtfs~koyanosekusubashihoshigaoka~jp",
+      "id": "f-上越市~大島区市営バス~旭線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.open-governmentdata.org/dataset/e3689c3c-d7e4-40a8-9d21-89aa95311bb8/resource/6185c93d-76cd-4287-a306-428216f7a285/download/401005_odekakekotsugtfs_koyanosekusubashihoshigaoka.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/asahi-line/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-401005~odekakekotsugtfs~okura~jp",
+      "id": "f-上越市~大島区市営バス~旭線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.open-governmentdata.org/dataset/950b03df-5142-4f34-b976-43dad98a9540/resource/91059af4-fc56-45e1-8ecd-fd4bcb5e2df1/download/401005_odekakekotsugtfs_okura.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/asahi-line/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-401005~odekakekotsugtfs~omadobaru~jp",
+      "id": "f-上越市~大島区市営バス~菖蒲線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.open-governmentdata.org/dataset/ccbc3e6b-d85f-4541-8d6f-2c40d065f836/resource/8d32347f-00a4-497c-b88e-51f413b4b49e/download/401005_odekakekotsugtfs_omadobaru.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/shobu-line/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-401005~odekakekotsugtfs~tashirokawachi~jp",
+      "id": "f-上越市~大島区市営バス~菖蒲線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.open-governmentdata.org/dataset/42e62bc8-cfe8-4f66-9e89-decffff56f23/resource/41dfa7d1-cb07-47b4-b509-5fcbe5c79765/download/401005_odekakekotsugtfs_tashirokawachi.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/shobu-line/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-401005~odekakekotsugtfs~tsunemikitaku~jp",
+      "id": "f-上越市~板倉区市営バス~上関田線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.open-governmentdata.org/dataset/6d387baa-dcfd-431d-a229-13b8670e07bf/resource/eaa79093-a1f8-4dbe-9bfd-ca7183419c72/download/401005_odekakekotsugtfs_tsunemikitaku.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/kamisekida-line/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-402257~ukihabasu~jp",
+      "id": "f-上越市~板倉区市営バス~上関田線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://data.bodik.jp/dataset/be02305f-43ab-40b7-b8e2-1d460f5756d1/resource/2aa2b7c6-2671-472f-87f2-b6e5cc06e2e2/download/402257_ukihabasu.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/kamisekida-line/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-402303tosengtfs~jp",
+      "id": "f-上越市~板倉区市営バス~山寺薬師~菰立線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://data.bodik.jp/dataset/2a380e2b-f584-425b-9385-24926b328296/resource/53252038-b26e-49c1-9de1-1fec6811e01a/download/402303tosengtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/yamaderayakushi-komodate-line/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-4360001000447~jp",
+      "id": "f-上越市~板倉区市営バス~山寺薬師~菰立線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/4360001000447"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/yamaderayakushi-komodate-line/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-4360001000835~jp",
+      "id": "f-上越市~清里区市営バス~櫛池線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/4360001000835"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/kushiike-line/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-4360002020964~jp",
+      "id": "f-上越市~清里区市営バス~櫛池線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/4360002020964"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/kushiike-line/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-4~jp",
+      "id": "f-上越市~牧区市営バス~坪山線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/4.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/tuboyma-line/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-5000020472107~jp",
+      "id": "f-上越市~牧区市営バス~坪山線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5000020472107"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/tuboyma-line/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-5000020472115~jp",
+      "id": "f-上越市~牧区市営バス~宇津俣線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5000020472115"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/utsunomata-line/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-5000020472131~jp",
+      "id": "f-上越市~牧区市営バス~宇津俣線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5000020472131"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/utsunomata-line/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-5000020473014~jp",
+      "id": "f-上越市~牧区市営バス~高谷~平山線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5000020473014"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/takatani-tairayama-line/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-5000020473154~jp",
+      "id": "f-上越市~牧区市営バス~高谷~平山線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5000020473154"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/takatani-tairayama-line/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-5000020473278~jp",
+      "id": "f-上越市~頸城区市営バス~大池線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5000020473278"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/oike-line/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-5000020473286~jp",
+      "id": "f-上越市~頸城区市営バス~大池線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5000020473286"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/oike-line/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-5000020473600~jp",
+      "id": "f-上越市市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5000020473600"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/joetsu/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-5290801024676~jp",
+      "id": "f-上越市市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5290801024676"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/joetsu/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-5340001010554~jp",
+      "id": "f-上郡町~愛のり号",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5340001010554"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kamigoritown/feeds/ainorigo/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-5360001014132~jp",
+      "id": "f-上郡町~愛のり号",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5360001014132"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kamigoritown/feeds/ainorigo/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-5360003005096~jp",
+      "id": "f-下仁田町~しもにたバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5360003005096"
+        "static_current": "https://www.town.shimonita.lg.jp/shimonita-bus/m01/gtfs.20230324.shimonita.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-5~jp",
+      "id": "f-下電バス下津井電鉄",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/5.zip"
+        "static_current": "http://shimoden.net/busmada/opendata/next/GTFS-JP.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-6360001013190~jp",
+      "id": "f-両備バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/6360001013190"
+        "static_current": "https://loc.bus-vision.jp/gtfs/ryobi/gtfsFeed"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-6360002013009~jp",
+      "id": "f-中国ジェイアールバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/6360002013009"
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/15/latest.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-6360003005178~jp",
+      "id": "f-中山町~町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/6360003005178"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nakayamatown/feeds/NakayamaTown/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-63~jp",
+      "id": "f-中山町~町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/63.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nakayamatown/feeds/NakayamaTown/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-7000020473243~jp",
+      "id": "f-中津川市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/7000020473243"
+        "static_current": "https://www.rosenzu.com/~gtfs/nakatsugawa/nakatsugawa_GTFS_next.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-7000020473821~jp",
+      "id": "f-中津川市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/7000020473821"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nakatsugawacity/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-7011501003070~jp",
+      "id": "f-中津川市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/7011501003070"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nakatsugawacity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-7360001012407~jp",
+      "id": "f-中鉄バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/7360001012407"
+        "static_current": "https://loc.bus-vision.jp/gtfs/chutetsu/gtfsFeed"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-7360001012745~jp",
+      "id": "f-丸亀市~丸亀コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/7360001012745"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/marugame-community/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-7360003005301~jp",
+      "id": "f-丸亀市~丸亀コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/7360003005301"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/marugame-community/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-8360003004772~jp",
+      "id": "f-丹波篠山市~コミバスハートラン",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/8360003004772"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tambasasayamacity/feeds/communitybusheartrun/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-9000020473596~jp",
+      "id": "f-丹波篠山市~コミバスハートラン",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/9000020473596"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tambasasayamacity/feeds/communitybusheartrun/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-9340001004024~jp",
+      "id": "f-九州産交バス~産交バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/9340001004024"
+        "static_current": "https://km.bus-vision.jp/gtfs/sankobus/gtfsFeed"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-9360001013023~jp",
+      "id": "f-亀の井バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/9360001013023"
+        "static_current": "https://data.bodik.jp/dataset/b9319381-3841-4a1c-a796-33e7953b193a/resource/8d18cbd7-eef0-48c6-9fa3-eae936d56f40/download/gtfs08_kamenoibus.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-9360001013238~jp",
+      "id": "f-亀の井バス~高速バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/9360001013238"
+        "static_current": "https://data.bodik.jp/dataset/4e332c7a-3ac9-4c7a-a4b0-f78665e635da/resource/be2e8be4-44d1-4a85-aea6-78c8147f41c5/download/gtfs10_highway03kamenoi.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-9360003005217~jp",
+      "id": "f-二宮町コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/9360003005217"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ninomiyatown/feeds/Ninomiyatowncommunitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-9~1~jp",
+      "id": "f-二宮町コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/9_1.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ninomiyatown/feeds/Ninomiyatowncommunitybus/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-9~2~jp",
+      "id": "f-京成トランジットバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/9_2.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/keisei-transitbus/feeds/keiseitransitbus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-abashirikankokotu~jp",
+      "id": "f-京成トランジットバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.abashiri-kk.com/wp/wp-content/uploads/2019/11/abashirikankokotu.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/keisei-transitbus/feeds/keiseitransitbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-abashiri~bus~jp",
+      "id": "f-仁淀川町民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/c84abf64-f7ba-4d22-8cc1-acac7adbdc6f/download/abashiri_bus.zip"
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Niyodogawa-Town.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-abiracho~com~jp",
+      "id": "f-伊勢市コミュニティバスおかげバス沼木バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/7f011237-1284-4063-8c55-ba4945031793/download/abiracho_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/isecity/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-akaiwa~gtfs~jp~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.akaiwa.lg.jp/material/files/group/5/GTFS.zip"
       },
-      "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-akan~bus~jp",
+      "id": "f-伊勢市コミュニティバスおかげバス沼木バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/e3bb6e27-d2bb-4925-a42c-adb5f49bb924/download/akan_bus.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/ise/ise_GTFS_next.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-akechirailway~gtfs~jp",
+      "id": "f-伊勢市コミュニティバスおかげバス沼木バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/akechirailway/akechirailway_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/isecity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-ama~gtfs~jp",
+      "id": "f-伊勢鉄道",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.ama.aichi.jp/_res/projects/default_project/_page_/001/002/512/ama_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/isetetu/feeds/iserailway/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-aoikotsu~gtfs~jp",
+      "id": "f-伊勢鉄道",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/aoikotsu/aoikotsu_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/isetetu/feeds/iserailway/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-asahikawa~denki~jp",
+      "id": "f-伊賀市コミュニティバス~行政バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/41ea2ac6-c6e4-47b2-9c1c-b482feaee17c/download/asahikawa_denki.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/iga/iga_GTFS_next.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-asahi~gtfs~jp",
+      "id": "f-佐川町~さかわぐるぐるバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/asahi_gtfs.zip"
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Sakawa-Town.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-atsuma~bus~jp",
+      "id": "f-佐用町~コミバス佐用",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/40e699d6-03c7-4191-b328-5e9c13841ab2/download/atsuma_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sayotown/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-awara~bus~jp",
+      "id": "f-佐用町~コミバス佐用",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/awara_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sayotown/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-b01~buzen~nakatsu~jp",
+      "id": "f-佐賀県内バス路線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/B01_Buzen_Nakatsu.zip"
+        "static_current": "http://opendata.sagabus.info/saga-2023-07-01.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-bankei~bus~jp",
+      "id": "f-備北交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/889906b8-eb1a-41c3-a7b3-75cd69aa891f/download/bankei_bus.zip"
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/12/latest.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-betsukaicho~com~jp",
+      "id": "f-入善町~入善町営バスのらんマイ~カー",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/469a1a00-020d-49f7-b5c1-e52dc9a6961e/download/betsukaicho_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nyuzentown/feeds/noranmaicar/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-bihoku~jp",
+      "id": "f-入善町~入善町営バスのらんマイ~カー",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/12/current_data.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nyuzentown/feeds/noranmaicar/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-bonbus~jp",
+      "id": "f-入善町~入善町営バスのらんマイ~カー県サイト掲載版",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/13/current_data.zip"
+        "static_current": "https://toyama-pref.box.com/shared/static/5e0royc3l3tun4vpjie0qmqpfbztj08n.zip"
       },
-      "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-busnettsu~gtfs~jp",
+      "id": "f-函館帝産バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/busnettsu/busnettsu_GTFS.zip"
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/e407ed56-37c0-4d70-92d6-0fdd3a05aac7/download/gtfs_hakodateteisanbus.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-bus~akitachuoukotsu~jp",
+      "id": "f-加古川市~かこバス~かこバスミニ",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-akita%20chuoukotsu.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kakogawacity/feeds/kakobuskakobusmini/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-bus~akitacity~jp",
+      "id": "f-加古川市~かこバス~かこバスミニ",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.akita-bus.or.jp/gtfs_jp/bus-akitacity.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kakogawacity/feeds/kakobuskakobusmini/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-bus~city~semboku~jp",
+      "id": "f-加古川市~かこバス~かこバスミニ市サイト版",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-city-semboku.zip"
+        "static_current": "https://opendata-api-kakogawa.jp/ckan/dataset/e6353d20-66e3-4d17-8cb4-dd91836d8195/resource/5773f858-07dc-4168-a2fc-0879ec273a84/download/gtfs.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-bus~city~yuzawa01~jp",
+      "id": "f-加東市~社市街地乗合タクシー",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-city-yuzawa01.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/katocity/feeds/yashiroshigaichinoriaitaxi/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-bus~city~yuzawa02~komachi~jp",
+      "id": "f-加東市~社市街地乗合タクシー",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-city-yuzawa02-komachi.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/katocity/feeds/yashiroshigaichinoriaitaxi/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-bus~hakusancity~ishikawa~jp~jp",
+      "id": "f-加能越バス~氷見市街地周遊バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.hakusan.lg.jp/_res/projects/default_project/_page_/001/003/950/bus-hakusancity-ishikawa-jp.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunouhimi/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-bus~ikawatown~jp",
+      "id": "f-加能越バス~氷見市街地周遊バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-ikawatown.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunouhimi/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-bus~kagoshimacity~kagoshima~jp~jp",
+      "id": "f-加西市~kasaiねっぴ～号~はっぴーバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.kagoshima.lg.jp/ict/documents/bus-kagoshimacity-kagoshima-jp.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kasaicity/feeds/kasaineppihappybus/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-bus~katagamicity~jp",
+      "id": "f-加西市~kasaiねっぴ～号~はっぴーバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-katagamicity.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kasaicity/feeds/kasaineppihappybus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-bus~nansyu~jp",
+      "id": "f-加越能バス~一般路線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-nansyu.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunouippan/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-bus~nikaho~akita~jp~jp",
+      "id": "f-加越能バス~一般路線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-nikaho-akita-jp.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunouippan/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-bus~noshirocity~jp",
+      "id": "f-加越能バス~世界遺産バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-noshirocity.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunousekaiisan/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-bus~ogacity~2~jp",
+      "id": "f-加越能バス~世界遺産バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.oga.akita.jp/material/files/group/2/bus-ogacity-2.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunousekaiisan/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-bus~yokotecity~jp",
+      "id": "f-勝央町ふれあいバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-yokotecity.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shootown/feeds/shoochofureaibus/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-bus~yurihonjyocity~jp",
+      "id": "f-勝央町ふれあいバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-yurihonjyocity.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shootown/feeds/shoochofureaibus/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-chitetsu~gtfs~jp",
+      "id": "f-北九州市~おでかけ交通~小倉南区東谷地区",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/96fo9k5gmz6qwlk8xfjz0bo8vl6mhta9.zip"
+        "static_current": "https://ckan.open-governmentdata.org/dataset/0ae9bb0b-9aea-40e6-9cdf-486b9421bf33/resource/55618aea-0a7a-472d-bc61-d54757d8b35a/download/401005_odekakekotsugtfs_higashitani.zip"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-chitetsu~tram~gtfs~jp",
+      "id": "f-北島町福祉バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/asr4jglw9sm038qq20h1pqxdg7eqk669.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kitajimatown/feeds/kitajimatownfukushibus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-chugoku~jr~jp",
+      "id": "f-北島町福祉バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/15/current_data.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kitajimatown/feeds/kitajimatownfukushibus/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-chusei~jp",
+      "id": "f-北恵那バス北恵那交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://bus-vision.jp/gtfs_v2/chusei/gtfsFeed"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kitaena/feeds/kitaena/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-chutetsu~jp",
+      "id": "f-北恵那バス北恵那交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://loc.bus-vision.jp/gtfs/chutetsu/gtfsFeed"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kitaena/feeds/kitaena/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-city~hatsukaichi~jp",
+      "id": "f-北恵那バス北恵那交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/19/current_data.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/kitaena/kitaena_GTFS_next.zip"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
-      }
-    },
-    {
-      "id": "f-city~kure~jp",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/18/current_data.zip"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
       },
-      "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-city~namerikawa~gtfs~jp",
+      "id": "f-北振バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.namerikawa.toyama.jp/material/files/group/10/city_namerikawa_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hokushin-bus/feeds/hokushinbus/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-city~takaoka~gtfs~jp",
+      "id": "f-北振バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.takaoka.toyama.jp/joho/shise/opendata/documents/city_takaoka_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hokushin-bus/feeds/hokushinbus/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-city~tonami~gtfs~jp",
+      "id": "f-北海道北見バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://opendata.pref.toyama.jp/files/city_tonami_gtfs.zip"
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/ae0e85ab-b317-4acd-b982-2ceda019309f/download/kitami_bus-1.zip"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-city~toyama~fuchu~gtfs~jp",
+      "id": "f-北海道拓殖バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opdt.city.toyama.lg.jp/dataset/8de65493-0af7-49d3-aab6-b495fc3ea2b0/resource/61a024ce-a377-4dd3-a3c0-b46183896597/download/city-toyama-fuchu-gtfs.zip"
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/3870b272-dabb-4527-9d51-67afc2c9a2d5/download/gtfs_takushoku_bus.zip"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-city~toyama~horikawaminami~gtfs~jp",
+      "id": "f-北海道拓殖バス~一般路線コミュニティバス音更町~新得町~清水町",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opdt.city.toyama.lg.jp/dataset/8de65493-0af7-49d3-aab6-b495fc3ea2b0/resource/5cb228a9-8a44-4db5-bbe5-3dcbabf1c1f6/download/city-toyama-horikawaminami-gtfs.zip"
+        "static_current": "https://www.takubus.com/app/download/11236187979/GTFS_regular_line20230526.zip?t=1685093868"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-city~toyama~kureha~gtfs~jp",
+      "id": "f-北海道拓殖バス~都市間高速バス~帯広空港連絡バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opdt.city.toyama.lg.jp/dataset/8de65493-0af7-49d3-aab6-b495fc3ea2b0/resource/26db7690-aa7e-41b2-8596-0d8bdcd5c885/download/city-toyama-kureha-gtfs.zip"
+        "static_current": "https://www.takubus.com/app/download/11238066179/GTFS_highway_line20230601.zip?t=1685428757"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-city~toyama~maidohaya~gtfs~jp",
+      "id": "f-十勝バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opdt.city.toyama.lg.jp/dataset/8de65493-0af7-49d3-aab6-b495fc3ea2b0/resource/43903d9f-1d9c-42f0-bd01-8a5fc1cb828c/download/city-toyama-maidohaya-gtfs.zip"
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/9ad9de7f-73a9-4695-858f-c09cdf13437a/download/20211121gtfs-dia.zip"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-city~toyama~mizuhashi~gtfs~jp",
+      "id": "f-十勝バス~一般路線コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opdt.city.toyama.lg.jp/dataset/8de65493-0af7-49d3-aab6-b495fc3ea2b0/resource/ff01c4dd-14e7-4dbc-acea-09bff6b7d40e/download/city-toyama-mizuhashi-gtfs.zip"
+        "static_current": "https://www.tokachibus.jp/download/20221205GTFS-dia.zip"
       },
-      "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-city~toyama~oyama~gtfs~jp",
+      "id": "f-南あわじ市コミュニティバス~らん~らんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opdt.city.toyama.lg.jp/dataset/8de65493-0af7-49d3-aab6-b495fc3ea2b0/resource/378bcf3e-8f32-477a-857d-2d3917b6e84d/download/city-toyama-oyama-gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/minamiawajicity/feeds/lanrunbus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-city~toyama~yamada~gtfs~jp",
+      "id": "f-南あわじ市コミュニティバス~らん~らんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opdt.city.toyama.lg.jp/dataset/8de65493-0af7-49d3-aab6-b495fc3ea2b0/resource/665ab7b2-e434-4a4a-8175-32a433b60008/download/city-toyama-yamada-gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/minamiawajicity/feeds/lanrunbus/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-city~toyama~yatsuo~gtfs~jp",
+      "id": "f-南伊勢町~町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opdt.city.toyama.lg.jp/dataset/8de65493-0af7-49d3-aab6-b495fc3ea2b0/resource/927992fb-e889-43cb-aa55-3bc3cab2e0aa/download/city-toyama-yatsuo-gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/minamiisetown/feeds/choeibus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-city~uozu~ainori~gtfs~jp",
+      "id": "f-南伊勢町~町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.uozu.toyama.jp/contents/busdata/city_uozu_ainori_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/minamiisetown/feeds/choeibus/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-city~uozu~shimin~gtfs~jp",
+      "id": "f-南伊勢町~町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.uozu.toyama.jp/contents/busdata/city_uozu_shimin_gtfs.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/minamiise/minamiise_GTFS_next.zip"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-current~gtfs~jp",
+      "id": "f-南木曽町~地域バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://data.bodik.jp/dataset/6d93f594-6b28-417b-a1df-931e93690a78/resource/6a0eaa15-185b-4156-8b98-9b680a65ad93/download/current_gtfs.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/nagiso/nagiso_GTFS_next.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-daiwa~kotsu~jp",
+      "id": "f-南砺市~なんバス南砺市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/yamato_kotsu.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nantocity/feeds/nanbus/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-dentetsu~jp",
+      "id": "f-南砺市~なんバス南砺市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://km.bus-vision.jp/gtfs/dentetsu/gtfsFeed"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nantocity/feeds/nanbus/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-dohoku~bus~jp",
+      "id": "f-南砺市~なんバス南砺市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/a89a7707-f346-45e7-8f98-0da0f3332531/download/dohoku_bus.zip"
+        "static_current": "https://toyama-pref.box.com/shared/static/u4kmkwax5vbrctr2rshqkh1wzyx6qr9u.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-dounan~bus~jp",
+      "id": "f-南陽市~市内循環バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/a70d369c-405c-4c25-996c-c70aa53682bc/download/dounan_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nanyocity/feeds/NanyoCity/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-easthokkaido~expressbus~jp",
+      "id": "f-南陽市~市内循環バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/4215a2dd-3491-4005-bf66-10fda633d1af/download/easthokkaido_expressbus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nanyocity/feeds/NanyoCity/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-echigokotsu~jp",
+      "id": "f-可児市~yaoバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://loc.bus-vision.jp/gtfs_v2/echigokotsu/gtfsFeed"
+        "static_current": "https://www.city.kani.lg.jp/secure/12816/202303_yao_bus.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-echizensi~bus~jp",
+      "id": "f-可児市~さつきバス~ｋバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/echizensi_bus.zip"
+        "static_current": "https://www.city.kani.lg.jp/secure/12816/202210_satuki_K_bus.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-eiheiji~bus~jp",
+      "id": "f-吉野川市代替バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/eiheiji_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yoshinogawacity/feeds/yoshinogawacitybus/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-ena~gtfs~jp",
+      "id": "f-吉野川市代替バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/ena/ena_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yoshinogawacity/feeds/yoshinogawacitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-engan~bus~jp",
+      "id": "f-名張市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/0dd30c37-4d45-4a23-8f86-12b74f6e65e1/download/engan_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nabaricity/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-engarucho~com~jp",
+      "id": "f-名張市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/cc6d76a4-3576-480e-a073-ef1bfa62eafa/download/engarucho_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nabaricity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-etajima~jp",
+      "id": "f-名鉄東部交通バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gtfs-st.busit.jp/api/etajimabus"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiocity/feeds/meitestu_tobu/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-f0100801~jp",
+      "id": "f-名鉄東部交通バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.hakodate.hokkaido.jp/docs/2020052700015/files/GTFS-JP.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiocity/feeds/meitestu_tobu/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-f0800103~jp",
+      "id": "f-名阪近鉄バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.tsukuba.lg.jp/_res/projects/default_project/_page_/001/018/463/GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ogakicity/feeds/meihankintetsubus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-f1301702~jp",
+      "id": "f-名阪近鉄バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://shibuya-data.maps.arcgis.com/sharing/rest/content/items/185d0dbc980443b8b60e135349e2ae5e/data"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ogakicity/feeds/meihankintetsubus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-f1600302~jp",
+      "id": "f-呉市~生活バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/df1tjqcd97nqdl41rm7bal2fxv7gpe90.zip"
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/18/latest.zip"
       },
-      "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-f1601102~jp",
+      "id": "f-和歌山バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/endsdhfeo2xhkrx4pghgflixbj9zy35i.zip"
+        "static_current": "https://loc.bus-vision.jp/gtfs/wakayama/gtfsFeed"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-f1601402~jp",
+      "id": "f-和気町営バスわけまろ号",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/etmkuksc9ynw52uhu4lr9bgfehxthea6.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/waketown/feeds/wakechoueibasu/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-f1601801~jp",
+      "id": "f-和気町営バスわけまろ号",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/hc26ot69inx8rzcfukozh69tklqodlnt.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/waketown/feeds/wakechoueibasu/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-f3500301~jp",
+      "id": "f-四国交通~四交",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.sentetsu.biz-web.jp/GTFS-JP.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yonkoh/feeds/shikokukoutsuu/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-f3701203~jp",
+      "id": "f-四国交通~四交",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.kagawa.lg.jp/dataset/543/resource/7280/GTFS-JP.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yonkoh/feeds/shikokukoutsuu/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-flatbus~jp",
+      "id": "f-四国交通~四交",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://catalog-data.city.kanazawa.ishikawa.jp/dataset/1196beb4-f9f9-463c-9723-5b38d8127425/resource/191bd7bd-8e97-4919-b3ad-a87757993a79/download/172014-flatbus.zip"
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2651/resource/7652/source-url"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-flower~liner~gtfs~jp",
+      "id": "f-国東観光バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/flower-liner_gtfs.zip"
+        "static_current": "https://data.bodik.jp/dataset/53ed44a0-0507-4002-aa9e-c4421d290dd4/resource/5469eca7-e04b-4fba-8cdd-208a4538a7e9/download/gtfs05_kunisakikanko.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-forble~jp",
+      "id": "f-土岐市~市民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/14/current_data.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokicity/feeds/communitybus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-fukagawashi~com~jp",
+      "id": "f-土岐市~市民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/2d439886-69ec-4bf9-9a12-9ee4014e3f3c/download/fukagawashi_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokicity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-fukuokasiei~tosen~gtfsfeeds~jp",
+      "id": "f-土浦市~つちまるバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.fukuoka.lg.jp/data/open/cnt/3/59675/1/fukuokasiei_tosen_GTFSfeeds.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuchiuracity/feeds/tsuchimarubus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-furano~bus~jp",
+      "id": "f-土浦市~つちまるバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/3623aa5b-7d0b-4621-a3c8-b09e55863d27/download/furano_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuchiuracity/feeds/tsuchimarubus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-fureai~bus~gtfs~jp~jp",
+      "id": "f-大交北部バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.town.kawagoe.mie.jp/wp-content/themes/kawagoecho/images/fureai_bus_gtfs-jp.zip"
+        "static_current": "https://data.bodik.jp/dataset/1e5193a5-c771-419a-9e7a-903d45ced2f3/resource/dd886eca-3abb-4244-a866-a62f676ccb83/download/gtfs07_daikohokubu.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-geiyo~jp",
+      "id": "f-大分バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/11/current_data.zip"
+        "static_current": "https://data.bodik.jp/dataset/6b8c3167-971c-4c3c-ab84-4eae561be553/resource/9c3c2dbb-493a-40be-991d-44923919908c/download/gtfs01_oitabus.zip"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gifu~gtfs~jp",
+      "id": "f-大分バス~高速バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/gifu/gifu_GTFS.zip"
+        "static_current": "https://data.bodik.jp/dataset/4e332c7a-3ac9-4c7a-a4b0-f78665e635da/resource/5713d7c2-b881-48e6-86b8-ed4eb0e9006f/download/gtfs10_highway01oitabus.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsdate~jp",
+      "id": "f-大分交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.city.komaki.aichi.jp/material/files/group/88/gtfsdate.zip"
+        "static_current": "https://data.bodik.jp/dataset/09f3116a-418d-42be-9bd5-4d395c7b3467/resource/899d5ccc-75ee-48a8-bc96-e241a6a0c0cd/download/gtfs04_oitakotsu.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp3~dmv~jp",
+      "id": "f-大分交通~高速バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2652/resource/7651/GTFSJP3_DMV.zip"
+        "static_current": "https://data.bodik.jp/dataset/4e332c7a-3ac9-4c7a-a4b0-f78665e635da/resource/3ece7365-9739-4c5d-92a8-f008922325ff/download/gtfs10_highway02oitakotsu.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp3~higashimiyoshi~cho~jp",
+      "id": "f-大月町~まちなか循環線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2620/resource/13826/GTFSJP_Higashimiyoshi-cho.zip"
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Otsuki-Town.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp3~kaiyo~town~jp",
+      "id": "f-大江町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2669/resource/7705/GTFSJP3_kaiyo-town.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/oetown/feeds/Oetown/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp3~kamihachiman~jp",
+      "id": "f-大江町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2639/resource/7597/GTFSJP3_kamihachiman.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/oetown/feeds/Oetown/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp3~kamikatsu~town~jp",
+      "id": "f-大泉町~千代田町~広域公共バスあおぞら",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2642/resource/7635/GTFSJP3_kamikatsu-town.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/oizumitown/feeds/kouikikoukyoubasuaozora/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp3~kamiyama~town~jp",
+      "id": "f-大泉町~千代田町~広域公共バスあおぞら",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2645/resource/7663/GTFSJP3_kamiyama-town.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/oizumitown/feeds/kouikikoukyoubasuaozora/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp3~kitajima~town~jp",
+      "id": "f-大蔵町~肘折ゆけむりライン",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2641/resource/7634/GTFSJP3_kitajima-town.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ohkuravillage/feeds/OhkuraVillage/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp3~matsushige~jp",
+      "id": "f-大蔵町~肘折ゆけむりライン",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2672/resource/13799/GTFSJP3_matsushige.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ohkuravillage/feeds/OhkuraVillage/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp3~minami~town~jp",
+      "id": "f-大野竹田バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2636/resource/7593/GTFSJP3_minami-town.zip"
+        "static_current": "https://data.bodik.jp/dataset/82f8e394-562d-4ccf-b279-cf31e2454d13/resource/c9321261-fa35-434a-8a6a-ad0c992b1194/download/gtfs02_oonotaketabus.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp3~miyoshi~city~jp",
+      "id": "f-天童市~市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2643/resource/7636/GTFSJP3_miyoshi-city.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tendocity/feeds/TendoCity/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp3~naka~town~jp",
+      "id": "f-天童市~市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2644/resource/7643/GTFSJP3_naka-town.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tendocity/feeds/TendoCity/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp3~naruto~city~jp",
+      "id": "f-姫路市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2635/resource/7591/GTFSJP3_naruto-city.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/himejicity/feeds/ieshima-boze-yukihiko/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp3~naruto~city~tosen~jp",
+      "id": "f-姫路市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2635/resource/7592/GTFSJP3_naruto-city_tosen.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/himejicity/feeds/ieshima-boze-yukihiko/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp3~oujin~jp",
+      "id": "f-宇野バス宇野自動車",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2640/resource/7598/GTFSJP3_oujin.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/UnoBus/AllLines.zip?date=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp3~tokushimabus~anan~jp",
+      "id": "f-宇野バス宇野自動車",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2647/resource/7646/GTFSJP3_tokushimabus_anan.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/UnoBus/AllLines.zip?date=current"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp3~tokushimabus~nanbu~jp",
+      "id": "f-宇野バス宇野自動車",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2648/resource/7647/GTFSJP3_tokushimabus_nanbu.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/UnoBus/AllLines.zip?date=latest"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp3~tsurugi~town~jp",
+      "id": "f-安城市~あんくるバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2637/resource/7594/GTFSJP3_tsurugi-town.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/anjocity/feeds/AnkuruBus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp3~yoshinogawa~city~jp",
+      "id": "f-安城市~あんくるバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2638/resource/7596/GTFSJP3_yoshinogawa-city.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/anjocity/feeds/AnkuruBus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~aki~genkibus~jp",
+      "id": "f-安芸市観光シャトルバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Aki-Genkibus.zip"
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Aki-Shuttlebus.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~geisei~village~jp",
+      "id": "f-宍粟市~しーたんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Geisei-Village.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shisocity/feeds/shitanbus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~hokubu~traffic~localbus~jp",
+      "id": "f-宍粟市~しーたんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Hokubu-Traffic_Localbus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shisocity/feeds/shitanbus/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~ino~inoloop~jp",
+      "id": "f-宝塚市~ランランバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Ino-InoLoop.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/takarazukacity/feeds/runrunbus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~jrbus~localbus~jp",
+      "id": "f-宝塚市~ランランバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-JRbus_Localbus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/takarazukacity/feeds/runrunbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~konan~city~jp",
+      "id": "f-宮若市~飯塚市共同運行コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Konan-City.zip"
+        "static_current": "https://data.bodik.jp/dataset/341b6046-0030-4a78-a54d-87b1a1335563/resource/93fa1f38-d6d2-45bf-a774-56e1c3856494/download/230315miyawakaiizuka_gtfs-jp.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~koryo~traffic~localbus~jp",
+      "id": "f-富士急バス富士五湖と甲府市周辺~山梨県東部エリア",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Koryo-Traffic_Localbus.zip"
+        "static_current": "https://gtfs.buskita.com/gtfs/fjb/gtfs.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~kuroiwa~localbus~jp",
+      "id": "f-富士急モビリティ御殿場市~裾野市~小山町周辺エリア",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Kuroiwa-Localbus.zip"
+        "static_current": "https://gtfs.buskita.com/gtfs/fmo/gtfs.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~kvca~my~yubus~jp",
+      "id": "f-富士急湘南バス神奈川県西部エリア",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-KVCA_MY-YUbus.zip"
+        "static_current": "https://gtfs.buskita.com/gtfs/fsy/gtfs.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~mihara~miharabus~jp",
+      "id": "f-富山地鉄バス富山地方鉄道",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Mihara-Miharabus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/chitetsu/feeds/chitetsubus/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~motoyama~town~jp",
+      "id": "f-富山地鉄バス富山地方鉄道",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Motoyama-Town.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/chitetsu/feeds/chitetsubus/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~muroto~city~jp",
+      "id": "f-富山地鉄市内電車",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Muroto-City.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/chitetsu/feeds/chitetsushinaidensha/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~nakatosa~town~jp",
+      "id": "f-富山地鉄市内電車",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Nakatosa-Town.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/chitetsu/feeds/chitetsushinaidensha/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~nankoku~city~zip~jp",
+      "id": "f-富山市~まいどはやバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Nankoku-City.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/maidohayabus/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~pref~ferry~jp",
+      "id": "f-富山市~まいどはやバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Pref-Ferry.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/maidohayabus/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~reihoku~kanko~localbus~jp",
+      "id": "f-富山市~まいどはやバス県サイト",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Reihoku-Kanko_Localbus.zip"
+        "static_current": "https://toyama-pref.box.com/shared/static/bcca7lwesg58h55hbg8rxgrhh34thn8h.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~seinan~expressbus~jp",
+      "id": "f-富山市~八尾コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Seinan-Expressbus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/yatsuocommunitybus/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~seinan~localbus~jp",
+      "id": "f-富山市~八尾コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Seinan-Localbus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/yatsuocommunitybus/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~seinan~riverbus~jp",
+      "id": "f-富山市~八尾コミュニティバス県サイト",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Seinan-Riverbus.zip"
+        "static_current": "https://toyama-pref.box.com/shared/static/x2i6f55uhgavm2f8vcsneyo68bazl1sn.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~seinan~shimaashi~jp",
+      "id": "f-富山市~呉羽いきいきバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Seinan-Shimaashi.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/kurehaikiikibus/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~seinan~trolleybus~jp",
+      "id": "f-富山市~呉羽いきいきバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Seinan-Trolleybus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/kurehaikiikibus/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~呉羽いきいきバス県サイト",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/9ivamh4rfhcseya2ngpj143qq5c1mv24.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~堀川南地域コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/horikawaminamicommunitybus/files/feed.zip?rid=next"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~堀川南地域コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/horikawaminamicommunitybus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~堀川南地域コミュニティバス県サイト",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/fy7q87srgu0a7r3cwuugahucqkpyezsj.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~大山コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/oyamacommunitybus/files/feed.zip?rid=next"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~大山コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/oyamacommunitybus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~大山コミュニティバス県サイト",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/nxd5vxqnlur54ak0mkoi2p8qt8lcrtvn.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~婦中コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/fuchucommunitybus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~婦中コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/fuchucommunitybus/files/feed.zip?rid=next"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~婦中コミュニティバス県サイト",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/aapqh2kbpttozqrhoscbjap43kez7dow.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~山田コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/yamadacommunitybus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~山田コミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/yamadacommunitybus/files/feed.zip?rid=next"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~山田コミュニティバス県サイト",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/lbkdalq5p8wzy1szvrhmye8otage9q8h.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~水橋ふれあいコミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/mizuhashifureaicommunitybus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~水橋ふれあいコミュニティバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/mizuhashifureaicommunitybus/files/feed.zip?rid=next"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-富山市~水橋ふれあいコミュニティバス県サイト",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/b724alggd7nnfmscvra8e8qjf0hq85r2.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~shimanto~city~demand~jp",
+      "id": "f-寒河江市内循環バススマイル号",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Shimanto-City-Demand.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sagaecity/feeds/SagaeCity/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~shimanto~city~jp",
+      "id": "f-寒河江市内循環バススマイル号",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Shimanto-City.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sagaecity/feeds/SagaeCity/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~shimanto~town~jp",
+      "id": "f-射水市~きときとバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Shimanto-Town.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/imizucity/feeds/imizushi/files/feed.zip"
       },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-射水市~きときとバス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/imizucity/feeds/imizushi/files/feed.zip?rid=next"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-小国町営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-ogunitown/feeds/OguniTown/files/feed.zip"
+      },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~shimanto~traffic~feeder~jp",
+      "id": "f-小国町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Shimanto-Traffic_Feeder.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-ogunitown/feeds/OguniTown/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-小矢部市~小矢部市営バスメルバス~乗合タクシー",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/oyabecity/feeds/oyabecitybus/files/feed.zip?rid=next"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-小矢部市~小矢部市営バスメルバス~乗合タクシー",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/oyabecity/feeds/oyabecitybus/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-小矢部市~小矢部市営バスメルバス~乗合タクシー",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/8xvzsmuxou6kj8moe999t5r0dah953ov.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~shimanto~traffic~localbus~jp",
+      "id": "f-小豆島オリーブバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Shimanto-Traffic_Localbus.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/ShodoshimaOliveBus/AllLines.zip?date=current"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~sukumo~ferry~jp",
+      "id": "f-小豆島オリーブバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Sukumo-Ferry.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/ShodoshimaOliveBus/AllLines.zip?date=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~sukumo~hanachan~jp",
+      "id": "f-小豆島オリーブバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Sukumo-Hanachan.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/ShodoshimaOliveBus/AllLines.zip?date=latest"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~sukumo~yururin~bus~jp",
+      "id": "f-小野市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Sukumo-Yururin-Bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-ono/feeds/ranranbus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~susaki~bus~jp",
+      "id": "f-小野市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Susaki-Bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-ono/feeds/ranranbus/files/feed.zip?rid=current"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~susaki~ferry~jp",
+      "id": "f-小野市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Susaki-Ferry.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-ono/feeds/ranranbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~tano~town~jp",
+      "id": "f-尾花沢市路線バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Tano-Town.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/obanazawacity/feeds/ObanazawaCity/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~tobu~traffic~localbus~jp",
+      "id": "f-尾花沢市路線バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Tobu-Traffic_Localbus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/obanazawacity/feeds/ObanazawaCity/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~tosashimizu~odekake~jp",
+      "id": "f-山交バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Tosashimizu-Odekake.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamakobus/feeds/YAMAKOBUS/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~tosa~city~dragonbus~jp",
+      "id": "f-山交バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Tosa-City-Dragonbus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamakobus/feeds/YAMAKOBUS/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~tsuno~town~jp",
+      "id": "f-山形市~ベニちゃんバスコミュニティバス高瀬線地域交流バス南部線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Tsuno-Town.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-yamagatacity/feeds/YamagataCity/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfsjp~yasuda~town~jp",
+      "id": "f-山形市~ベニちゃんバスコミュニティバス高瀬線地域交流バス南部線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Yasuda-Town.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-yamagatacity/feeds/YamagataCity/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfstubame~jp",
+      "id": "f-山形鉄道",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.city.sendai.jp/kokyo/documents/gtfstubame.zip"
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/flower-liner_gtfs_1.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~0002~express~gma~jp",
+      "id": "f-山辺町~やまのべコミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.0002.express.GMA.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamanobetown/feeds/YamanobeTown/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~0003~lim~gma~jp",
+      "id": "f-山辺町~やまのべコミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.0003.lim.GMA.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamanobetown/feeds/YamanobeTown/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~0211117~jp",
+      "id": "f-岐阜市コミュニティバスぎふっこバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/gtfs_0211117.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/gifu/gifu_GTFS_next.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1001~kanetsu~kotu~jp",
+      "id": "f-岡垣コミュニティバスふれあい",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1001.kanetsu_kotu.zip"
+        "static_current": "https://data.bodik.jp/dataset/18581c45-386a-4ddf-b60d-526e43e41046/resource/d8a94e2c-23eb-40d2-b4d1-e822e34e8dea/download/gtfs.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1007~gunma~bus~jp",
+      "id": "f-岡電バス岡山電気軌道",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1007.gunma_bus.zip"
+        "static_current": "https://loc.bus-vision.jp/gtfs/okaden/gtfsFeed"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1017~yajima~taxi~jp",
+      "id": "f-岩国市生活交通バス~由宇地区バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1017.yajima_taxi.zip"
+        "static_current": "https://yamaguchi-opendata.jp/ckan/dataset/2dbaeb43-5134-4880-90a3-62870504f1d3/resource/31d5dd9c-113c-4fc5-bfa6-31d832f830fc/download/352080_gtfs-jp.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1018~shibukawashi~com~jp",
+      "id": "f-島田市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1018.shibukawashi_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shimadacity/feeds/shimada_combus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1019~maebashishi~com~jp",
+      "id": "f-島田市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1019.maebashishi_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shimadacity/feeds/shimada_combus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1020~takasakishi~com~jp",
+      "id": "f-川越町~ふれあいバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1020.takasakishi_com.zip"
+        "static_current": "https://www.town.kawagoe.mie.jp/wp-content/themes/kawagoecho/images/hureaibus202208.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1021~numatashi~com~jp",
+      "id": "f-市川町コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1021.numatashi_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ichikawatown/feeds/communitybus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1022~minakamimachi~com~jp",
+      "id": "f-市川町コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1022.minakamimachi_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ichikawatown/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1024~tatebayashishi~com~jp",
+      "id": "f-広島バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1024.tatebayashishi_com.zip"
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/9/latest.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1025~kiryushi~com~jp",
+      "id": "f-広島交通~広交観光",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1025.kiryushi_com.zip"
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/10/latest.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1026~isesakishi~com~jp",
+      "id": "f-広電バス広島電鉄",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1026.isesakishi_com.zip"
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/8/latest.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1027~otashi~com~jp",
+      "id": "f-庄内交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1027.otashi_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shonaikotsu/feeds/SHONAIKOTSU/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1028~fujiokashi~com~jp",
+      "id": "f-庄内交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1028.fujiokashi_com.zip"
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/syonaikotsu_gtfs.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1029~tomiokashi~com~jp",
+      "id": "f-庄内交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1029.tomiokashi_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shonaikotsu/feeds/SHONAIKOTSU/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1030~annakashi~com~jp",
+      "id": "f-庄内町~町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1030.annakashi_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shonaitown/feeds/ShonaiTown/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1031~midorishi~com~jp",
+      "id": "f-庄内町~町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1031.midorishi_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shonaitown/feeds/ShonaiTown/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1034~uenomura~com~jp",
+      "id": "f-度会町~町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1034.uenomura_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/wataraitown/feeds/choeibus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1036~shimonitamachi~com~jp",
+      "id": "f-度会町~町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1036.shimonitamachi_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/wataraitown/feeds/choeibus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1037~nanmokumura~com~jp",
+      "id": "f-廿日市市~自主運行バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1037.nanmokumura_com.zip"
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/19/latest.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1038~nakanojomachi~com~jp",
+      "id": "f-徳島バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1038.nakanojomachi_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus/feeds/tokushimabus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1040~gunma~takayamamura~com~jp",
+      "id": "f-徳島バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1040.gunma_takayamamura_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus/feeds/tokushimabus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1041~higashiagatsumamachi~com~jp",
+      "id": "f-徳島バス南部",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1041.higashiagatsumamachi_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus-nanbu/feeds/tokushimabusnanbu/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1042~kawabamura~com~jp",
+      "id": "f-徳島バス南部",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1042.kawabamura_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus-nanbu/feeds/tokushimabusnanbu/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1043~showamura~com~jp",
+      "id": "f-徳島バス阿南",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1043.showamura_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus-anan/feeds/tokushimabusanan/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1048~oizumimachi~com~jp",
+      "id": "f-徳島バス阿南",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1048.oizumimachi_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus-anan/feeds/tokushimabusanan/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1049~oramachi~com~jp",
+      "id": "f-徳島市~上八万コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1049.oramachi_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushimacity/feeds/kamihachimanbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1051~joshin~kanko~bus~jp",
+      "id": "f-徳島市~上八万コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1051.joshin_kanko_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushimacity/feeds/kamihachimanbus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1052~juo~jidousha~jp",
+      "id": "f-徳島市~応神ふれあいバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1052.juo_jidousha.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushimacity/feeds/oujinfureaibus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1106~asahi~bus~gma~jp",
+      "id": "f-徳島市~応神ふれあいバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1106.asahi_bus.GMA.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushimacity/feeds/oujinfureaibus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1115~seibu~kanko~gma~jp",
+      "id": "f-徳島市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1115.seibu_kanko.GMA.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-shiei/feeds/tokushimacitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~1302~jr~bus~kanto~gma~jp",
+      "id": "f-徳島市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1302.jr_bus_kanto.GMA.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-shiei/feeds/tokushimacitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~2002~kusakaru~jp",
+      "id": "f-徳島市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.2002.kusakaru.zip"
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2649/url_resource/66/GTFS-JP.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~abashiribus~current~data~jp",
+      "id": "f-恵庭市コミュニティ",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.abashiribus.com/open_data/gtfs_abashiribus_current_data.zip"
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/5f05a49e-1bf0-4de3-918e-de6a1c6255b8/download/_gtfs-jp_202141_20211115131545-1.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~abibus~nedo~root~jp",
+      "id": "f-恵那市自主運行バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.abiko.chiba.jp/shisei/opendata/GTFS-JP.files/gtfs_Abibus_nedo_root.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/enacity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~abibus~other~root~jp",
+      "id": "f-恵那市自主運行バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.abiko.chiba.jp/shisei/opendata/GTFS-JP.files/gtfs_Abibus_other_root.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/enacity/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~aibus~jp",
+      "id": "f-掛川市自主運行バス~市街地循環線北回りジーネット",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.abiko.chiba.jp/shisei/opendata/GTFS-JP.files/gtfs_Aibus.zip"
+        "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/66108/shigaichijyunkan-kita202304.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~data~jp",
+      "id": "f-掛川市自主運行バス~市街地循環線北回りジーネット",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.chiryu.aichi.jp/ikkrwebBrowse/material/files/group/4/gtfs_data.zip"
+        "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/65791/shigaichijyunkan-kita.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~data~shika~jp",
+      "id": "f-掛川市自主運行バス~掛川大須賀線ジーネット",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.town.shika.lg.jp/data/open/cnt/3/4031/1/gtfs_data.zip"
+        "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/65789/kakegawaosuka.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~data~zip~jp",
+      "id": "f-掛川市自主運行バス~掛川大須賀線ジーネット",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.suzaka.nagano.jp/opendata/file/gtfs_data.zip"
+        "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/66106/kakegawaosuka202304.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~echizenchou~com~jp",
+      "id": "f-掛川市自主運行バス~桜木線~居尻線~倉真線~東山線~粟本線~市街地循環線南回り掛川バスサービス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/gtfs_echizenchou_com.zip"
+        "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/65790/sakuragi.ijiri.kurami.higashiyama.awamoto.shigaichijyunkan-minami.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~eniwashi~com~jp",
+      "id": "f-掛川市自主運行バス~桜木線~居尻線~倉真線~東山線~粟本線~市街地循環線南回り掛川バスサービス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/5f05a49e-1bf0-4de3-918e-de6a1c6255b8/download/gtfs_eniwashi_com.zip"
+        "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/66109/sakuragi.ijiri.kurami.higashiyama.awamoto.shigaichijyunkan-minami202304.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~hashikamicho~com~jp",
+      "id": "f-揖斐川町~ふれあいバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.aomori.lg.jp/dataset/1596/resource/16700/gtfs_hashikamicho_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ibigawatown/feeds/communitybus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~hekinan~jp",
+      "id": "f-揖斐川町~ふれあいバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.hekinan.lg.jp/material/files/group/3/GTFS.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/ibigawa/ibigawa_GTFS_next.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~highway~line~jp",
+      "id": "f-揖斐川町~ふれあいバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.takubus.com/app/download/11135470279/GTFS_highway_line.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/ibigawatown/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~hokan~takeyakotsu~jp",
+      "id": "f-新庄市~市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.takeyakoutu.jp/assets/gtfs-hokan-takeyakotsu.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shinjocity/feeds/ShinjoCity/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~jp",
+      "id": "f-新庄市~市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/a0b5a3ab-5207-4974-94aa-7886afb138fc/download/gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shinjocity/feeds/ShinjoCity/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~jpgeiyobus~jp",
+      "id": "f-新温泉町~町民バス夢つばめ",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.geiyo.co.jp/Unyu/gtfs/GTFS-JPgeiyobus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shinonsentown/feeds/yumetsubame/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~jp~akanbus~jp",
+      "id": "f-日光市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.akanbus.co.jp/gtfs/GTFS-JP-akanbus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nikkocity/feeds/nikkocity/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~jp~gunbus~jp",
+      "id": "f-日光市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.gunbus.co.jp/GTFS/GTFS-JP_gunbus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nikkocity/feeds/nikkocity/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~jp~gyoumu~jp",
+      "id": "f-日本中央バス前橋近郊路線空港バス高速バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www3.unobus.co.jp/opendata/GTFS-JP-GYOUMU.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Maebashi_Area.zip?date=latest"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~jp~kitamibus~jp",
+      "id": "f-日本中央バス前橋近郊路線空港バス高速バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://drive.google.com/uc?export=view&id=13MQ00Oq6pJgHpB2jz5nG1iay0fEyXpAj"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Maebashi_Area.zip?date=current"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~jp~kitamibus~m~jp",
+      "id": "f-日本中央バス前橋近郊路線空港バス高速バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://drive.google.com/uc?export=view&id=1Pekt6M8SaXCS4iX8Q8u-Q6pRBbKyeqqU"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Maebashi_Area.zip?date=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~jp~nbaux~gunma~jp~gyomu~zip~jp",
+      "id": "f-日本中央バス奥多野線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.nagai-unyu.net/rosen/GTFS/aux/GTFS-JP_nbaux-gunma-jp_gyomu.zip"
+        "static_current": "https://ncb.jp/route/GTFS/latest/GTFS(OT).zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~jp~nbaux~gunma~jp~jp",
+      "id": "f-日本中央バス奥多野線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.nagai-unyu.net/rosen/GTFS/aux/GTFS-JP_nbaux-gunma-jp.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Okutano_Area.zip?date=current"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~jp~sendaicitybus~current~data~jp",
+      "id": "f-日本中央バス奥多野線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.city.sendai.jp/joho-kikaku/shise/security/kokai/documents/gtfs-jp_sendaicitybus_current_data.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Okutano_Area.zip?date=latest"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~jp~tamarin~gunma~jp~jp",
+      "id": "f-日田バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.nagai-unyu.net/rosen/GTFS/tamarin/GTFS-JP_tamarin-gunma-jp.zip"
+        "static_current": "https://data.bodik.jp/dataset/2dcbcc0d-6fbb-4c6b-9790-2f54ed41bf4f/resource/e37c6f56-ed8b-4032-a91f-4fc24639a18e/download/gtfs09_hitabus.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~jp~tokushima~jp",
+      "id": "f-日田バス~高速バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.city.tokushima.tokushima.jp/shisei/open-data/living/gtfs-jp.files/GTFS-JP.zip"
+        "static_current": "https://data.bodik.jp/dataset/4e332c7a-3ac9-4c7a-a4b0-f78665e635da/resource/17806124-f3bd-4146-b276-675133184953/download/gtfs10_highway04hita.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~katsuyamashi~jp",
+      "id": "f-日進市巡回バス~くるりんばす",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/gtfs_katsuyamashi.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/nisshin/nisshin_GTFS_next.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~kb~jp",
+      "id": "f-日進市巡回バス~くるりんばす",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.kotoden.co.jp/publichtm/gtfs/gtfsdata/gtfs_kb.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nisshincity/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~kd~jp",
+      "id": "f-日進市巡回バス~くるりんばす",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.kotoden.co.jp/publichtm/gtfs/gtfsdata/latest/gtfs_kd.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nisshincity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~kochi~busterminal~jp",
+      "id": "f-日野町営バス県ポータル",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Kochi-BusTerminal.zip"
+        "static_current": "https://data.bodik.jp/dataset/e3f3ad12-171c-442b-95b5-896f4b50e5a7/resource/e431dddb-dc3a-4699-b570-9d77043306fa/download/gtfs.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~kumano~jp",
+      "id": "f-早島町コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.wakayama.lg.jp/prefg/062500/kotsu/opendata_d/fil/GTFS_kumano.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hayashimatown/feeds/hayashimatowncommunitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~mb~jp",
+      "id": "f-早島町コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ncb.jp/route/GTFS/GTFS(MB).zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hayashimatown/feeds/hayashimatowncommunitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~meiko~jp",
+      "id": "f-明知鉄道",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.wakayama.lg.jp/prefg/062500/kotsu/opendata_d/fil/GTFS_meiko.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/aketetsu/feeds/akechirailway/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~nakatsu~city~jp",
+      "id": "f-明知鉄道",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/GTFS_Nakatsu_city.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/aketetsu/feeds/akechirailway/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~obamashi~jp",
+      "id": "f-明石市~たこバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/gtfs_obamashi.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/akashicity/feeds/tacobustacobusmini/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~ot~jp",
+      "id": "f-明石市~たこバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ncb.jp/route/GTFS/GTFS(OT).zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/akashicity/feeds/tacobustacobusmini/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~regular~line~jp",
+      "id": "f-最上川交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.takubus.com/app/download/10941479479/GTFS_regular_line.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/mogamigawakotsu/feeds/MOGAMIGAWAKOTSU/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~rinkan~jp",
+      "id": "f-最上川交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.wakayama.lg.jp/prefg/062500/kotsu/opendata_d/fil/GTFS_rinkan.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/mogamigawakotsu/feeds/MOGAMIGAWAKOTSU/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~ryujin~jp",
+      "id": "f-朝日町~あさひまちバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.wakayama.lg.jp/prefg/062500/kotsu/opendata_d/fil/GTFS_ryujin.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyama-asahitown/feeds/asahimachibus/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~sabae~jp",
+      "id": "f-朝日町~あさひまちバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/gtfs_sabae.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyama-asahitown/feeds/asahimachibus/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~shichinohecommunitybus~jp",
+      "id": "f-朝日町路線バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.town.shichinohe.lg.jp/gtfs-ShichinoheCommunityBus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-asahitown/feeds/AsahiTown/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~tokaicity~jp",
+      "id": "f-朝日町路線バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.city.tokai.aichi.jp/secure/47255/gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-asahitown/feeds/AsahiTown/files/feed.zip?rid=next"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~tokushimabus~jp",
+      "id": "f-朝来市コミュニティバスアコバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2646/resource/7704/GTFS_tokushimabus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/asagocity/feeds/acobus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~tosaden~traffic~airportbus~jp",
+      "id": "f-朝来市コミュニティバスアコバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Tosaden-Traffic_Airportbus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/asagocity/feeds/acobus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gtfs~yonkoh~jp",
+      "id": "f-村山市~市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://yonkoh.co.jp/wp/gtfs/gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/murayamacity/feeds/MurayamaCity/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-gunkanjima~jp",
+      "id": "f-村山市~市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://data.bodik.jp/dataset/c507ab86-fa09-4ee6-91cd-d0a865a31229/resource/54ebdbe4-63ae-4f04-b2a3-094f9a04aee0/download/gunkanjima.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/murayamacity/feeds/MurayamaCity/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-haborocho~com~jp",
+      "id": "f-東みよし町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/635cdd26-246c-4bd7-a095-6705c1eebb91/download/haborocho_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/higashimiyoshitown/feeds/hitashimiyoshitownbus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-haboro~enkai~ferry~jp",
+      "id": "f-東みよし町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/b1535cdf-9798-4990-afe2-5c5c5bcdfdfa/download/haboro-enkai-ferry.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/higashimiyoshitown/feeds/hitashimiyoshitownbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-hashimoto~gtfsjp~jp",
+      "id": "f-東京都町田市~コミュニティバス市民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.city.hashimoto.lg.jp/material/files/group/67/hashimoto_gtfsjp.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/MachidaCity/AllLines.zip?date=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-heart~land~ferry~jp",
+      "id": "f-東京都町田市~コミュニティバス市民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/677e45d0-45d1-4eaf-a679-319cdbfaa89e/download/heart-land-ferry.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/MachidaCity/AllLines.zip?date=current"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-hehigashitani~jp",
+      "id": "f-東京都町田市~コミュニティバス市民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/HEHigashitani.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/MachidaCity/AllLines.zip?date=latest"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-hichiso~gtfs~jp",
+      "id": "f-東根市~市民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/hichiso/hichiso_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/higashinecity/feeds/HigashineCity/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-hida~gtfs~jp",
+      "id": "f-東根市~市民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/hida/hida_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/higashinecity/feeds/HigashineCity/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-higashine~gtfs~jp",
+      "id": "f-東浦町運行バスう~ら~ら",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/higashine_gtfs.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/higashiura/higashiura_GTFS_next.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-higashiura~gtfs~jp",
+      "id": "f-東浦町運行バスう~ら~ら",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/higashiura/higashiura_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/higashiuratown/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-higashi~izumo~jp",
+      "id": "f-東浦町運行バスう~ら~ら",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.docodemo-bus.net/opendata/higashi-izumo.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/higashiuratown/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-hirobus~jp",
+      "id": "f-東鉄バス東濃鉄道",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/9/current_data.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tohtetsu/feeds/tohtetsu_ena/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-hiroden~jp",
+      "id": "f-東鉄バス東濃鉄道",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/8/current_data.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tohtetsu/feeds/tohtetsu_ena/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-hiroko~jp",
+      "id": "f-松江市コミュニティバス~本庄~持田コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/10/current_data.zip"
+        "static_current": "http://www.docodemo-bus.net/opendata/honjo-mochida.zip"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-hokkaido~bus~jp",
+      "id": "f-松茂町地域コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/19e47509-3dac-4607-a595-61447226fa3b/download/hokkaido_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/matsushigetown/feeds/matsushigetownbus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-hokkaido~chuo~jp",
+      "id": "f-松茂町地域コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/dbadfccc-670e-49b9-be77-c3f346ee3160/download/hokkaido_chuo.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/matsushigetown/feeds/matsushigetownbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-hokkaido~express~bus~jp",
+      "id": "f-松阪市コミュニティ交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/ccfd2358-c804-4cfe-b4fe-278c3f035c64/download/hokkaido-express_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/matsusakacity/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-hokkaido~ikedacho~com~jp",
+      "id": "f-松阪市コミュニティ交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/bbeb17c6-b127-4437-a457-cff8969f5949/download/hokkaido_ikedacho_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/matsusakacity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-hokkaido~kamikawacho~com~jp",
+      "id": "f-桐生市~おりひめバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/59c9f350-2419-46ce-9bab-4e86e21f396b/download/hokkaido_kamikawacho_com.zip"
+        "static_current": "https://www.city.kiryu.lg.jp/_res/common/opendata/1014528/20230320_kiryu_gtfs.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-hokumon~bus~jp",
+      "id": "f-桑名市~k-バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/226fe0ae-79af-4971-b15f-332770cdc9c1/download/hokumon_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kuwanacity/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-honjomochida~jp",
+      "id": "f-桑名市~k-バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.docodemo-bus.net/opendata/honjomochida.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kuwanacity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-hurue~jp",
+      "id": "f-桑名市~k-バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.docodemo-bus.net/opendata/hurue.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/kuwana/kuwana_GTFS_next.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-hwnishitani~jp",
+      "id": "f-横須賀市~ハマちゃんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/HWNishitani.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yokosukacity/feeds/hamachanbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-hyyakata~jp",
+      "id": "f-横須賀市~ハマちゃんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/HYYakata.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yokosukacity/feeds/hamachanbus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-ibigawa~gtfs~jp",
+      "id": "f-橋本市コミュニティバス~デマンドタクシー",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/ibigawa/ibigawa_GTFS.zip"
+        "static_current": "https://www.city.hashimoto.lg.jp/material/files/group/67/hashimoto_gtfsjp.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-iga~gtfs~jp",
+      "id": "f-武豊町ゆめころん",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/iga/iga_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/taketoyotown/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-iga~jp",
+      "id": "f-武豊町ゆめころん",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://bus-vision.jp/gtfs_v2/iga/gtfsFeed"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/taketoyotown/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-ikalliance~jp",
+      "id": "f-武豊町ゆめころん",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://loc.bus-vision.jp/gtfs_v2/ikalliance/gtfsFeed"
+        "static_current": "https://www.rosenzu.com/~gtfs/taketoyo/taketoyo_GTFS_next.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-inbe~jp",
+      "id": "f-永井バス永井運輸",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.docodemo-bus.net/opendata/inbe.zip"
+        "static_current": "https://www.nagai-unyu.net/rosen/GTFS/aux/latest/GTFS-JP_nbaux-gunma-jp.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-iserailway~gtfs~jp",
+      "id": "f-永井バス永井運輸",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/iserailway/iserailway_GTFS.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/AllLines.zip?date=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-ise~gtfs~jp",
+      "id": "f-永井バス永井運輸",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/ise/ise_GTFS.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/AllLines.zip?date=latest"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-ise~jp",
+      "id": "f-永井バス永井運輸",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://bus-vision.jp/gtfs_v2/ise/gtfsFeed"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagai-unyu/feeds/Nagaibus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-iwanaicho~com~jp",
+      "id": "f-永井バス永井運輸",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/a3be17ab-40ab-4b7d-9051-03562baf2ed4/download/iwanaicho_com.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/AllLines.zip?date=current"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-iyoshi~gtfs~jp",
+      "id": "f-永井バス永井運輸",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.iyo.lg.jp/keizaikoyou/matidukuri/documents/gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagai-unyu/feeds/Nagaibus/files/feed.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-i~jp",
+      "id": "f-永井バス永井運輸独自拡張版gtfs",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.nishio.aichi.jp/_res/projects/default_project/_page_/001/003/763/i.zip"
+        "static_current": "https://www.nagai-unyu.net/rosen/GTFS/aux/latest/GTFS-JP_nbaux-gunma-jp_gyomu.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-joutetsu~jp",
+      "id": "f-河北町路線バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/fef98fef-6fe2-472f-bde3-9d4f0a509a4a/download/joutetsu.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kahokutown/feeds/KahokuTown/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kaetsunou~gtfs~himi~jp",
+      "id": "f-河北町路線バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/tdu8l9t46rifwo2vx8a5o1qede4g3xhc.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kahokutown/feeds/KahokuTown/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kaetsunou~gtfs~ippan~jp",
+      "id": "f-津ベルライン津エアポートライン",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/ufgq55b2oxb6i0b15r9ih9q82w3q3jj5.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/tsuairportline/tsuairportline_GTFS_next.zip"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kaetsunou~gtfs~sekaiisan~jp",
+      "id": "f-津山市~市営阿波バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/ix5so7pza4m5d5yo3ikbfv4xk4tms80x.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuyamacity/feeds/bus-tsuyamacity-okayama-jp/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kahoku~gtfs~jp",
+      "id": "f-津山市~市営阿波バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/kahoku_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuyamacity/feeds/bus-tsuyamacity-okayama-jp/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kaigan~bus~jp",
+      "id": "f-津市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/kaigan_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsucity/feeds/communitybus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kaizu~gtfs~jp",
+      "id": "f-津市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/kaizu/kaizu_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsucity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kakobus~gtfs~jp",
+      "id": "f-津市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata-api-kakogawa.jp/ckan/dataset/e6353d20-66e3-4d17-8cb4-dd91836d8195/resource/5773f858-07dc-4168-a2fc-0879ec273a84/download/_gtfs.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/tsu/tsu_GTFS_next.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kameyama~gtfs~jp",
+      "id": "f-洲本市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/kameyama/kameyama_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sumotocity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kaminoyama~gtfs~jp",
+      "id": "f-洲本市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/kaminoyama_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sumotocity/feeds/communitybus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kanbaratetsudo~jp",
+      "id": "f-流山市~流山ぐりーんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://loc.bus-vision.jp/gtfs_v2/kanbaratetsudo/gtfsFeed"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagareyamacity/feeds/nagareyamagreenbus/files/feed.zip?rid=next_1"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kaneyama~gtfs~jp",
+      "id": "f-流山市~流山ぐりーんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/kaneyama_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagareyamacity/feeds/nagareyamagreenbus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kariya~gtfs~jp",
+      "id": "f-流山市~流山ぐりーんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/kariya/kariya_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagareyamacity/feeds/nagareyamagreenbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kasamatsu~gtfs~jp",
+      "id": "f-浪岡地区コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/kasamatsu/kasamatsu_GTFS.zip"
+        "static_current": "https://www.city.aomori.aomori.jp/n-somu/documents/namiokabus_current.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kashima~jp",
+      "id": "f-海津市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.docodemo-bus.net/opendata/kashima.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaizucity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-keifuku~bus~jp",
+      "id": "f-海津市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/keifuku_bus.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/kaizu/kaizu_GTFS_next.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-keiseitransitbus~gtfs~jp~jp",
+      "id": "f-海津市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.transitbus.co.jp/web/archive/KeiseiTransitBus_gtfs_jp.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaizucity/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kibichuo~jp",
+      "id": "f-海陽町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://loc.bus-vision.jp/gtfs_v2/kibichuo/gtfsFeed"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaiyotown/feeds/kaiyotownbus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kimobetsucho~com~jp",
+      "id": "f-海陽町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/7727a55e-856d-4a49-aaa4-4ae4a605ba47/download/kimobetsucho_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaiyotown/feeds/kaiyotownbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kitaena~gtfs~jp",
+      "id": "f-淡路市~あわ神あわ姫バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/kitaena/kitaena_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/awajicity/feeds/awajinawahimebus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kitamishi~com~jp",
+      "id": "f-淡路市~あわ神あわ姫バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/d4ecb0d3-4b28-4fff-897f-f56979e9b5c9/download/kitamishi_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/awajicity/feeds/awajinawahimebus/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kitami~bus~jp",
+      "id": "f-滑川市~のる~my~car",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/ae0e85ab-b317-4acd-b982-2ceda019309f/download/kitami_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/namerikawacity/feeds/norumycar/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kubikijidosha~jp",
+      "id": "f-滑川市~のる~my~car",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://loc.bus-vision.jp/gtfs_v2/kubikijidosha/gtfsFeed"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/namerikawacity/feeds/norumycar/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kumabus~jp",
+      "id": "f-滑川市~のる~my~car",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://km.bus-vision.jp/gtfs/kumabus/gtfsFeed"
+        "static_current": "https://toyama-pref.box.com/shared/static/jpxqjqmxqrbu47o2f45i84f3m43qkxzi.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kumano~gtfs~jp",
+      "id": "f-濃飛バス一般路線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/kumano/kumano_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nouhibus/feeds/nouhibus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kumano~shuyu~gtfs~jp",
+      "id": "f-濃飛バス観光路線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/kumano_shuyu/kumano_shuyu_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nouhibus/feeds/nouhibus_kanko/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kuriyamacho~com~jp",
+      "id": "f-濃飛バス高山周遊バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/2365427f-ee06-40cc-a7d0-364a31d7afc8/download/kuriyamacho_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nouhibus/feeds/takayama_shuyu/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kururin~gtfs~jp",
+      "id": "f-熊本バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.city.nisshin.lg.jp/material/files/group/108/kururin-gtfs.zip"
+        "static_current": "https://km.bus-vision.jp/gtfs/kumabus/gtfsFeed"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kushiro~bus~jp",
+      "id": "f-熊本市電",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/dd2557d2-39f9-4e03-8703-117c64eaabe2/download/kushiro_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kumamoto-shiden/feeds/kumamotoshiden/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kutchancho~com~jp",
+      "id": "f-熊本市電",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/bd408ce3-8910-48bc-bf4c-1135cac7070a/download/kutchancho_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kumamoto-shiden/feeds/kumamotoshiden/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kuwana~gtfs~jp",
+      "id": "f-熊本都市バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/kuwana/kuwana_GTFS.zip"
+        "static_current": "https://km.bus-vision.jp/gtfs/toshibus/gtfsFeed"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-kuwana~jp",
+      "id": "f-熊本電鉄バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://bus-vision.jp/gtfs_v2/kuwana/gtfsFeed"
+        "static_current": "https://km.bus-vision.jp/gtfs/dentetsu/gtfsFeed"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-k~jp",
+      "id": "f-猪名川町~ふれあいバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.nishio.aichi.jp/_res/projects/default_project/_page_/001/003/763/k.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/inagawatown/feeds/fureaibus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-m1~miho~jp",
+      "id": "f-猪名川町~ふれあいバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/M1_Miho.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/inagawatown/feeds/fureaibus/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-makubetsucho~com~jp",
+      "id": "f-玉村町乗合タクシー~たまりん",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/95c715ca-21de-4206-a345-b781e0952dd0/download/makubetsucho_com.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/Tamarin.zip?date=current"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-mamurogawa~gtfs~jp",
+      "id": "f-玉村町乗合タクシー~たまりん",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/mamurogawa_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagai-unyu/feeds/tamarin/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-matsusaka~gtfs~jp",
+      "id": "f-玉村町乗合タクシー~たまりん",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/matsusaka/matsusaka_GTFS.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/Tamarin.zip?date=latest"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-matsusaka~jp",
+      "id": "f-玉村町乗合タクシー~たまりん",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://bus-vision.jp/gtfs_v2/matsusaka/gtfsFeed"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagai-unyu/feeds/tamarin/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-meishi~bus~jp",
+      "id": "f-玉村町乗合タクシー~たまりん",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/4bddd9a6-5edf-4887-82aa-b61cb93afc9e/download/meishi_bus.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/Tamarin.zip?date=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-memurocho~com~jp",
+      "id": "f-玉村町乗合タクシー~たまりん",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/2a15bf71-a472-4e7b-9722-1e304ba8e400/download/memurocho_com.zip"
+        "static_current": "https://www.nagai-unyu.net/rosen/GTFS/tamarin/latest/GTFS-JP_tamarin-gunma-jp.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-mihama~bus~jp",
+      "id": "f-玖珠観光バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/mihama_bus.zip"
+        "static_current": "https://data.bodik.jp/dataset/b90a15f4-9680-4b7c-bcf9-d510d426e210/resource/d99bc99a-4358-4eab-af68-b140c12477a0/download/gtfs06_kusukanko.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-mihonoseki~jp",
+      "id": "f-琴参バス坂出営業所",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.docodemo-bus.net/opendata/mihonoseki.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/sakaide-local/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-miike~shimabara~jp",
+      "id": "f-琴参バス坂出営業所",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://data.bodik.jp/dataset/2b03e4b2-83a1-4c53-b884-22c05e53da9a/resource/ea3aa42e-f03f-471b-850a-daa87c07e61b/download/miike-shimabara.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/sakaide-local/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-mikasashi~com~jp",
+      "id": "f-琴参バス琴平営業所",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/b529697a-82c2-4f78-b6b1-19fce6c9c3dc/download/mikasashi_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/kotohira-local/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-minamiise~gtfs~jp",
+      "id": "f-琴参バス琴平営業所",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/minamiise/minamiise_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/kotohira-local/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-minokamo~gtfs~jp",
+      "id": "f-瑞浪市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/minokamo/minokamo_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/mizunamicity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-mitake~gtfs~jp",
+      "id": "f-瑞浪市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/mitake/mitake_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/mizunamicity/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-miyama~bus~jp",
+      "id": "f-瑞浪市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/miyama_bus.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/mizunami/mizunami_GTFS_next.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-mizunami~gtfs~jp",
+      "id": "f-生活バスよっかいち",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/mizunami/mizunami_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/seikatsubus-yokkaichi/feeds/sbusyokkaichi/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-mogamigawakotsu~gtfs~jp",
+      "id": "f-生活バスよっかいち",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/mogamigawakotsu_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/seikatsubus-yokkaichi/feeds/sbusyokkaichi/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-moritan~bus~jp",
+      "id": "f-由布市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/moritan_bus.zip"
+        "static_current": "https://data.bodik.jp/dataset/bf767ad7-4651-42f8-a9b1-78874542e046/resource/9b537213-f309-4116-9952-53050ea768ba/download/gtfs11_combus13_yufu.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-motosu~gtfs~jp",
+      "id": "f-男鹿市内路線バス全路線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/motosu/motosu_GTFS.zip"
+        "static_current": "https://www.city.oga.akita.jp/material/files/group/2/bus-ogacity.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-murayama~gtfs~jp",
+      "id": "f-白山市コミュニティバスめぐーる",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/murayama_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hakusancity/feeds/hakusan_bus_meguru/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-m~jp",
+      "id": "f-白山市コミュニティバスめぐーる",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.nishio.aichi.jp/_res/projects/default_project/_page_/001/003/763/m.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hakusancity/feeds/hakusan_bus_meguru/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-nabari~gtfs~jp",
+      "id": "f-白鷹町~町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/nabari/nabari_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shiratakatown/feeds/ShiratakaTown/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-nagai~gtfs~jp",
+      "id": "f-白鷹町~町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/nagai_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/shiratakatown/feeds/ShiratakaTown/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-nagakute~nbus~gtfs~current~data~jp",
+      "id": "f-真室川町路線バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.nagakute.lg.jp/material/files/group/4/Nagakute_Nbus_gtfs_current_data.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/mamurogawatown/feeds/MamurogawaTown/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-naganumacho~com~jp",
+      "id": "f-真室川町路線バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/16e0d070-789e-41ae-bc2a-0d0f7f63c80f/download/naganumacho_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/mamurogawatown/feeds/MamurogawaTown/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-nagiso~gtfs~jp",
+      "id": "f-石巻市~住民バス~市民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/nagiso/nagiso_GTFS.zip"
+        "static_current": "https://miyagi.dataeye.jp/resource_download/340"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+      }
+    },
+    {
+      "id": "f-砺波市~砺波市営バス",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tonamicity/feeds/tonamishieibasu/files/feed.zip"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-naiecho~com~jp",
+      "id": "f-砺波市~砺波市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/af325038-7d05-485d-9b71-85c19a3d96e7/download/naiecho_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tonamicity/feeds/tonamishieibasu/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-nakashibetsucho~com~jp",
+      "id": "f-砺波市~砺波市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/75e1e2db-ab48-4dfb-9514-1ebbc898791a/download/nakashibetsucho_com.zip"
+        "static_current": "https://toyama-pref.box.com/shared/static/70l7nwf33az6y13k4hzyc1gw679enkss.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-nakatsugawa~gtfs~jp",
+      "id": "f-磐田市生活路線バス浜松バス~掛塚磐田駅線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/nakatsugawa/nakatsugawa_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hamabus/feeds/iwata_seikatsubus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-nakayama~gtfs~jp",
+      "id": "f-神戸市垂水区~塩屋コミュニティバスしおかぜ",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/nakayama_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kobecity/feeds/kobe-shiokaze/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-namioka~current~jp",
+      "id": "f-神戸市垂水区~塩屋コミュニティバスしおかぜ",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.aomori.aomori.jp/n-somu/documents/namioka_current.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kobecity/feeds/kobe-shiokaze/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-nanki~jp",
+      "id": "f-神河町コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://bus-vision.jp/gtfs_v2/nanki/gtfsFeed"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-kamikawatown/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-nanyo~gtfs~jp",
+      "id": "f-神河町コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/nanyo_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-kamikawatown/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-nayoroshi~com~jp",
+      "id": "f-福崎町コミュニティバス巡回バスふくひめ号福崎町~加西市連携コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/4abe45b3-7390-4d7d-8bf1-e8c7230ab962/download/nayoroshi_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/fukusakitown/feeds/junkai-fukuhime-fukusakikasairenkei/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-nebutango~current~jp",
+      "id": "f-福崎町コミュニティバス巡回バスふくひめ号福崎町~加西市連携コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.aomori.aomori.jp/toshi-seisaku/opendata/documents/nebutango_current.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/fukusakitown/feeds/junkai-fukuhime-fukusakikasairenkei/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-niigatakotsukanko~jp",
+      "id": "f-秋北バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://loc.bus-vision.jp/gtfs_v2/niigatakotsukanko/gtfsFeed"
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-shuhokubus202304.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-niigatakotsu~jp",
+      "id": "f-秋田中央交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://loc.bus-vision.jp/gtfs_v2/niigatakotsu/gtfsFeed"
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-akitachuoukotsu.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-niseko~bus~jp",
+      "id": "f-秋田市マイタウン~バス中心市街地循環バスぐるる県バス協会掲載版",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/c46f9cd8-4c92-42eb-89a5-26e3fabb1dce/download/niseko_bus.zip"
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/next/bus-akitacity.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-nishikawa~gtfs~jp",
+      "id": "f-秋田市マイタウン~バス中心市街地循環バスぐるる県バス協会掲載版",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/nishikawa_gtfs.zip"
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-akitacity.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-nishinihonjr~gtfs~jp",
+      "id": "f-立山町~立山町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/supauq0zy11t8iqtqamnbyhqm0l8ylqt.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tateyamatown/feeds/tateyama/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-nishin~bus~jp",
+      "id": "f-立山町~立山町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/nishin_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tateyamatown/feeds/tateyama/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-nishiwaga~jp",
+      "id": "f-立山町~立山町営バス県サイト",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://mc.bus-vision.jp/gtfs/nishiwaga/gtfsFeed"
+        "static_current": "https://toyama-pref.box.com/shared/static/8u3d410n3ioow5juxkce2ocg0vynisw7.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-nisshin~gtfs~jp",
+      "id": "f-竹富島交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/nisshin/nisshin_GTFS.zip"
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/4360002021665"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-nomi~gtfs~jp",
+      "id": "f-竹田市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.nomi.ishikawa.jp/www/contents/1001000000402/simple/nomi_GTFS2021.zip"
+        "static_current": "https://data.bodik.jp/dataset/bf767ad7-4651-42f8-a9b1-78874542e046/resource/0f39370a-d524-43f1-998b-d59c87c4e9ae/download/gtfs11_combus08_taketa.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-noriaitaxi~jp",
+      "id": "f-笠松町公共施設巡回町民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/noriaitaxi.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kasamatsutown/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-notty~current~jp",
+      "id": "f-笠松町公共施設巡回町民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.nonoichi.lg.jp/img/opendata/notty_current.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kasamatsutown/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-obanazawa~gtfs~jp",
+      "id": "f-笠松町公共施設巡回町民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/obanazawa_gtfs.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/kasamatsu/kasamatsu_GTFS_next.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-obiun~kanko~jp",
+      "id": "f-米沢市~市民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/edc6b615-7308-4bd0-bfe4-6b3a510f9fc0/download/obiun-kanko.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yonezawacity/feeds/Yonezawa/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-obu~gtfs~current~data~jp",
+      "id": "f-米沢市~市民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.obu.aichi.jp/_res/projects/default_project/_page_/001/017/133/obu-gtfs-current-data.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yonezawacity/feeds/Yonezawa/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-oe~gtfs~jp",
+      "id": "f-紀宝町民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/oe_gtfs.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/kiho/kiho_GTFS.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-oguni~gtfs~jp",
+      "id": "f-網走バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/oguni_gtfs.zip"
+        "static_current": "https://www.abashiribus.com/open_data/gtfs_abashiribus_latest.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-ohkura~gtfs~jp",
+      "id": "f-美波町~美波病院連絡バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/ohkura_gtfs.zip"
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2636/resource/7707/GTFSJP3_minami-town_20220601.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-okabo~bus~jp",
+      "id": "f-美波町~美波病院連絡バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/okabo_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-minamitown/feeds/minabubyoinrenrakubus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-okaden~jp",
+      "id": "f-美波町~美波病院連絡バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://loc.bus-vision.jp/gtfs/okaden/gtfsFeed"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-minamitown/feeds/minabubyoinrenrakubus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-okoppecho~com~jp",
+      "id": "f-美濃加茂市コミュニティバスあい愛バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/9f741a86-60e2-42b2-89d8-384be8bf50ba/download/okoppecho_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/minokamocity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-onoshiei~bus~jp",
+      "id": "f-美濃加茂市コミュニティバスあい愛バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/onoshiei_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/minokamocity/feeds/communitybus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-onosi~machinaka~bus~jp",
+      "id": "f-群馬バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/onosi_machinaka_bus.zip"
+        "static_current": "https://www.gunbus.co.jp/GTFS/GTFS-JP_gunbus_next.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-otofukecho~com~jp",
+      "id": "f-群馬中央バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/2d430e06-7e0b-4ef7-86f3-64ccb709d270/download/otofukecho_com.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/GunmachuoBus/AllLines.zip?date=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-rankoshicho~com~jp",
+      "id": "f-群馬中央バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/595f0db5-9e55-43a5-8b85-74c3edcd7da7/download/rankoshicho_com.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/GunmachuoBus/AllLines.zip?date=latest"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-rosen~bus~hakui~jp",
+      "id": "f-群馬中央バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.hakui.lg.jp/material/files/group/1/rosen_bus.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/GunmachuoBus/AllLines.zip?date=current"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-ryobi~jp",
+      "id": "f-羽咋市~市内循環バスるんるんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://loc.bus-vision.jp/gtfs/ryobi/gtfsFeed"
+        "static_current": "https://www.city.hakui.lg.jp/material/files/group/2/GTFS20230401.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-sagae~gtfs~jp",
+      "id": "f-羽後交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/sagae_gtfs.zip"
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/ugo-bus-jp.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-saga~current~jp",
+      "id": "f-能美市~のみバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://opendata.sagabus.info/saga-current.zip"
+        "static_current": "https://www.city.nomi.ishikawa.jp/www/contents/1683514558086/simple/GTFS_nomi_20230401.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-sakaide~city~bus~jp",
+      "id": "f-臼杵市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.sakaide.lg.jp/uploaded/library/sakaide_city_bus.zip"
+        "static_current": "https://data.bodik.jp/dataset/bf767ad7-4651-42f8-a9b1-78874542e046/resource/95513da5-7317-4b97-911a-5df29d387900/download/gtfs11_combus06_usuki.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-sakaide~kotosan~bus~jp",
+      "id": "f-臼津交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.sakaide.lg.jp/uploaded/library/sakaide_kotosan_bus.zip"
+        "static_current": "https://data.bodik.jp/dataset/af52f355-1e78-405c-9d89-9df309bbb30f/resource/76e548c5-617e-4273-81f7-23499ec3aafe/download/gtfs03_kyushinkotsu.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-sakaisi~bus~jp",
+      "id": "f-芸陽バス広島県バス協会サイト掲載版",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/sakaisi_bus.zip"
+        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/11/latest.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-sakata~gtfs~jp",
+      "id": "f-藤岡市~めぐるん",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/sakata_gtfs.zip"
+        "static_current": "https://www.city.fujioka.gunma.jp/material/files/group/7/fujiokaGTFS.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-sakegawa~gtfs~jp",
+      "id": "f-西宮市~さくらやまなみバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/sakegawa_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinomiyacity/feeds/sakurayamanami/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-sakou~bus~jp",
+      "id": "f-西宮市~さくらやまなみバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/sakou_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinomiyacity/feeds/sakurayamanami/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-sankobus~jp",
+      "id": "f-西宮市コミュニティ交通ぐるっと生瀬",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://km.bus-vision.jp/gtfs/sankobus/gtfsFeed"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinomiyacity/feeds/guruttonamaze/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-sansanbus~jp",
+      "id": "f-西宮市コミュニティ交通ぐるっと生瀬",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.city.aichi-miyoshi.lg.jp/shisei/opendata/documents/sansanbus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinomiyacity/feeds/guruttonamaze/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-sanuki~gtfs~jp",
+      "id": "f-西尾市~いっちゃんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.sanuki.kagawa.jp/wp-content/uploads/2022/11/sanuki_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiocity/feeds/ichanbus/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-saromacho~com~zip~jp",
+      "id": "f-西尾市~いっちゃんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/be66e348-db27-423f-8668-8b90b828c871/download/saromacho_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiocity/feeds/ichanbus/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-sasakikanko~jp",
+      "id": "f-西尾市~六万石くるりんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/17/current_data.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiocity/feeds/rokumangokukururinbus/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-satukik~jp",
+      "id": "f-西尾市~六万石くるりんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.kani.lg.jp/secure/12816/satukik.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiocity/feeds/rokumangokukururinbus/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-sbusyokkaichi~gtfs~jp",
+      "id": "f-西川町路線バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/sbusyokkaichi/sbusyokkaichi_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishikawatown/feeds/NishikawaTown/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-seikan~ferry~jp",
+      "id": "f-西川町路線バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/16a31295-1709-4e5e-abcf-fa17ae7853b7/download/seikan_ferry.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishikawatown/feeds/NishikawaTown/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-seisankanko~gtfs~jp",
+      "id": "f-西日本ジェイアールバス~名金線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/seisankanko/seisankanko_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinihonjrbus/feeds/meikinsen/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-sharicho~com~jp",
+      "id": "f-西日本ジェイアールバス~名金線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/e59d88f1-2236-41bb-ba8c-75fd4754af1a/download/sharicho_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinihonjrbus/feeds/meikinsen/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-shibetsu~kido~jp",
+      "id": "f-西脇市コミュニティバスループバスめぐリンおりひめバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/a5702fbb-eac7-401c-8dff-e7675091fd26/download/shibetsu_kido.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiwakicity/feeds/loopbus-orihimebus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-shibus~current~jp",
+      "id": "f-西脇市コミュニティバスループバスめぐリンおりひめバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.aomori.aomori.jp/toshi-seisaku/opendata/documents/shibus_current.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiwakicity/feeds/loopbus-orihimebus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-shihorocho~com~jp",
+      "id": "f-豊山町~とよやまタウンバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/3c8f82fe-c997-45c8-9307-c904b206a450/download/shihorocho_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyoyamatown/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-shimane~jp",
+      "id": "f-豊山町~とよやまタウンバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.docodemo-bus.net/opendata/shimane.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyoyamatown/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-shima~jp",
+      "id": "f-豊岡市~市営バスイナカー",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://bus-vision.jp/gtfs_v2/shima/gtfsFeed"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyookacity/feeds/inacar/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-shimodengtfs~jp~jp",
+      "id": "f-豊岡市~市営バスイナカー",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://shimoden.net/busmada/opendata/GTFS-JP.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyookacity/feeds/inacar/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-shimokawacho~com~jp",
+      "id": "f-豊岡市~市街地循環バスコバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/fc98f52c-5dd9-4c55-b089-288eeba92044/download/shimokawacho_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyookacity/feeds/kobus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-shinji~jp",
+      "id": "f-豊岡市~市街地循環バスコバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.docodemo-bus.net/opendata/shinji.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyookacity/feeds/kobus/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-shinjo~gtfs~jp",
+      "id": "f-豊田市~とよたおいでんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/shinjo_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyotacity/feeds/kikanbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-shinshinotsu~kotsu~jp",
+      "id": "f-豊田市~とよたおいでんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/ceb69900-431d-4bb7-9605-a3b74e829b56/download/shinshinotsu_kotsu.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyotacity/feeds/kikanbus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-shiranukacho~com~jp",
+      "id": "f-豊田市~とよたおいでんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/f4f6deb3-e9ad-469e-aa39-38279bdbfeb0/download/shiranukacho_com.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/toyota/toyota_kikan_GTFS_next.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-shiraoicho~com~jp",
+      "id": "f-豊田市~地域バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/120a024f-c2b5-4183-aa90-802398e010fd/download/shiraoicho_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyotacity/feeds/chiikibus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-shirataka~gtfs~jp",
+      "id": "f-豊田市~地域バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/shirataka_gtfs.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/toyota_chiiki/toyota_chiiki_GTFS_next.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-shonaikotsu~gtfs~jp",
+      "id": "f-豊田市~地域バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/shonaikotsu_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyotacity/feeds/chiikibus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-shonai~gtfs~jp",
+      "id": "f-赤磐市広域路線バス~市民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/shonai_gtfs.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AkaiwaCity/AllLines.zip?date=current"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-simizu~bus~jp",
+      "id": "f-赤磐市広域路線バス~市民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/simizu_bus.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AkaiwaCity/AllLines.zip?date=latest"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-snh01~chokokuji~jp",
+      "id": "f-赤磐市広域路線バス~市民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/SNH01_Chokokuji.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AkaiwaCity/AllLines.zip?date=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-snn01~nishimagusakouminkan~jp",
+      "id": "f-赤磐市広域路線バス~市民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/SNN01_Nishimagusakouminkan.zip"
+        "static_current": "https://www.city.akaiwa.lg.jp/material/files/group/5/GTFS-JP.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-sorachi~chuo~bus~jp",
+      "id": "f-赤穂市~市内循環バスゆらのすけ",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/671debb1-44c5-4dea-99eb-be693911c50c/download/sorachi_chuo_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/akocity/feeds/yuranosuke/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-sorachi~kotsu~jp",
+      "id": "f-那賀町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/9a28fbf9-69fe-4a5c-8d26-b12fc2440074/download/sorachi_kotsu.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nakatown/feeds/nakatownbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-sotogahama~bus~gtfs~jp",
+      "id": "f-那賀町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.town.sotogahama.lg.jp/gyosei/jouhou/files/sotogahama_bus_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nakatown/feeds/nakatownbus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-soya~bus~jp",
+      "id": "f-酒田市~るんるんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/04e3efd7-29fd-4295-ab8d-d27933f94bbc/download/soya_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sakatacity/feeds/SakataCity/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-sugitogtfs~jp",
+      "id": "f-酒田市~るんるんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.pref.saitama.lg.jp/data/dataset/ae39c95f-917a-4f60-80ef-6341c0783092/resource/6fbd7a95-2759-4ee3-8d2a-e1e2b55f4002/download/sugitogtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sakatacity/feeds/SakataCity/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-syari~bus~jp",
+      "id": "f-金山町町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/d93cb12c-390f-4215-891d-c250db8f26d0/download/syari_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-kaneyamatown/feeds/KaneyamaTown/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-taikicho~com~jp",
+      "id": "f-金山町町営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/aa50ca49-dc3b-4c34-89ca-79749aeaaa21/download/taikicho_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-kaneyamatown/feeds/KaneyamaTown/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-tainoura~nagasaki~gtfs~jp",
+      "id": "f-金沢ふらっとバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://data.bodik.jp/dataset/80da3e1f-5e26-4b85-a9f1-61fa560b91b1/resource/5acda669-d9be-4610-9df0-0d82a098b579/download/tainoura-nagasaki_gtfs.zip"
+        "static_current": "https://catalog-data.city.kanazawa.ishikawa.jp/dataset/1196beb4-f9f9-463c-9723-5b38d8127425/resource/191bd7bd-8e97-4919-b3ad-a87757993a79/download/20230401.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-taketoyo~gtfs~jp",
+      "id": "f-長井市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/taketoyo/taketoyo_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagaicity/feeds/NagaiCity/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-takushoku~bus~jp",
+      "id": "f-長井市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/3870b272-dabb-4527-9d51-67afc2c9a2d5/download/takushoku_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagaicity/feeds/NagaiCity/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-tamayu~jp",
+      "id": "f-長岡市~小国地域生活交通~八王子線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.docodemo-bus.net/opendata/tamayu.zip"
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-10.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-tendo~gtfs~jp",
+      "id": "f-長岡市~小国地域生活交通~大貝線オーケーバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/tendo_gtfs.zip"
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-09.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-tengakajika~bus~jp",
+      "id": "f-長岡市~小国地域生活交通~法末線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/tengakajika_bus.zip"
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-11.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-toba~bus~gtfs~jp",
+      "id": "f-長岡市~山古志地域クローバーバス~小千谷線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/toba_bus/toba_bus_GTFS.zip"
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-06.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-toba~ship~gtfs~jp",
+      "id": "f-長岡市~山古志地域クローバーバス~小松倉線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/toba_ship/toba_ship_GTFS.zip"
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-08.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-tobetsucho~com~jp",
+      "id": "f-長岡市~山古志地域クローバーバス~村松線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/a3603010-da90-4228-8095-a42a31adf855/download/tobetsucho_com.zip"
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-05.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-toeibus~gtfs~jp",
+      "id": "f-長岡市~山古志地域クローバーバス~種苧原線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/Toei/data/ToeiBus-GTFS.zip"
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-07.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-togo~bus~jp",
+      "id": "f-長岡市~川口地域バス上川線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/togo_bus.zip"
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-12.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-tohtetsu~gtfs~jp",
+      "id": "f-長岡市~川口地域バス木沢~和南津線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/tohtetsu/tohtetsu_GTFS.zip"
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-14.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-tokachi~bus~jp",
+      "id": "f-長岡市~川口地域バス西川口~田麦山線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/9ad9de7f-73a9-4695-858f-c09cdf13437a/download/tokachi_bus.zip"
+        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-13.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-toki~gtfs~jp",
+      "id": "f-関越交通",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/toki/toki_GTFS.zip"
+        "static_current": "https://kan-etsu.net/relays/download/193/2807/433//?file=/files/libs/11049/202305261450561282.zip&file_name=GTFS-JP(kan-etsu)"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-toshibus~jp",
+      "id": "f-阿佐海岸鉄道",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://km.bus-vision.jp/gtfs/toshibus/gtfsFeed"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/asatetu/feeds/asakaigantetsudo/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-town~nyuzen~noran~gtfs~jp",
+      "id": "f-阿佐海岸鉄道",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.town.nyuzen.toyama.jp/material/files/group/3/town_nyuzen_noran_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/asatetu/feeds/asakaigantetsudo/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC0-1.0",
-        "use_without_attribution": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-toyoake~jp",
+      "id": "f-階上町コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.toyoake.lg.jp/secure/5217/toyoake.zip"
+        "static_current": "https://opendata.pref.aomori.lg.jp/dataset/1596/resource/19655/gtfs_hashikamicho_com_latest.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-toyota~chiiki~gtfs~jp",
+      "id": "f-階上町コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/toyota_chiiki/toyota_chiiki_GTFS.zip"
+        "static_current": "https://opendata.pref.aomori.lg.jp/dataset/1596/resource/16908/gtfs_hashikamicho_com.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-toyota~kikan~gtfs~jp",
+      "id": "f-青森市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/toyota/toyota_kikan_GTFS.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AomoriCity/AllLines.zip?date=latest"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-toyotetsu~jp",
+      "id": "f-青森市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://loc.bus-vision.jp/gtfs/toyotetsu/gtfsFeed"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AomoriCity/AllLines.zip?date=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-toyouracho~com~jp",
+      "id": "f-青森市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/c9fe757b-0756-424b-a8da-e3438798dd55/download/toyouracho_com.zip"
+        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AomoriCity/AllLines.zip?date=current"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-toyoyama~gtfs~jp",
+      "id": "f-飛騨市おでかけバスひだまる",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/toyoyama/toyoyama_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hidacity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-tozawa~gtfs~jp",
+      "id": "f-飛騨市おでかけバスひだまる",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/tozawa_gtfs.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/hida/hida_GTFS_next.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-tsuairportline~gtfs~jp",
+      "id": "f-飛騨市おでかけバスひだまる",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/tsuairportline/tsuairportline_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hidacity/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-tsukigatacho~com~jp",
+      "id": "f-養父市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/d5e7795d-6c36-4468-ac2c-245e7f3378e1/download/tsukigatacho_com.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yabucity/feeds/waiwai-sekimiya-yoka/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-tsuruga~bus~jp",
+      "id": "f-養父市コミュニティバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/tsuruga_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/yabucity/feeds/waiwai-sekimiya-yoka/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-tsuruoka~gtfs~jp",
+      "id": "f-香美町~町民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/tsuruoka_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-kamitown/feeds/kamichominbus/files/feed.zip"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-tsu~gtfs~jp",
+      "id": "f-香美町~町民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/tsu/tsu_GTFS.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-kamitown/feeds/kamichominbus/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0",
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-ugokotsu~data~jp",
+      "id": "f-高岡市~高岡市公営バス福岡地域",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/ugokotsu_data.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/takaokacity/feeds/koueibus/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-uzura~bus~jp",
+      "id": "f-高岡市~高岡市公営バス福岡地域",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/uzura_bus.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/takaokacity/feeds/koueibus/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-wakasa~bus~jp",
+      "id": "f-高岡市~高岡市公営バス福岡地域県サイト",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.fukui.lg.jp/doc/dx-suishin/opendata/gtfs_jp_d/fil/wakasa_bus.zip"
+        "static_current": "https://toyama-pref.box.com/shared/static/hjzzrbhbq92r7qli46ygb4qjci7030gy.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-wakayama~jp",
+      "id": "f-高崎市内循環バスぐるりん~高崎アリーナシャトルバス~よしいバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://loc.bus-vision.jp/gtfs/wakayama/gtfsFeed"
+        "static_current": "https://www.city.takasaki.gunma.jp/docs/2020060400037/files/bus-takasaki-gunma-jp_20230414.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-watarai~gtfs~jp",
+      "id": "f-高知観光コンベンション協会~my遊バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/watarai/watarai_GTFS.zip"
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-KVCA_MY-Yubus.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-y010~kawaraguchi~jp",
+      "id": "f-高砂市~じょうとんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y010_Kawaraguchi.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/takasagocity/feeds/jotonbus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-y021~kaminogouchi~masaki~for~masaki~jp",
+      "id": "f-高砂市~じょうとんバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y021_Kaminogouchi_Masaki_for_Masaki.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/takasagocity/feeds/jotonbus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-y022~kaminogouchi~masaki~for~kaminogouchi~jp",
+      "id": "f-魚津市~予約式あいのりタクシー~おもてなし魚津直行便",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y022_Kaminogouchi_Masaki_for_Kaminogouchi.zip"
+        "static_current": "https://www.city.uozu.toyama.jp/attach/EDIT/062/062570.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-y031~hiyamaji~kamagi~for~hiyamaji~jp",
+      "id": "f-魚津市~予約式あいのりタクシー~おもてなし魚津直行便",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y031_Hiyamaji_Kamagi_for_Hiyamaji.zip"
+        "static_current": "https://toyama-pref.box.com/shared/static/glzk70eid2g89z8zos927s4emfxdvni4.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-y032~hiyamaji~kamagi~for~kamagi~jp",
+      "id": "f-魚津市~予約式あいのりタクシー~おもてなし魚津直行便",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y032_Hiyamaji_Kamagi_for_Kamagi.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/uozucity/feeds/omotenashi/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-y051~ohshimadai~kanayoshi~for~kanayoshi~jp",
+      "id": "f-魚津市~予約式あいのりタクシー~おもてなし魚津直行便",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y051_Ohshimadai_Kanayoshi_for_Kanayoshi.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/uozucity/feeds/omotenashi/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-y052~ohshimadai~kanayoshi~for~ohshimadai~jp",
+      "id": "f-魚津市~魚津市民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y052_Ohshimadai_Kanayoshi_for_Ohshimadai.zip"
+        "static_current": "https://toyama-pref.box.com/shared/static/na9rrq16urut58g79ba13bil9ig1m9rh.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-y060~ohshima~ifuku~jp",
+      "id": "f-魚津市~魚津市民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y060_Ohshima_Ifuku.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/uozucity/feeds/junkai/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-y080~shin~yaba~west~jp",
+      "id": "f-魚津市~魚津市民バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y080_Shin-Yaba_West.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/uozucity/feeds/junkai/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-y090~yamautsuri~north~jp",
+      "id": "f-鮭川村村営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y090_Yamautsuri_North.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sakegawavillage/feeds/SakegawaVillage/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-y100~yamautsuri~south~jp",
+      "id": "f-鮭川村村営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y100_Yamautsuri_South.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/sakegawavillage/feeds/SakegawaVillage/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-y110~tsutami~jp",
+      "id": "f-鳥羽市~かもめバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y110_Tsutami.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tobacity/feeds/communitybus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-y121~urayabakei~for~kakisaka~jp",
+      "id": "f-鳥羽市~かもめバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y121_Urayabakei_for_Kakisaka.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tobacity/feeds/communitybus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-y122~urayabakei~for~hiyamaji~jp",
+      "id": "f-鳥羽市~かもめバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/Y122_Urayabakei_for_Hiyamaji.zip"
+        "static_current": "https://www.rosenzu.com/~gtfs/toba_bus/toba_bus_GTFS_next.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-yakumo~jp",
+      "id": "f-鳥羽市~市営定期船",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.docodemo-bus.net/opendata/yakumo.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tobacity/feeds/teikisen/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-yamagata~gtfs~jp",
+      "id": "f-鳥羽市~市営定期船",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/yamagata_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tobacity/feeds/teikisen/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-yamakobus~gtfs~jp",
+      "id": "f-鳴門市営渡船",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/yamakobus_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/narutocity/feeds/narutocitytosen/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-yamanobe~gtfs~jp",
+      "id": "f-鳴門市営渡船",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/yamanobe_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/narutocity/feeds/narutocitytosen/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-yanbaru~express~gtfs~jp",
+      "id": "f-鳴門市地域バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://yanbaru-expressbus.com/wp-content/themes/ykb/download/gtfs/statics.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/narutocity/feeds/narutocitychiikibus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-yao~jp",
+      "id": "f-鳴門市地域バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.kani.lg.jp/secure/12816/yao.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/narutocity/feeds/narutocitychiikibus/files/feed.zip?rid=next"
       },
       "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-yatsuka~jp",
+      "id": "f-鶴岡市~羽黒地域市営バス朝日地域市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://www.docodemo-bus.net/opendata/yatsuka.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuruokacity/feeds/TsuruokaCity/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-yk01~tsukinoki~jp",
+      "id": "f-鶴岡市~羽黒地域市営バス朝日地域市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/YK01_Tsukinoki.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuruokacity/feeds/TsuruokaCity/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-yk02~tokoro~ono~jp",
+      "id": "f-鶴岡市~羽黒地域市営バス朝日地域市営バス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/YK02_Tokoro-ono.zip"
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/tsuruoka_gtfs_1.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-yk03~ichibira~okudani~jp",
+      "id": "f-鹿児島市コミュニティバスあいばす",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/YK03_Ichibira_Okudani.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kagoshimacity/feeds/aibus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-yk04~nagaono~jp",
+      "id": "f-鹿児島市コミュニティバスあいばす",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/YK04_Nagaono.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kagoshimacity/feeds/aibus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-yk05~fukebaru~ohishitohge~jp",
+      "id": "f-鹿沼市~リーバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/YK05_Fukebaru_Ohishitohge.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kanumacity/feeds/ri-bus/files/feed.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-yk06~moromiya~jp",
+      "id": "f-鹿沼市~リーバス",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/YK06_Moromiya.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kanumacity/feeds/ri-bus/files/feed.zip?rid=next"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      },
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-ykk1~kii~jp",
+      "id": "f-黒部市~市内路線バス新幹線生地線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/YKK1_Kii.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kurobecity/feeds/shinkansenikujisen/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-yokkaichi~jp",
+      "id": "f-黒部市~市内路線バス新幹線生地線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://bus-vision.jp/gtfs_v2/yokkaichi/gtfsFeed"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kurobecity/feeds/shinkansenikujisen/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-yokosuka~gtfs~jp",
+      "id": "f-黒部市~市内路線バス新幹線生地線",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city.yokosuka.kanagawa.jp/0830/opendata/documents/gtfs.zip"
+        "static_current": "https://toyama-pref.box.com/shared/static/y8rvyr2h3dtbz1tu0c2hm78teuvwqwcy.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-yonezawa~gtfs~jp",
+      "id": "f-黒部市~市内路線バス石田三日市線~愛本コミュニティタクシー",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/yonezawa_gtfs.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kurobecity/feeds/ishida-aimoto/files/feed.zip?rid=next"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-ysw1~shinyabahigashi~jp",
+      "id": "f-黒部市~市内路線バス石田三日市線~愛本コミュニティタクシー",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.city-nakatsu.jp/doc/2019072300060/file_contents/YSW1_Shinyabahigashi.zip"
+        "static_current": "https://api.gtfs-data.jp/v2/organizations/kurobecity/feeds/ishida-aimoto/files/feed.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
-      "id": "f-yutetsu~bus~jp",
+      "id": "f-黒部市~市内路線バス石田三日市線~愛本コミュニティタクシー",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/594c9dd3-d356-4445-98e2-c480d49c9d65/download/yutetsu_bus.zip"
+        "static_current": "https://toyama-pref.box.com/shared/static/3vqbuvgk41hq3k47bf8b5iit989vrbbl.zip"
       },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
+      "tags": {
+        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     }
   ],

--- a/feeds/tshimada291.github.com.dmfr.json
+++ b/feeds/tshimada291.github.com.dmfr.json
@@ -24,6 +24,50 @@
       }
     },
     {
+      "id": "f-10~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/10.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-11~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/11.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-12~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/12.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-131130~gtfs~jp~hachiko~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.shibuya.tokyo.jp/assets/mng/131130_gtfs-jp_hachiko_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-133~jp",
       "spec": "gtfs",
       "urls": {
@@ -86,6 +130,17 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-13~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/13.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
       }
     },
@@ -164,6 +219,13 @@
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-20220621gtfs~dia~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.tokachibus.jp/download/20220621GTFS-dia.zip"
       }
     },
     {
@@ -284,6 +346,17 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-27miyawakaiizuka~gtfs~jp~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.bodik.jp/dataset/341b6046-0030-4a78-a54d-87b1a1335563/resource/5627c6c0-533f-4d4a-926d-a60ec5c9d139/download/27miyawakaiizuka_gtfs-jp.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       }
     },
@@ -640,6 +713,17 @@
       }
     },
     {
+      "id": "f-5340001010554~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/5340001010554"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-5360001014132~jp",
       "spec": "gtfs",
       "urls": {
@@ -658,6 +742,17 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-5~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/5.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
       }
     },
@@ -794,6 +889,17 @@
       }
     },
     {
+      "id": "f-9340001004024~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/9340001004024"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-9360001013023~jp",
       "spec": "gtfs",
       "urls": {
@@ -827,6 +933,17 @@
       }
     },
     {
+      "id": "f-9~1~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://odp-pref-tottori.tori-info.co.jp/bus_data/9_1.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-9~2~jp",
       "spec": "gtfs",
       "urls": {
@@ -834,6 +951,17 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-abashirikankokotu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.abashiri-kk.com/wp/wp-content/uploads/2019/11/abashirikankokotu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       }
     },
@@ -857,6 +985,17 @@
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-akaiwa~gtfs~jp~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.akaiwa.lg.jp/material/files/group/5/GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
       }
     },
     {
@@ -1007,6 +1146,28 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.rosenzu.com/~gtfs/busnettsu/busnettsu_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-bus~akitachuoukotsu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-akita%20chuoukotsu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-bus~akitacity~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.akita-bus.or.jp/gtfs_jp/bus-akitacity.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -1201,6 +1362,17 @@
       }
     },
     {
+      "id": "f-chutetsu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://loc.bus-vision.jp/gtfs/chutetsu/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-city~hatsukaichi~jp",
       "spec": "gtfs",
       "urls": {
@@ -1238,6 +1410,17 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.city.takaoka.toyama.jp/joho/shise/opendata/documents/city_takaoka_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-city~tonami~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://opendata.pref.toyama.jp/files/city_tonami_gtfs.zip"
       },
       "license": {
         "spdx_identifier": "CC0-1.0",
@@ -1333,6 +1516,17 @@
       }
     },
     {
+      "id": "f-city~uozu~ainori~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.uozu.toyama.jp/contents/busdata/city_uozu_ainori_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
       "id": "f-city~uozu~shimin~gtfs~jp",
       "spec": "gtfs",
       "urls": {
@@ -1362,6 +1556,17 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-dentetsu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://km.bus-vision.jp/gtfs/dentetsu/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       }
     },
@@ -1487,6 +1692,17 @@
       }
     },
     {
+      "id": "f-f0800103~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.tsukuba.lg.jp/_res/projects/default_project/_page_/001/018/463/GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-f1301702~jp",
       "spec": "gtfs",
       "urls": {
@@ -1564,6 +1780,17 @@
       }
     },
     {
+      "id": "f-flatbus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://catalog-data.city.kanazawa.ishikawa.jp/dataset/1196beb4-f9f9-463c-9723-5b38d8127425/resource/191bd7bd-8e97-4919-b3ad-a87757993a79/download/172014-flatbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-flower~liner~gtfs~jp",
       "spec": "gtfs",
       "urls": {
@@ -1597,10 +1824,32 @@
       }
     },
     {
+      "id": "f-fukuokasiei~tosen~gtfsfeeds~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.fukuoka.lg.jp/data/open/cnt/3/59675/1/fukuokasiei_tosen_GTFSfeeds.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-furano~bus~jp",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/3623aa5b-7d0b-4621-a3c8-b09e55863d27/download/furano_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-fureai~bus~gtfs~jp~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.town.kawagoe.mie.jp/wp-content/themes/kawagoecho/images/fureai_bus_gtfs-jp.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -1696,6 +1945,17 @@
       }
     },
     {
+      "id": "f-gtfsjp3~kamiyama~town~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2645/resource/7663/GTFSJP3_kamiyama-town.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-gtfsjp3~kitajima~town~jp",
       "spec": "gtfs",
       "urls": {
@@ -1711,6 +1971,17 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2672/resource/13799/GTFSJP3_matsushige.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp3~minami~town~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2636/resource/7593/GTFSJP3_minami-town.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -1861,6 +2132,17 @@
       }
     },
     {
+      "id": "f-gtfsjp~jrbus~localbus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-JRbus_Localbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-gtfsjp~konan~city~jp",
       "spec": "gtfs",
       "urls": {
@@ -1887,6 +2169,17 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Kuroiwa-Localbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfsjp~kvca~my~yubus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-KVCA_MY-YUbus.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2213,6 +2506,28 @@
       }
     },
     {
+      "id": "f-gtfs~0002~express~gma~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.0002.express.GMA.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~0003~lim~gma~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.0003.lim.GMA.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-gtfs~0211117~jp",
       "spec": "gtfs",
       "urls": {
@@ -2220,6 +2535,358 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1001~kanetsu~kotu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1001.kanetsu_kotu.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1007~gunma~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1007.gunma_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1017~yajima~taxi~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1017.yajima_taxi.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1018~shibukawashi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1018.shibukawashi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1019~maebashishi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1019.maebashishi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1020~takasakishi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1020.takasakishi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1021~numatashi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1021.numatashi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1022~minakamimachi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1022.minakamimachi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1024~tatebayashishi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1024.tatebayashishi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1025~kiryushi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1025.kiryushi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1026~isesakishi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1026.isesakishi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1027~otashi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1027.otashi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1028~fujiokashi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1028.fujiokashi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1029~tomiokashi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1029.tomiokashi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1030~annakashi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1030.annakashi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1031~midorishi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1031.midorishi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1034~uenomura~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1034.uenomura_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1036~shimonitamachi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1036.shimonitamachi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1037~nanmokumura~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1037.nanmokumura_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1038~nakanojomachi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1038.nakanojomachi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1040~gunma~takayamamura~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1040.gunma_takayamamura_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1041~higashiagatsumamachi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1041.higashiagatsumamachi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1042~kawabamura~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1042.kawabamura_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1043~showamura~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1043.showamura_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1048~oizumimachi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1048.oizumimachi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1049~oramachi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1049.oramachi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1051~joshin~kanko~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1051.joshin_kanko_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1052~juo~jidousha~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1052.juo_jidousha.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1106~asahi~bus~gma~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1106.asahi_bus.GMA.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1115~seibu~kanko~gma~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1115.seibu_kanko.GMA.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~1302~jr~bus~kanto~gma~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.1302.jr_bus_kanto.GMA.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~2002~kusakaru~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gma.jcld.jp/GMA_OPENDATA/GTFS/gtfs.2002.kusakaru.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       }
     },
@@ -2312,6 +2979,28 @@
       }
     },
     {
+      "id": "f-gtfs~eniwashi~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/5f05a49e-1bf0-4de3-918e-de6a1c6255b8/download/gtfs_eniwashi_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~hashikamicho~com~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata.pref.aomori.lg.jp/dataset/1596/resource/16700/gtfs_hashikamicho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
       "id": "f-gtfs~hekinan~jp",
       "spec": "gtfs",
       "urls": {
@@ -2389,10 +3078,43 @@
       }
     },
     {
+      "id": "f-gtfs~jp~gyoumu~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www3.unobus.co.jp/opendata/GTFS-JP-GYOUMU.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
       "id": "f-gtfs~jp~kitamibus~jp",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://drive.google.com/uc?export=view&id=13MQ00Oq6pJgHpB2jz5nG1iay0fEyXpAj"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~jp~kitamibus~m~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://drive.google.com/uc?export=view&id=1Pekt6M8SaXCS4iX8Q8u-Q6pRBbKyeqqU"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~jp~nbaux~gunma~jp~gyomu~zip~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.nagai-unyu.net/rosen/GTFS/aux/GTFS-JP_nbaux-gunma-jp_gyomu.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2455,10 +3177,32 @@
       }
     },
     {
+      "id": "f-gtfs~kb~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.kotoden.co.jp/publichtm/gtfs/gtfsdata/gtfs_kb.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-gtfs~kd~jp",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.kotoden.co.jp/publichtm/gtfs/gtfsdata/latest/gtfs_kd.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~kochi~busterminal~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Kochi-BusTerminal.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -2521,6 +3265,17 @@
       }
     },
     {
+      "id": "f-gtfs~ot~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ncb.jp/route/GTFS/GTFS(OT).zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-gtfs~regular~line~jp",
       "spec": "gtfs",
       "urls": {
@@ -2561,6 +3316,17 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-gtfs~shichinohecommunitybus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.town.shichinohe.lg.jp/gtfs-ShichinoheCommunityBus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       }
     },
@@ -2634,6 +3400,17 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-hashimoto~gtfsjp~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.city.hashimoto.lg.jp/material/files/group/67/hashimoto_gtfsjp.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
         "use_without_attribution": "no"
       }
     },
@@ -2814,6 +3591,17 @@
       }
     },
     {
+      "id": "f-honjomochida~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.docodemo-bus.net/opendata/honjomochida.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-hurue~jp",
       "spec": "gtfs",
       "urls": {
@@ -2953,6 +3741,17 @@
       }
     },
     {
+      "id": "f-i~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.nishio.aichi.jp/_res/projects/default_project/_page_/001/003/763/i.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-joutetsu~jp",
       "spec": "gtfs",
       "urls": {
@@ -2961,20 +3760,6 @@
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-jr四国バス高知支店~大栃線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-Jrbus_Localbus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     },
     {
@@ -3037,6 +3822,17 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.rosenzu.com/~gtfs/kaizu/kaizu_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kakobus~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://opendata-api-kakogawa.jp/ckan/dataset/e6353d20-66e3-4d17-8cb4-dd91836d8195/resource/5773f858-07dc-4168-a2fc-0879ec273a84/download/_gtfs.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3132,6 +3928,17 @@
       }
     },
     {
+      "id": "f-keiseitransitbus~gtfs~jp~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.transitbus.co.jp/web/archive/KeiseiTransitBus_gtfs_jp.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-kibichuo~jp",
       "spec": "gtfs",
       "urls": {
@@ -3176,10 +3983,32 @@
       }
     },
     {
+      "id": "f-kitami~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/ae0e85ab-b317-4acd-b982-2ceda019309f/download/kitami_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-kubikijidosha~jp",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://loc.bus-vision.jp/gtfs_v2/kubikijidosha/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-kumabus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://km.bus-vision.jp/gtfs/kumabus/gtfsFeed"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3268,6 +4097,17 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://bus-vision.jp/gtfs_v2/kuwana/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-k~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.nishio.aichi.jp/_res/projects/default_project/_page_/001/003/763/k.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3495,6 +4335,17 @@
       }
     },
     {
+      "id": "f-m~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.nishio.aichi.jp/_res/projects/default_project/_page_/001/003/763/m.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-nabari~gtfs~jp",
       "spec": "gtfs",
       "urls": {
@@ -3594,6 +4445,17 @@
       }
     },
     {
+      "id": "f-namioka~current~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.aomori.aomori.jp/n-somu/documents/namioka_current.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-nanki~jp",
       "spec": "gtfs",
       "urls": {
@@ -3682,6 +4544,17 @@
       }
     },
     {
+      "id": "f-nishinihonjr~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://toyama-pref.box.com/shared/static/supauq0zy11t8iqtqamnbyhqm0l8ylqt.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "use_without_attribution": "yes"
+      }
+    },
+    {
       "id": "f-nishin~bus~jp",
       "spec": "gtfs",
       "urls": {
@@ -3708,6 +4581,17 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.rosenzu.com/~gtfs/nisshin/nisshin_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-nomi~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.nomi.ishikawa.jp/www/contents/1001000000402/simple/nomi_GTFS2021.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3759,6 +4643,17 @@
       }
     },
     {
+      "id": "f-obu~gtfs~current~data~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.obu.aichi.jp/_res/projects/default_project/_page_/001/017/133/obu-gtfs-current-data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-oe~gtfs~jp",
       "spec": "gtfs",
       "urls": {
@@ -3799,6 +4694,17 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-okaden~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://loc.bus-vision.jp/gtfs/okaden/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       }
     },
@@ -3851,6 +4757,28 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/595f0db5-9e55-43a5-8b85-74c3edcd7da7/download/rankoshicho_com.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-rosen~bus~hakui~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.hakui.lg.jp/material/files/group/1/rosen_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-ryobi~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://loc.bus-vision.jp/gtfs/ryobi/gtfsFeed"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -3913,6 +4841,17 @@
       }
     },
     {
+      "id": "f-sakata~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/sakata_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-sakegawa~gtfs~jp",
       "spec": "gtfs",
       "urls": {
@@ -3931,6 +4870,28 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-sankobus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://km.bus-vision.jp/gtfs/sankobus/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-sansanbus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.city.aichi-miyoshi.lg.jp/shisei/opendata/documents/sansanbus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       }
     },
@@ -3965,6 +4926,17 @@
       "license": {
         "spdx_identifier": "CC0-1.0",
         "use_without_attribution": "yes"
+      }
+    },
+    {
+      "id": "f-satukik~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.kani.lg.jp/secure/12816/satukik.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
       }
     },
     {
@@ -4155,6 +5127,17 @@
       }
     },
     {
+      "id": "f-shonaikotsu~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.pref.yamagata.jp/documents/20978/shonaikotsu_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-shonai~gtfs~jp",
       "spec": "gtfs",
       "urls": {
@@ -4221,6 +5204,17 @@
       }
     },
     {
+      "id": "f-sotogahama~bus~gtfs~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.town.sotogahama.lg.jp/gyosei/jouhou/files/sotogahama_bus_gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-soya~bus~jp",
       "spec": "gtfs",
       "urls": {
@@ -4280,6 +5274,17 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.rosenzu.com/~gtfs/taketoyo/taketoyo_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-takushoku~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/3870b272-dabb-4527-9d51-67afc2c9a2d5/download/takushoku_bus.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4386,10 +5391,32 @@
       }
     },
     {
+      "id": "f-tokachi~bus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/9ad9de7f-73a9-4695-858f-c09cdf13437a/download/tokachi_bus.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-toki~gtfs~jp",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.rosenzu.com/~gtfs/toki/toki_GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-toshibus~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://km.bus-vision.jp/gtfs/toshibus/gtfsFeed"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
@@ -4540,6 +5567,17 @@
       }
     },
     {
+      "id": "f-ugokotsu~data~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/ugokotsu_data.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-uzura~bus~jp",
       "spec": "gtfs",
       "urls": {
@@ -4558,6 +5596,17 @@
       },
       "license": {
         "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-wakayama~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://loc.bus-vision.jp/gtfs/wakayama/gtfsFeed"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
       }
     },
@@ -4782,6 +5831,28 @@
       }
     },
     {
+      "id": "f-yao~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://www.city.kani.lg.jp/secure/12816/yao.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-SA-2.1-JP",
+        "use_without_attribution": "no"
+      }
+    },
+    {
+      "id": "f-yatsuka~jp",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "http://www.docodemo-bus.net/opendata/yatsuka.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "use_without_attribution": "no"
+      }
+    },
+    {
       "id": "f-yk01~tsukinoki~jp",
       "spec": "gtfs",
       "urls": {
@@ -4911,7438 +5982,6 @@
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "use_without_attribution": "no"
-      }
-    },
-    {
-      "id": "f-あおい交通",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/aoi-komaki/feeds/aoikotsu/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-あおい交通~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/aoi-komaki/feeds/aoikotsu/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-おおのハートバスささき観光",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/17/latest.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-ことでんバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.kotoden.co.jp/publichtm/gtfs/gtfsdata/latest/gtfs_kb.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-さかわ~おち花＊花ループバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Niyodoblue_Shuttlebus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-たつの市コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tatsunocity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-たつの市コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tatsunocity/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-つくば市~つくバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsukubacity/feeds/TSUKUBUS/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-つくば市~つくバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsukubacity/feeds/TSUKUBUS/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-つくば市~筑波地区支線型バスつくばね号",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.tsukuba.lg.jp/material/files/group/126/GTFS.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-つくば市~筑波地区支線型バスつくばね号~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsukubacity/feeds/TSUKUBANEGO/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-つくば市~筑波地区支線型バスつくばね号~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsukubacity/feeds/TSUKUBANEGO/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-つるぎ町コミュニティーバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsurugitown/feeds/tsurugitownbus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-つるぎ町コミュニティーバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsurugitown/feeds/tsurugitownbus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-とさでん交通~一般路線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Tosaden-Traffic_Regularbus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-ふれあいバス大府市循環バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.obu.aichi.jp/_res/projects/default_project/_page_/001/017/133/bus/obu-gtfs-current-data.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-みよし市~さんさんバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.aichi-miyoshi.lg.jp/shisei/opendata/documents/sansanbus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-やんばる急行バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yanbaru-expressbus/feeds/yanbaru-express-bus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-やんばる急行バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yanbaru-expressbus/feeds/yanbaru-express-bus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-バスネット津~ぐるっと~つーバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/busnet-tsu/feeds/guruttotsubus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-バスネット津~ぐるっと~つーバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/busnet-tsu/feeds/guruttotsubus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-フォーブル",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/14/latest.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-フジエクスプレス港区ちぃばす",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gtfs.buskita.com/gtfs/fxc/gtfs.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-ボン~バスエイチ~ディー西広島",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/13/latest.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-マリックスライン~クイーンコーラルプラス~クイーンコーラル８",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.ottop.databed.org/transitfeed/9340001004024"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-マルエーフェリー~鹿児島航路~フェリーあけぼの",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.ottop.databed.org/transitfeed/5340001010554"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-七宗町営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hichisotown/feeds/choeibus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-七宗町営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hichisotown/feeds/choeibus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-七戸町コミュニティバス~シャトルバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.town.shichinohe.lg.jp/gtfs-ShichinoheCommunityBus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-万葉線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/manyosen/feeds/manyosen/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-万葉線~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/manyosen/feeds/manyosen/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-三好市営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-miyoshicity/feeds/miyoshicitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-三好市営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-miyoshicity/feeds/miyoshicitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-三条市循環バスぐるっとさん",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/sanjocity/feeds/guruttosan/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-三条市循環バスぐるっとさん~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/sanjocity/feeds/guruttosan/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-三沢市コミュニティバスみーばす",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.misawa.lg.jp/index.cfm/22%2C45535%2Cc%2Chtml/45535/GTFSJP3.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上勝町営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kamikatsutown/feeds/kamikatsutownbus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上勝町営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kamikatsutown/feeds/kamikatsutownbus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上山市営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaminoyamacity/feeds/KaminoyamaCity/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上山市営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaminoyamacity/feeds/KaminoyamaCity/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上市町~上市町営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kamiichitown/feeds/kamiichi/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上市町~上市町営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kamiichitown/feeds/kamiichi/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~名立区市営バス~東飛山線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/higashihiyama-line/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~名立区市営バス~東飛山線~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/higashihiyama-line/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~大島区市営バス~旭線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/asahi-line/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~大島区市営バス~旭線~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/asahi-line/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~大島区市営バス~菖蒲線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/shobu-line/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~大島区市営バス~菖蒲線~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/shobu-line/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~板倉区市営バス~上関田線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/kamisekida-line/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~板倉区市営バス~上関田線~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/kamisekida-line/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~板倉区市営バス~山寺薬師~菰立線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/yamaderayakushi-komodate-line/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~板倉区市営バス~山寺薬師~菰立線~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/yamaderayakushi-komodate-line/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~清里区市営バス~櫛池線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/kushiike-line/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~清里区市営バス~櫛池線~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/kushiike-line/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~牧区市営バス~坪山線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/tuboyma-line/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~牧区市営バス~坪山線~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/tuboyma-line/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~牧区市営バス~宇津俣線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/utsunomata-line/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~牧区市営バス~宇津俣線~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/utsunomata-line/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~牧区市営バス~高谷~平山線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/takatani-tairayama-line/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~牧区市営バス~高谷~平山線~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/takatani-tairayama-line/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~頸城区市営バス~大池線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/oike-line/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市~頸城区市営バス~大池線~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/oike-line/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市市営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/joetsu/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上越市市営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/joetsucity/feeds/joetsu/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上郡町~愛のり号",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kamigoritown/feeds/ainorigo/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-上郡町~愛のり号~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kamigoritown/feeds/ainorigo/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-下仁田町~しもにたバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.town.shimonita.lg.jp/shimonita-bus/m01/gtfs.20230324.shimonita.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-下電バス下津井電鉄",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://shimoden.net/busmada/opendata/next/GTFS-JP.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-両備バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://loc.bus-vision.jp/gtfs/ryobi/gtfsFeed"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-中国ジェイアールバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/15/latest.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-中山町~町営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nakayamatown/feeds/NakayamaTown/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-中山町~町営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nakayamatown/feeds/NakayamaTown/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-中津川市コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/nakatsugawa/nakatsugawa_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-中津川市コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nakatsugawacity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-中津川市コミュニティバス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nakatsugawacity/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-中鉄バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://loc.bus-vision.jp/gtfs/chutetsu/gtfsFeed"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-丸亀市~丸亀コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/marugame-community/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-丸亀市~丸亀コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/marugame-community/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-丹波篠山市~コミバスハートラン",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tambasasayamacity/feeds/communitybusheartrun/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-丹波篠山市~コミバスハートラン~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tambasasayamacity/feeds/communitybusheartrun/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-九州産交バス~産交バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://km.bus-vision.jp/gtfs/sankobus/gtfsFeed"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-亀の井バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/b9319381-3841-4a1c-a796-33e7953b193a/resource/8d18cbd7-eef0-48c6-9fa3-eae936d56f40/download/gtfs08_kamenoibus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-亀の井バス~高速バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/4e332c7a-3ac9-4c7a-a4b0-f78665e635da/resource/be2e8be4-44d1-4a85-aea6-78c8147f41c5/download/gtfs10_highway03kamenoi.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-二宮町コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/ninomiyatown/feeds/Ninomiyatowncommunitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-二宮町コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/ninomiyatown/feeds/Ninomiyatowncommunitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-京成トランジットバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/keisei-transitbus/feeds/keiseitransitbus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-京成トランジットバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/keisei-transitbus/feeds/keiseitransitbus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-仁淀川町民バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Niyodogawa-Town.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-伊勢市コミュニティバスおかげバス沼木バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/ise/ise_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-伊勢市コミュニティバスおかげバス沼木バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/isecity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-伊勢市コミュニティバスおかげバス沼木バス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/isecity/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-伊勢鉄道",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/isetetu/feeds/iserailway/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-伊勢鉄道~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/isetetu/feeds/iserailway/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-伊賀市コミュニティバス~行政バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/iga/iga_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-佐川町~さかわぐるぐるバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Sakawa-Town.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-佐用町~コミバス佐用",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/sayotown/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-佐用町~コミバス佐用~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/sayotown/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-佐賀県内バス路線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://opendata.sagabus.info/saga-2023-07-01.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-備北交通",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/12/latest.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-入善町~入善町営バスのらんマイ~カー",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nyuzentown/feeds/noranmaicar/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-入善町~入善町営バスのらんマイ~カー~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nyuzentown/feeds/noranmaicar/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-入善町~入善町営バスのらんマイ~カー県サイト掲載版",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/5e0royc3l3tun4vpjie0qmqpfbztj08n.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-函館帝産バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/e407ed56-37c0-4d70-92d6-0fdd3a05aac7/download/gtfs_hakodateteisanbus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-加古川市~かこバス~かこバスミニ",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kakogawacity/feeds/kakobuskakobusmini/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-加古川市~かこバス~かこバスミニ~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kakogawacity/feeds/kakobuskakobusmini/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-加古川市~かこバス~かこバスミニ市サイト版",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://opendata-api-kakogawa.jp/ckan/dataset/e6353d20-66e3-4d17-8cb4-dd91836d8195/resource/5773f858-07dc-4168-a2fc-0879ec273a84/download/gtfs.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-加東市~社市街地乗合タクシー",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/katocity/feeds/yashiroshigaichinoriaitaxi/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-加東市~社市街地乗合タクシー~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/katocity/feeds/yashiroshigaichinoriaitaxi/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-加能越バス~氷見市街地周遊バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunouhimi/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-加能越バス~氷見市街地周遊バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunouhimi/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-加西市~kasaiねっぴ～号~はっぴーバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kasaicity/feeds/kasaineppihappybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-加西市~kasaiねっぴ～号~はっぴーバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kasaicity/feeds/kasaineppihappybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-加越能バス~一般路線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunouippan/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-加越能バス~一般路線~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunouippan/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-加越能バス~世界遺産バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunousekaiisan/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-加越能バス~世界遺産バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaetsunou/feeds/kaetsunousekaiisan/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-勝央町ふれあいバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shootown/feeds/shoochofureaibus/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-勝央町ふれあいバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shootown/feeds/shoochofureaibus/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-北九州市~おでかけ交通~小倉南区東谷地区",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ckan.open-governmentdata.org/dataset/0ae9bb0b-9aea-40e6-9cdf-486b9421bf33/resource/55618aea-0a7a-472d-bc61-d54757d8b35a/download/401005_odekakekotsugtfs_higashitani.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-北島町福祉バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kitajimatown/feeds/kitajimatownfukushibus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-北島町福祉バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kitajimatown/feeds/kitajimatownfukushibus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-北恵那バス北恵那交通",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/kitaena/kitaena_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-北恵那バス北恵那交通~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kitaena/feeds/kitaena/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-北恵那バス北恵那交通~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kitaena/feeds/kitaena/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-北振バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hokushin-bus/feeds/hokushinbus/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-北振バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hokushin-bus/feeds/hokushinbus/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-北海道北見バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/ae0e85ab-b317-4acd-b982-2ceda019309f/download/kitami_bus-1.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-北海道拓殖バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/3870b272-dabb-4527-9d51-67afc2c9a2d5/download/gtfs_takushoku_bus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-北海道拓殖バス~一般路線コミュニティバス音更町~新得町~清水町",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.takubus.com/app/download/11236187979/GTFS_regular_line20230526.zip?t=1685093868"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-北海道拓殖バス~都市間高速バス~帯広空港連絡バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.takubus.com/app/download/11238066179/GTFS_highway_line20230601.zip?t=1685428757"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-十勝バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/9ad9de7f-73a9-4695-858f-c09cdf13437a/download/20211121gtfs-dia.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-十勝バス~一般路線コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.tokachibus.jp/download/20221205GTFS-dia.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-南あわじ市コミュニティバス~らん~らんバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/minamiawajicity/feeds/lanrunbus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-南あわじ市コミュニティバス~らん~らんバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/minamiawajicity/feeds/lanrunbus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-南伊勢町~町営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/minamiise/minamiise_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-南伊勢町~町営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/minamiisetown/feeds/choeibus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-南伊勢町~町営バス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/minamiisetown/feeds/choeibus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-南木曽町~地域バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/nagiso/nagiso_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-南砺市~なんバス南砺市営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/u4kmkwax5vbrctr2rshqkh1wzyx6qr9u.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-南砺市~なんバス南砺市営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nantocity/feeds/nanbus/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-南砺市~なんバス南砺市営バス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nantocity/feeds/nanbus/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-南陽市~市内循環バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nanyocity/feeds/NanyoCity/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-南陽市~市内循環バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nanyocity/feeds/NanyoCity/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-可児市~yaoバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.kani.lg.jp/secure/12816/202303_yao_bus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-可児市~さつきバス~ｋバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.kani.lg.jp/secure/12816/202210_satuki_K_bus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-吉野川市代替バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yoshinogawacity/feeds/yoshinogawacitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-吉野川市代替バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yoshinogawacity/feeds/yoshinogawacitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-名張市コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nabaricity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-名張市コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nabaricity/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-名鉄東部交通バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiocity/feeds/meitestu_tobu/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-名鉄東部交通バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiocity/feeds/meitestu_tobu/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-名阪近鉄バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/ogakicity/feeds/meihankintetsubus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-名阪近鉄バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/ogakicity/feeds/meihankintetsubus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-呉市~生活バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/18/latest.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-和歌山バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://loc.bus-vision.jp/gtfs/wakayama/gtfsFeed"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-和気町営バスわけまろ号",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/waketown/feeds/wakechoueibasu/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-和気町営バスわけまろ号~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/waketown/feeds/wakechoueibasu/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-四国交通~四交",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2651/resource/7652/source-url"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-四国交通~四交~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yonkoh/feeds/shikokukoutsuu/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-四国交通~四交~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yonkoh/feeds/shikokukoutsuu/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-国東観光バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/53ed44a0-0507-4002-aa9e-c4421d290dd4/resource/5469eca7-e04b-4fba-8cdd-208a4538a7e9/download/gtfs05_kunisakikanko.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-土岐市~市民バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokicity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-土岐市~市民バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokicity/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-土浦市~つちまるバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuchiuracity/feeds/tsuchimarubus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-土浦市~つちまるバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuchiuracity/feeds/tsuchimarubus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-大交北部バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/1e5193a5-c771-419a-9e7a-903d45ced2f3/resource/dd886eca-3abb-4244-a866-a62f676ccb83/download/gtfs07_daikohokubu.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-大分バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/6b8c3167-971c-4c3c-ab84-4eae561be553/resource/9c3c2dbb-493a-40be-991d-44923919908c/download/gtfs01_oitabus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-大分バス~高速バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/4e332c7a-3ac9-4c7a-a4b0-f78665e635da/resource/5713d7c2-b881-48e6-86b8-ed4eb0e9006f/download/gtfs10_highway01oitabus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-大分交通",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/09f3116a-418d-42be-9bd5-4d395c7b3467/resource/899d5ccc-75ee-48a8-bc96-e241a6a0c0cd/download/gtfs04_oitakotsu.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-大分交通~高速バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/4e332c7a-3ac9-4c7a-a4b0-f78665e635da/resource/3ece7365-9739-4c5d-92a8-f008922325ff/download/gtfs10_highway02oitakotsu.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-大月町~まちなか循環線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Otsuki-Town.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-大江町営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/oetown/feeds/Oetown/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-大江町営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/oetown/feeds/Oetown/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-大泉町~千代田町~広域公共バスあおぞら",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/oizumitown/feeds/kouikikoukyoubasuaozora/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-大泉町~千代田町~広域公共バスあおぞら~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/oizumitown/feeds/kouikikoukyoubasuaozora/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-大蔵町~肘折ゆけむりライン",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/ohkuravillage/feeds/OhkuraVillage/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-大蔵町~肘折ゆけむりライン~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/ohkuravillage/feeds/OhkuraVillage/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-大野竹田バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/82f8e394-562d-4ccf-b279-cf31e2454d13/resource/c9321261-fa35-434a-8a6a-ad0c992b1194/download/gtfs02_oonotaketabus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-天童市~市営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tendocity/feeds/TendoCity/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-天童市~市営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tendocity/feeds/TendoCity/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-姫路市コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/himejicity/feeds/ieshima-boze-yukihiko/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-姫路市コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/himejicity/feeds/ieshima-boze-yukihiko/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-宇野バス宇野自動車",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/UnoBus/AllLines.zip?date=current"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-宇野バス宇野自動車~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/UnoBus/AllLines.zip?date=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-宇野バス宇野自動車~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/UnoBus/AllLines.zip?date=latest"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-安城市~あんくるバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/anjocity/feeds/AnkuruBus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-安城市~あんくるバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/anjocity/feeds/AnkuruBus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-安芸市観光シャトルバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFS-Aki-Shuttlebus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-宍粟市~しーたんバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shisocity/feeds/shitanbus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-宍粟市~しーたんバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shisocity/feeds/shitanbus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-宝塚市~ランランバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/takarazukacity/feeds/runrunbus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-宝塚市~ランランバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/takarazukacity/feeds/runrunbus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-宮若市~飯塚市共同運行コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/341b6046-0030-4a78-a54d-87b1a1335563/resource/93fa1f38-d6d2-45bf-a774-56e1c3856494/download/230315miyawakaiizuka_gtfs-jp.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富士急バス富士五湖と甲府市周辺~山梨県東部エリア",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gtfs.buskita.com/gtfs/fjb/gtfs.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富士急モビリティ御殿場市~裾野市~小山町周辺エリア",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gtfs.buskita.com/gtfs/fmo/gtfs.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富士急湘南バス神奈川県西部エリア",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gtfs.buskita.com/gtfs/fsy/gtfs.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山地鉄バス富山地方鉄道",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/chitetsu/feeds/chitetsubus/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山地鉄バス富山地方鉄道~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/chitetsu/feeds/chitetsubus/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山地鉄市内電車",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/chitetsu/feeds/chitetsushinaidensha/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山地鉄市内電車~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/chitetsu/feeds/chitetsushinaidensha/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~まいどはやバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/maidohayabus/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~まいどはやバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/maidohayabus/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~まいどはやバス県サイト",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/bcca7lwesg58h55hbg8rxgrhh34thn8h.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~八尾コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/yatsuocommunitybus/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~八尾コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/yatsuocommunitybus/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~八尾コミュニティバス県サイト",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/x2i6f55uhgavm2f8vcsneyo68bazl1sn.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~呉羽いきいきバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/kurehaikiikibus/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~呉羽いきいきバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/kurehaikiikibus/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~呉羽いきいきバス県サイト",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/9ivamh4rfhcseya2ngpj143qq5c1mv24.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~堀川南地域コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/horikawaminamicommunitybus/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~堀川南地域コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/horikawaminamicommunitybus/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~堀川南地域コミュニティバス県サイト",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/fy7q87srgu0a7r3cwuugahucqkpyezsj.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~大山コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/oyamacommunitybus/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~大山コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/oyamacommunitybus/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~大山コミュニティバス県サイト",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/nxd5vxqnlur54ak0mkoi2p8qt8lcrtvn.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~婦中コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/fuchucommunitybus/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~婦中コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/fuchucommunitybus/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~婦中コミュニティバス県サイト",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/aapqh2kbpttozqrhoscbjap43kez7dow.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~山田コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/yamadacommunitybus/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~山田コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/yamadacommunitybus/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~山田コミュニティバス県サイト",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/lbkdalq5p8wzy1szvrhmye8otage9q8h.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~水橋ふれあいコミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/mizuhashifureaicommunitybus/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~水橋ふれあいコミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/mizuhashifureaicommunitybus/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-富山市~水橋ふれあいコミュニティバス県サイト",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/b724alggd7nnfmscvra8e8qjf0hq85r2.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-寒河江市内循環バススマイル号",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/sagaecity/feeds/SagaeCity/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-寒河江市内循環バススマイル号~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/sagaecity/feeds/SagaeCity/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-射水市~きときとバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/imizucity/feeds/imizushi/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-射水市~きときとバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/imizucity/feeds/imizushi/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-小国町営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-ogunitown/feeds/OguniTown/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-小国町営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-ogunitown/feeds/OguniTown/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-小矢部市~小矢部市営バスメルバス~乗合タクシー",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/8xvzsmuxou6kj8moe999t5r0dah953ov.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-小矢部市~小矢部市営バスメルバス~乗合タクシー~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/oyabecity/feeds/oyabecitybus/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-小矢部市~小矢部市営バスメルバス~乗合タクシー~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/oyabecity/feeds/oyabecitybus/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-小豆島オリーブバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/ShodoshimaOliveBus/AllLines.zip?date=current"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-小豆島オリーブバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/ShodoshimaOliveBus/AllLines.zip?date=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-小豆島オリーブバス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/ShodoshimaOliveBus/AllLines.zip?date=latest"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-小野市コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-ono/feeds/ranranbus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-小野市コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-ono/feeds/ranranbus/files/feed.zip?rid=current"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-小野市コミュニティバス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-ono/feeds/ranranbus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-尾花沢市路線バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/obanazawacity/feeds/ObanazawaCity/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-尾花沢市路線バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/obanazawacity/feeds/ObanazawaCity/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-山交バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamakobus/feeds/YAMAKOBUS/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-山交バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamakobus/feeds/YAMAKOBUS/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-山形市~ベニちゃんバスコミュニティバス高瀬線地域交流バス南部線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-yamagatacity/feeds/YamagataCity/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-山形市~ベニちゃんバスコミュニティバス高瀬線地域交流バス南部線~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-yamagatacity/feeds/YamagataCity/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-山形鉄道",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/flower-liner_gtfs_1.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-山辺町~やまのべコミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamanobetown/feeds/YamanobeTown/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-山辺町~やまのべコミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamanobetown/feeds/YamanobeTown/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-岐阜市コミュニティバスぎふっこバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/gifu/gifu_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-岡垣コミュニティバスふれあい",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/18581c45-386a-4ddf-b60d-526e43e41046/resource/d8a94e2c-23eb-40d2-b4d1-e822e34e8dea/download/gtfs.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-岡電バス岡山電気軌道",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://loc.bus-vision.jp/gtfs/okaden/gtfsFeed"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-岩国市生活交通バス~由宇地区バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://yamaguchi-opendata.jp/ckan/dataset/2dbaeb43-5134-4880-90a3-62870504f1d3/resource/31d5dd9c-113c-4fc5-bfa6-31d832f830fc/download/352080_gtfs-jp.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-島田市コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shimadacity/feeds/shimada_combus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-島田市コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shimadacity/feeds/shimada_combus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-川越町~ふれあいバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.town.kawagoe.mie.jp/wp-content/themes/kawagoecho/images/hureaibus202208.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-市川町コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/ichikawatown/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-市川町コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/ichikawatown/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-広島バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/9/latest.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-広島交通~広交観光",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/10/latest.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-広電バス広島電鉄",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/8/latest.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-庄内交通",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/syonaikotsu_gtfs.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-庄内交通~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shonaikotsu/feeds/SHONAIKOTSU/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-庄内交通~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shonaikotsu/feeds/SHONAIKOTSU/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-庄内町~町営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shonaitown/feeds/ShonaiTown/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-庄内町~町営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shonaitown/feeds/ShonaiTown/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-度会町~町営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/wataraitown/feeds/choeibus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-度会町~町営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/wataraitown/feeds/choeibus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-廿日市市~自主運行バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/19/latest.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-徳島バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus/feeds/tokushimabus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-徳島バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus/feeds/tokushimabus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-徳島バス南部",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus-nanbu/feeds/tokushimabusnanbu/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-徳島バス南部~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus-nanbu/feeds/tokushimabusnanbu/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-徳島バス阿南",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus-anan/feeds/tokushimabusanan/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-徳島バス阿南~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokubus-anan/feeds/tokushimabusanan/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-徳島市~上八万コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushimacity/feeds/kamihachimanbus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-徳島市~上八万コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushimacity/feeds/kamihachimanbus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-徳島市~応神ふれあいバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushimacity/feeds/oujinfureaibus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-徳島市~応神ふれあいバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushimacity/feeds/oujinfureaibus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-徳島市営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2649/url_resource/66/GTFS-JP.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-徳島市営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-shiei/feeds/tokushimacitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-徳島市営バス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-shiei/feeds/tokushimacitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-恵庭市コミュニティ",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ckan.hoda.jp/dataset/24d1dd70-5395-4d6b-b41f-0d83e8eabdb9/resource/5f05a49e-1bf0-4de3-918e-de6a1c6255b8/download/_gtfs-jp_202141_20211115131545-1.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-恵那市自主運行バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/enacity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-恵那市自主運行バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/enacity/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-掛川市自主運行バス~市街地循環線北回りジーネット",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/66108/shigaichijyunkan-kita202304.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-掛川市自主運行バス~市街地循環線北回りジーネット~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/65791/shigaichijyunkan-kita.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-掛川市自主運行バス~掛川大須賀線ジーネット",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/65789/kakegawaosuka.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-掛川市自主運行バス~掛川大須賀線ジーネット~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/66106/kakegawaosuka202304.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-掛川市自主運行バス~桜木線~居尻線~倉真線~東山線~粟本線~市街地循環線南回り掛川バスサービス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/65790/sakuragi.ijiri.kurami.higashiyama.awamoto.shigaichijyunkan-minami.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-掛川市自主運行バス~桜木線~居尻線~倉真線~東山線~粟本線~市街地循環線南回り掛川バスサービス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://opendata.pref.shizuoka.jp/dataset/9718/resource/66109/sakuragi.ijiri.kurami.higashiyama.awamoto.shigaichijyunkan-minami202304.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-揖斐川町~ふれあいバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/ibigawa/ibigawa_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-揖斐川町~ふれあいバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/ibigawatown/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-揖斐川町~ふれあいバス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/ibigawatown/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-新庄市~市営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shinjocity/feeds/ShinjoCity/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-新庄市~市営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shinjocity/feeds/ShinjoCity/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-新温泉町~町民バス夢つばめ",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shinonsentown/feeds/yumetsubame/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-日光市営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nikkocity/feeds/nikkocity/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-日光市営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nikkocity/feeds/nikkocity/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-日本中央バス前橋近郊路線空港バス高速バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Maebashi_Area.zip?date=current"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-日本中央バス前橋近郊路線空港バス高速バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Maebashi_Area.zip?date=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-日本中央バス前橋近郊路線空港バス高速バス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Maebashi_Area.zip?date=latest"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-日本中央バス奥多野線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ncb.jp/route/GTFS/latest/GTFS(OT).zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-日本中央バス奥多野線~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Okutano_Area.zip?date=current"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-日本中央バス奥多野線~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NipponChuoBus/Okutano_Area.zip?date=latest"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-日田バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/2dcbcc0d-6fbb-4c6b-9790-2f54ed41bf4f/resource/e37c6f56-ed8b-4032-a91f-4fc24639a18e/download/gtfs09_hitabus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-日田バス~高速バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/4e332c7a-3ac9-4c7a-a4b0-f78665e635da/resource/17806124-f3bd-4146-b276-675133184953/download/gtfs10_highway04hita.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-日進市巡回バス~くるりんばす",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/nisshin/nisshin_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-日進市巡回バス~くるりんばす~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nisshincity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-日進市巡回バス~くるりんばす~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nisshincity/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-日野町営バス県ポータル",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/e3f3ad12-171c-442b-95b5-896f4b50e5a7/resource/e431dddb-dc3a-4699-b570-9d77043306fa/download/gtfs.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-早島町コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hayashimatown/feeds/hayashimatowncommunitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-早島町コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hayashimatown/feeds/hayashimatowncommunitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-明知鉄道",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/aketetsu/feeds/akechirailway/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-明知鉄道~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/aketetsu/feeds/akechirailway/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-明石市~たこバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/akashicity/feeds/tacobustacobusmini/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-明石市~たこバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/akashicity/feeds/tacobustacobusmini/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-最上川交通",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/mogamigawakotsu/feeds/MOGAMIGAWAKOTSU/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-最上川交通~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/mogamigawakotsu/feeds/MOGAMIGAWAKOTSU/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-朝日町~あさひまちバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyama-asahitown/feeds/asahimachibus/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-朝日町~あさひまちバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyama-asahitown/feeds/asahimachibus/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-朝日町路線バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-asahitown/feeds/AsahiTown/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-朝日町路線バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-asahitown/feeds/AsahiTown/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-朝来市コミュニティバスアコバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/asagocity/feeds/acobus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-朝来市コミュニティバスアコバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/asagocity/feeds/acobus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-村山市~市営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/murayamacity/feeds/MurayamaCity/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-村山市~市営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/murayamacity/feeds/MurayamaCity/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-東みよし町営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/higashimiyoshitown/feeds/hitashimiyoshitownbus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-東みよし町営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/higashimiyoshitown/feeds/hitashimiyoshitownbus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-東京都町田市~コミュニティバス市民バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/MachidaCity/AllLines.zip?date=current"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-東京都町田市~コミュニティバス市民バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/MachidaCity/AllLines.zip?date=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-東京都町田市~コミュニティバス市民バス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/MachidaCity/AllLines.zip?date=latest"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-東根市~市民バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/higashinecity/feeds/HigashineCity/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-東根市~市民バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/higashinecity/feeds/HigashineCity/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-東浦町運行バスう~ら~ら",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/higashiura/higashiura_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-東浦町運行バスう~ら~ら~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/higashiuratown/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-東浦町運行バスう~ら~ら~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/higashiuratown/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-東鉄バス東濃鉄道",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tohtetsu/feeds/tohtetsu_ena/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-東鉄バス東濃鉄道~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tohtetsu/feeds/tohtetsu_ena/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-松江市コミュニティバス~本庄~持田コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://www.docodemo-bus.net/opendata/honjo-mochida.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-松茂町地域コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/matsushigetown/feeds/matsushigetownbus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-松茂町地域コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/matsushigetown/feeds/matsushigetownbus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-松阪市コミュニティ交通",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/matsusakacity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-松阪市コミュニティ交通~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/matsusakacity/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-桐生市~おりひめバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.kiryu.lg.jp/_res/common/opendata/1014528/20230320_kiryu_gtfs.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-桑名市~k-バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/kuwana/kuwana_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-桑名市~k-バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kuwanacity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-桑名市~k-バス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kuwanacity/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-横須賀市~ハマちゃんバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yokosukacity/feeds/hamachanbus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-横須賀市~ハマちゃんバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yokosukacity/feeds/hamachanbus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-橋本市コミュニティバス~デマンドタクシー",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.hashimoto.lg.jp/material/files/group/67/hashimoto_gtfsjp.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-武豊町ゆめころん",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/taketoyo/taketoyo_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-武豊町ゆめころん~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/taketoyotown/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-武豊町ゆめころん~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/taketoyotown/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-永井バス永井運輸",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.nagai-unyu.net/rosen/GTFS/aux/latest/GTFS-JP_nbaux-gunma-jp.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-永井バス永井運輸~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/AllLines.zip?date=current"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-永井バス永井運輸~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/AllLines.zip?date=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-永井バス永井運輸~3",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/AllLines.zip?date=latest"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-永井バス永井運輸~4",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagai-unyu/feeds/Nagaibus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-永井バス永井運輸~5",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagai-unyu/feeds/Nagaibus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-永井バス永井運輸独自拡張版gtfs",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.nagai-unyu.net/rosen/GTFS/aux/latest/GTFS-JP_nbaux-gunma-jp_gyomu.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-河北町路線バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kahokutown/feeds/KahokuTown/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-河北町路線バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kahokutown/feeds/KahokuTown/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-津ベルライン津エアポートライン",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/tsuairportline/tsuairportline_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-津山市~市営阿波バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuyamacity/feeds/bus-tsuyamacity-okayama-jp/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-津山市~市営阿波バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuyamacity/feeds/bus-tsuyamacity-okayama-jp/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-津市コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/tsu/tsu_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-津市コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsucity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-津市コミュニティバス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsucity/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-洲本市コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/sumotocity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-洲本市コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/sumotocity/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-流山市~流山ぐりーんバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagareyamacity/feeds/nagareyamagreenbus/files/feed.zip?rid=next_1"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-流山市~流山ぐりーんバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagareyamacity/feeds/nagareyamagreenbus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-流山市~流山ぐりーんバス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagareyamacity/feeds/nagareyamagreenbus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-浪岡地区コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.aomori.aomori.jp/n-somu/documents/namiokabus_current.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-海津市コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/kaizu/kaizu_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-海津市コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaizucity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-海津市コミュニティバス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaizucity/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-海陽町営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaiyotown/feeds/kaiyotownbus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-海陽町営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kaiyotown/feeds/kaiyotownbus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-淡路市~あわ神あわ姫バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/awajicity/feeds/awajinawahimebus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-淡路市~あわ神あわ姫バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/awajicity/feeds/awajinawahimebus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-滑川市~のる~my~car",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/jpxqjqmxqrbu47o2f45i84f3m43qkxzi.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-滑川市~のる~my~car~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/namerikawacity/feeds/norumycar/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-滑川市~のる~my~car~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/namerikawacity/feeds/norumycar/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-濃飛バス一般路線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nouhibus/feeds/nouhibus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-濃飛バス観光路線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nouhibus/feeds/nouhibus_kanko/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-濃飛バス高山周遊バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nouhibus/feeds/takayama_shuyu/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-熊本バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://km.bus-vision.jp/gtfs/kumabus/gtfsFeed"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-熊本市電",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kumamoto-shiden/feeds/kumamotoshiden/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-熊本市電~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kumamoto-shiden/feeds/kumamotoshiden/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-熊本都市バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://km.bus-vision.jp/gtfs/toshibus/gtfsFeed"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-熊本電鉄バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://km.bus-vision.jp/gtfs/dentetsu/gtfsFeed"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-猪名川町~ふれあいバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/inagawatown/feeds/fureaibus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-猪名川町~ふれあいバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/inagawatown/feeds/fureaibus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-玉村町乗合タクシー~たまりん",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.nagai-unyu.net/rosen/GTFS/tamarin/latest/GTFS-JP_tamarin-gunma-jp.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-玉村町乗合タクシー~たまりん~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/Tamarin.zip?date=current"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-玉村町乗合タクシー~たまりん~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/Tamarin.zip?date=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-玉村町乗合タクシー~たまりん~3",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/NagaiTransportation/Tamarin.zip?date=latest"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-玉村町乗合タクシー~たまりん~4",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagai-unyu/feeds/tamarin/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-玉村町乗合タクシー~たまりん~5",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagai-unyu/feeds/tamarin/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-玖珠観光バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/b90a15f4-9680-4b7c-bcf9-d510d426e210/resource/d99bc99a-4358-4eab-af68-b140c12477a0/download/gtfs06_kusukanko.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-琴参バス坂出営業所",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/sakaide-local/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-琴参バス坂出営業所~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/sakaide-local/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-琴参バス琴平営業所",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/kotohira-local/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-琴参バス琴平営業所~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kotosan/feeds/kotohira-local/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-瑞浪市コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/mizunami/mizunami_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-瑞浪市コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/mizunamicity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-瑞浪市コミュニティバス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/mizunamicity/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-生活バスよっかいち",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/seikatsubus-yokkaichi/feeds/sbusyokkaichi/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-生活バスよっかいち~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/seikatsubus-yokkaichi/feeds/sbusyokkaichi/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-由布市コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/bf767ad7-4651-42f8-a9b1-78874542e046/resource/9b537213-f309-4116-9952-53050ea768ba/download/gtfs11_combus13_yufu.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-男鹿市内路線バス全路線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.oga.akita.jp/material/files/group/2/bus-ogacity.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-白山市コミュニティバスめぐーる",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hakusancity/feeds/hakusan_bus_meguru/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-白山市コミュニティバスめぐーる~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hakusancity/feeds/hakusan_bus_meguru/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-白鷹町~町営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shiratakatown/feeds/ShiratakaTown/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-白鷹町~町営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/shiratakatown/feeds/ShiratakaTown/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-真室川町路線バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/mamurogawatown/feeds/MamurogawaTown/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-真室川町路線バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/mamurogawatown/feeds/MamurogawaTown/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-石巻市~住民バス~市民バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://miyagi.dataeye.jp/resource_download/340"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-砺波市~砺波市営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/70l7nwf33az6y13k4hzyc1gw679enkss.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-砺波市~砺波市営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tonamicity/feeds/tonamishieibasu/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-砺波市~砺波市営バス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tonamicity/feeds/tonamishieibasu/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-磐田市生活路線バス浜松バス~掛塚磐田駅線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hamabus/feeds/iwata_seikatsubus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-神戸市垂水区~塩屋コミュニティバスしおかぜ",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kobecity/feeds/kobe-shiokaze/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-神戸市垂水区~塩屋コミュニティバスしおかぜ~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kobecity/feeds/kobe-shiokaze/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-神河町コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-kamikawatown/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-神河町コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-kamikawatown/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-福崎町コミュニティバス巡回バスふくひめ号福崎町~加西市連携コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/fukusakitown/feeds/junkai-fukuhime-fukusakikasairenkei/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-福崎町コミュニティバス巡回バスふくひめ号福崎町~加西市連携コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/fukusakitown/feeds/junkai-fukuhime-fukusakikasairenkei/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-秋北バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-shuhokubus202304.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-秋田中央交通",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-akitachuoukotsu.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-秋田市マイタウン~バス中心市街地循環バスぐるる県バス協会掲載版",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/bus-akitacity.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-秋田市マイタウン~バス中心市街地循環バスぐるる県バス協会掲載版~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/next/bus-akitacity.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-立山町~立山町営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tateyamatown/feeds/tateyama/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-立山町~立山町営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tateyamatown/feeds/tateyama/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-立山町~立山町営バス県サイト",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/8u3d410n3ioow5juxkce2ocg0vynisw7.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-竹富島交通",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api3.ottop.org/download/gtfs/ooXuXei4op7y/4360002021665"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-竹田市コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/bf767ad7-4651-42f8-a9b1-78874542e046/resource/0f39370a-d524-43f1-998b-d59c87c4e9ae/download/gtfs11_combus08_taketa.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-笠松町公共施設巡回町民バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/kasamatsu/kasamatsu_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-笠松町公共施設巡回町民バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kasamatsutown/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-笠松町公共施設巡回町民バス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kasamatsutown/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-米沢市~市民バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yonezawacity/feeds/Yonezawa/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-米沢市~市民バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yonezawacity/feeds/Yonezawa/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-紀宝町民バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/kiho/kiho_GTFS.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-網走バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.abashiribus.com/open_data/gtfs_abashiribus_latest.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-美波町~美波病院連絡バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://opendata.pref.tokushima.lg.jp/dataset/2636/resource/7707/GTFSJP3_minami-town_20220601.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-美波町~美波病院連絡バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-minamitown/feeds/minabubyoinrenrakubus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-美波町~美波病院連絡バス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tokushima-minamitown/feeds/minabubyoinrenrakubus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-美濃加茂市コミュニティバスあい愛バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/minokamocity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-美濃加茂市コミュニティバスあい愛バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/minokamocity/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-群馬バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.gunbus.co.jp/GTFS/GTFS-JP_gunbus_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-群馬中央バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/GunmachuoBus/AllLines.zip?date=current"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-群馬中央バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/GunmachuoBus/AllLines.zip?date=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-群馬中央バス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/GunmachuoBus/AllLines.zip?date=latest"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-羽咋市~市内循環バスるんるんバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.hakui.lg.jp/material/files/group/2/GTFS20230401.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-羽後交通",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.akita-bus.or.jp/~akita-gtfs/ugo-bus-jp.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-能美市~のみバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.nomi.ishikawa.jp/www/contents/1683514558086/simple/GTFS_nomi_20230401.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-臼杵市コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/bf767ad7-4651-42f8-a9b1-78874542e046/resource/95513da5-7317-4b97-911a-5df29d387900/download/gtfs11_combus06_usuki.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-臼津交通",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.bodik.jp/dataset/af52f355-1e78-405c-9d89-9df309bbb30f/resource/76e548c5-617e-4273-81f7-23499ec3aafe/download/gtfs03_kyushinkotsu.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-芸陽バス広島県バス協会サイト掲載版",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://ajt-mobusta-gtfs.mcapps.jp/static/11/latest.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-藤岡市~めぐるん",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.fujioka.gunma.jp/material/files/group/7/fujiokaGTFS.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-西宮市~さくらやまなみバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinomiyacity/feeds/sakurayamanami/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-西宮市~さくらやまなみバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinomiyacity/feeds/sakurayamanami/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-西宮市コミュニティ交通ぐるっと生瀬",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinomiyacity/feeds/guruttonamaze/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-西宮市コミュニティ交通ぐるっと生瀬~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinomiyacity/feeds/guruttonamaze/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-西尾市~いっちゃんバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiocity/feeds/ichanbus/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-西尾市~いっちゃんバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiocity/feeds/ichanbus/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-西尾市~六万石くるりんバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiocity/feeds/rokumangokukururinbus/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-西尾市~六万石くるりんバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiocity/feeds/rokumangokukururinbus/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-西川町路線バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishikawatown/feeds/NishikawaTown/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-西川町路線バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishikawatown/feeds/NishikawaTown/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-西日本ジェイアールバス~名金線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinihonjrbus/feeds/meikinsen/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-西日本ジェイアールバス~名金線~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishinihonjrbus/feeds/meikinsen/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-西脇市コミュニティバスループバスめぐリンおりひめバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiwakicity/feeds/loopbus-orihimebus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-西脇市コミュニティバスループバスめぐリンおりひめバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nishiwakicity/feeds/loopbus-orihimebus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-豊山町~とよやまタウンバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyoyamatown/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-豊山町~とよやまタウンバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyoyamatown/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-豊岡市~市営バスイナカー",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyookacity/feeds/inacar/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-豊岡市~市営バスイナカー~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyookacity/feeds/inacar/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-豊岡市~市街地循環バスコバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyookacity/feeds/kobus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-豊岡市~市街地循環バスコバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyookacity/feeds/kobus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-豊田市~とよたおいでんバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/toyota/toyota_kikan_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-豊田市~とよたおいでんバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyotacity/feeds/kikanbus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-豊田市~とよたおいでんバス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyotacity/feeds/kikanbus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-豊田市~地域バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/toyota_chiiki/toyota_chiiki_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-豊田市~地域バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyotacity/feeds/chiikibus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-豊田市~地域バス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/toyotacity/feeds/chiikibus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-赤磐市広域路線バス~市民バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.akaiwa.lg.jp/material/files/group/5/GTFS-JP.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-赤磐市広域路線バス~市民バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AkaiwaCity/AllLines.zip?date=current"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-赤磐市広域路線バス~市民バス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AkaiwaCity/AllLines.zip?date=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-赤磐市広域路線バス~市民バス~3",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AkaiwaCity/AllLines.zip?date=latest"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-赤穂市~市内循環バスゆらのすけ",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/akocity/feeds/yuranosuke/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-那賀町営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nakatown/feeds/nakatownbus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-那賀町営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nakatown/feeds/nakatownbus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-酒田市~るんるんバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/sakatacity/feeds/SakataCity/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-酒田市~るんるんバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/sakatacity/feeds/SakataCity/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-金山町町営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-kaneyamatown/feeds/KaneyamaTown/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-金山町町営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yamagata-kaneyamatown/feeds/KaneyamaTown/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-金沢ふらっとバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://catalog-data.city.kanazawa.ishikawa.jp/dataset/1196beb4-f9f9-463c-9723-5b38d8127425/resource/191bd7bd-8e97-4919-b3ad-a87757993a79/download/20230401.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-長井市営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagaicity/feeds/NagaiCity/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-長井市営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/nagaicity/feeds/NagaiCity/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-長岡市~小国地域生活交通~八王子線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-10.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-長岡市~小国地域生活交通~大貝線オーケーバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-09.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-長岡市~小国地域生活交通~法末線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-11.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-長岡市~山古志地域クローバーバス~小千谷線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-06.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-長岡市~山古志地域クローバーバス~小松倉線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-08.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-長岡市~山古志地域クローバーバス~村松線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-05.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-長岡市~山古志地域クローバーバス~種苧原線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-07.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-長岡市~川口地域バス上川線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-12.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-長岡市~川口地域バス木沢~和南津線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-14.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-長岡市~川口地域バス西川口~田麦山線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.nagaoka.niigata.jp/shisei/cate10/gis/file/28-13.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-関越交通",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://kan-etsu.net/relays/download/193/2807/433//?file=/files/libs/11049/202305261450561282.zip&file_name=GTFS-JP(kan-etsu)"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-阿佐海岸鉄道",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/asatetu/feeds/asakaigantetsudo/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-阿佐海岸鉄道~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/asatetu/feeds/asakaigantetsudo/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-階上町コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://opendata.pref.aomori.lg.jp/dataset/1596/resource/16908/gtfs_hashikamicho_com.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-階上町コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://opendata.pref.aomori.lg.jp/dataset/1596/resource/19655/gtfs_hashikamicho_com_latest.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-青森市営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AomoriCity/AllLines.zip?date=current"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-青森市営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AomoriCity/AllLines.zip?date=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-青森市営バス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api-public.odpt.org/api/v4/files/odpt/AomoriCity/AllLines.zip?date=latest"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-飛騨市おでかけバスひだまる",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/hida/hida_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-飛騨市おでかけバスひだまる~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hidacity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-飛騨市おでかけバスひだまる~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hidacity/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-養父市コミュニティバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yabucity/feeds/waiwai-sekimiya-yoka/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-養父市コミュニティバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/yabucity/feeds/waiwai-sekimiya-yoka/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-香美町~町民バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-kamitown/feeds/kamichominbus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-香美町~町民バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/hyogo-kamitown/feeds/kamichominbus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-SA-2.1-JP",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-高岡市~高岡市公営バス福岡地域",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/takaokacity/feeds/koueibus/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-高岡市~高岡市公営バス福岡地域~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/takaokacity/feeds/koueibus/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-高岡市~高岡市公営バス福岡地域県サイト",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/hjzzrbhbq92r7qli46ygb4qjci7030gy.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-高崎市内循環バスぐるりん~高崎アリーナシャトルバス~よしいバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.takasaki.gunma.jp/docs/2020060400037/files/bus-takasaki-gunma-jp_20230414.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-高知観光コンベンション協会~my遊バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.pref.kochi.lg.jp/opendata/docs/bosai_anzen_machizukuri/file_contents/GTFSJP-KVCA_MY-Yubus.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-高砂市~じょうとんバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/takasagocity/feeds/jotonbus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-高砂市~じょうとんバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/takasagocity/feeds/jotonbus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-魚津市~予約式あいのりタクシー~おもてなし魚津直行便",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.city.uozu.toyama.jp/attach/EDIT/062/062570.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-魚津市~予約式あいのりタクシー~おもてなし魚津直行便~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/glzk70eid2g89z8zos927s4emfxdvni4.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-魚津市~予約式あいのりタクシー~おもてなし魚津直行便~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/uozucity/feeds/omotenashi/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-魚津市~予約式あいのりタクシー~おもてなし魚津直行便~3",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/uozucity/feeds/omotenashi/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-魚津市~魚津市民バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/na9rrq16urut58g79ba13bil9ig1m9rh.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-魚津市~魚津市民バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/uozucity/feeds/junkai/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-魚津市~魚津市民バス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/uozucity/feeds/junkai/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鮭川村村営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/sakegawavillage/feeds/SakegawaVillage/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鮭川村村営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/sakegawavillage/feeds/SakegawaVillage/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鳥羽市~かもめバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.rosenzu.com/~gtfs/toba_bus/toba_bus_GTFS_next.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鳥羽市~かもめバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tobacity/feeds/communitybus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鳥羽市~かもめバス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tobacity/feeds/communitybus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鳥羽市~市営定期船",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tobacity/feeds/teikisen/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鳥羽市~市営定期船~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tobacity/feeds/teikisen/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鳴門市営渡船",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/narutocity/feeds/narutocitytosen/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鳴門市営渡船~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/narutocity/feeds/narutocitytosen/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鳴門市地域バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/narutocity/feeds/narutocitychiikibus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鳴門市地域バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/narutocity/feeds/narutocitychiikibus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鶴岡市~羽黒地域市営バス朝日地域市営バス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://www.pref.yamagata.jp/documents/20978/tsuruoka_gtfs_1.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鶴岡市~羽黒地域市営バス朝日地域市営バス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuruokacity/feeds/TsuruokaCity/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鶴岡市~羽黒地域市営バス朝日地域市営バス~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/tsuruokacity/feeds/TsuruokaCity/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鹿児島市コミュニティバスあいばす",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kagoshimacity/feeds/aibus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鹿児島市コミュニティバスあいばす~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kagoshimacity/feeds/aibus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鹿沼市~リーバス",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kanumacity/feeds/ri-bus/files/feed.zip"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-鹿沼市~リーバス~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kanumacity/feeds/ri-bus/files/feed.zip?rid=next"
-      },
-      "license": {
-        "spdx_identifier": "CC-BY-4.0",
-        "use_without_attribution": "no"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-黒部市~市内路線バス新幹線生地線",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/y8rvyr2h3dtbz1tu0c2hm78teuvwqwcy.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-黒部市~市内路線バス新幹線生地線~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kurobecity/feeds/shinkansenikujisen/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-黒部市~市内路線バス新幹線生地線~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kurobecity/feeds/shinkansenikujisen/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-黒部市~市内路線バス石田三日市線~愛本コミュニティタクシー",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://toyama-pref.box.com/shared/static/3vqbuvgk41hq3k47bf8b5iit989vrbbl.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-黒部市~市内路線バス石田三日市線~愛本コミュニティタクシー~1",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kurobecity/feeds/ishida-aimoto/files/feed.zip"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
-      }
-    },
-    {
-      "id": "f-黒部市~市内路線バス石田三日市線~愛本コミュニティタクシー~2",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://api.gtfs-data.jp/v2/organizations/kurobecity/feeds/ishida-aimoto/files/feed.zip?rid=next"
-      },
-      "tags": {
-        "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
       }
     }
   ],

--- a/scripts/convert-jp-list-csv-to-dmfr.py
+++ b/scripts/convert-jp-list-csv-to-dmfr.py
@@ -44,6 +44,10 @@ def remove_duplicate_urls(data):
         url = row.get('url')
         if '?rid=next' in url:
             logging.warn(f"URL found with '?rid=next' and removed: {url}")
+        elif '?date=next' in url:
+            logging.warn(f"URL found with '?date=next' and removed: {url}")
+        elif '/next/' in url:
+            logging.warn(f"URL found with '/next/' and removed: {url}")
         elif '_next.zip' in url:
             logging.warn(f"URL found with '_next.zip' and removed: {url}")
         elif url in unique_urls:

--- a/scripts/convert-jp-list-csv-to-dmfr.py
+++ b/scripts/convert-jp-list-csv-to-dmfr.py
@@ -42,8 +42,12 @@ def remove_duplicate_urls(data):
     unique_data = []
     for row in data:
         url = row.get('url')
-        if url in unique_urls:
-            logging.error(f"Duplicate URL found and removed: {url}")
+        if '?rid=next' in url:
+            logging.warn(f"URL found with '?rid=next' and removed: {url}")
+        elif '_next.zip' in url:
+            logging.warn(f"URL found with '_next.zip' and removed: {url}")
+        elif url in unique_urls:
+            logging.warn(f"Duplicate URL found and removed: {url}")
         else:
             unique_urls.add(url)
             unique_data.append(row)

--- a/scripts/convert-jp-list-csv-to-dmfr.py
+++ b/scripts/convert-jp-list-csv-to-dmfr.py
@@ -1,13 +1,14 @@
-# turn https://github.com/tshimada291/gtfs-jp-list-datecheck into a DMFR
-# license on the GitHub repo is CC0-1.0: https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/LICENSE
-
 import csv
-import json
 import requests
+import json
 import re
+import subprocess
+import logging
 
-# http POST https://transit.land/api/v2/query apikey:XXXX query="{agencies(where: {adm0_iso: \"JP\"}) {feed_version {feed {urls {static_current}}}}}" | jq '.data.agencies[] .feed_version.feed.urls.static_current' | uniq
-existing_feeds_to_skip = [
+dmfr_url = 'https://github.com/transitland/transitland-atlas/raw/refs/heads/main/feeds/tshimada291.github.com.dmfr.json'
+csv_url = 'https://github.com/tshimada291/gtfs-jp-list-datecheck/raw/refs/heads/main/GTFS_fixedURL_LastModified.csv'
+
+existing_feed_urls_to_skip = [
     "http://codeforkobe.github.io/kobe-transit/kobe_subway_gtfs.zip",
     "http://www.city.nomi.ishikawa.jp/data/open/cnt/3/5145/1/GTFSnomi2018.zip",
     "https://www.city.aomori.aomori.jp/toshi-seisaku/opendata/documents/siminbus20190401.zip",
@@ -23,72 +24,124 @@ existing_feeds_to_skip = [
     "http://www3.unobus.co.jp/opendata/GTFS-JP.zip",
 ]
 
-existing_names_to_skip = []
+# Collection to store created DMFR records
+created_dmfr_records = []
+checked_or_added_feeds = set()
 
-r = requests.get(
-    "https://raw.githubusercontent.com/tshimada291/gtfs-jp-list-datecheck/main/GTFS_fixedURL.csv"
-)
-decoded_content = r.content.decode("utf-8")
-cr = csv.DictReader(decoded_content.splitlines(), delimiter=",")
-feeds = []
-for row in list(cr):
-    # skip some feeds
-    if row["fixed_current_url"] in existing_feeds_to_skip:
-        continue
-    if row["fixed_current_url"].startswith("https://openmobilitydata.org"):
-        continue
+def load_csv_from_url(csv_url):
+    response = requests.get(csv_url)
+    response.raise_for_status()  # Raise an error for bad responses
+    lines = response.content.decode('utf-8').splitlines()
+    reader = csv.DictReader(lines)
+    data = [row for row in reader]
+    return data
 
-    # name for Onestop ID
-    if row["fixed_current_basename"] in ["GTFS-JP", "GTFS"]:
-        name = row["feed_id"]
-    elif row["fixed_current_basename"]:
-        name = (
-            row["fixed_current_basename"]
-            .lower()
-            .replace("_", "~")
-            .replace("-", "~")
-            .replace(".", "~")
-        )
-    else:
-        name = row["feed_id"]
+# Remove duplicate URLs from data
+def remove_duplicate_urls(data):
+    unique_urls = set()
+    unique_data = []
+    for row in data:
+        url = row.get('url')
+        if url in unique_urls:
+            logging.error(f"Duplicate URL found and removed: {url}")
+        else:
+            unique_urls.add(url)
+            unique_data.append(row)
+    return unique_data
 
-    # the source CSV has some rows with fixed_current_basename
-    # we will only take the first feed URL for each
-    if name in existing_names_to_skip:
-        continue
-    else:
-        existing_names_to_skip.append(name)
+def create_dmfr_record(feed_url, label, license_name, new_dmfr):
+    label = label.strip().lower()
+    label = re.sub(r'\(.*?\)|\[.*?\]', '', label) # remove [gtfs-data], [HODaP], and (HODaP)
+    label = re.sub(r'[()\[\]（）「」『』、。“”‘’]', '', label)
+    label = re.sub(r'\s+|・|〜', '~', label)
+    label = label.strip('~')
+    onestop_id = f"f-{label}"
 
-    # prepare feed record
-    feed = {
+    # Determine SPDX identifier and additional license properties based on license name
+    spdx_identifier = None
+    use_without_attribution = None
+    if license_name == "CC BY 4.0":
+        spdx_identifier = "CC-BY-4.0"
+        use_without_attribution = "no"
+    elif license_name == "CC BY 2.1":
+        spdx_identifier = "CC-BY-SA-2.1-JP"
+        use_without_attribution = "no"
+
+    dmfr = {
+        "id": onestop_id,
         "spec": "gtfs",
-        "id": f"f-{name}~jp",
-        "urls": {"static_current": row["fixed_current_url"]},
+        "urls": {
+            "static_current": feed_url
+        },
+        "tags": {
+            "notes": "This feed record is managed in https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv"
+        },
+        "license": {
+            "spdx_identifier": spdx_identifier,
+            "use_without_attribution": use_without_attribution
+        } if spdx_identifier else None
+    }
+    new_dmfr.setdefault("feeds", []).append(dmfr)
+
+# Load existing DMFR from URL
+def load_existing_dmfr(dmfr_url):
+    response = requests.get(dmfr_url)
+    response.raise_for_status()  # Raise an error for bad responses
+    dmfr_data = response.json()
+    return dmfr_data
+
+# Check if a feed URL exists in the existing DMFR records
+def check_for_feed_in_existing_dmfr(feed_url, existing_dmfr):
+    for feed in existing_dmfr.get("feeds", []):
+        if feed.get("urls", {}).get("static_current") == feed_url:
+            logging.info(f"Feed URL found in existing DMFR: {feed_url}")
+            checked_or_added_feeds.add(feed.get("id"))
+            return True
+    logging.info(f"Feed URL not found in existing DMFR: {feed_url}")
+    return False
+
+if __name__ == "__main__":
+    # Set up logging
+    logging.basicConfig(level=logging.INFO, format='%(levelname)s - %(message)s')
+
+    # Load data from external CSV
+    data = load_csv_from_url(csv_url)
+
+    # Remove duplicate URLs
+    data = remove_duplicate_urls(data)
+
+    # Load existing DMFR
+    existing_dmfr = load_existing_dmfr(dmfr_url)
+
+    new_dmfr = {
+        "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
+        "feeds": [],
+        "license_spdx_identifier": "CDLA-Permissive-1.0"
     }
 
-    # license
-    if row["license_name"] == "CC BY 4.0":
-        feed["license"] = {
-            "spdx_identifier": "CC-BY-4.0",
-            "use_without_attribution": "no",
-        }
-    elif row["license_name"] == "CC 0":
-        feed["license"] = {
-            "spdx_identifier": "CC0-1.0",
-            "use_without_attribution": "yes",
-        }
-    elif row["license_name"] == "CC BY 2.1":
-        feed["license"] = {
-            "spdx_identifier": "CC-BY-SA-2.1-JP",
-            "use_without_attribution": "no",
-        }
-    feeds.append(feed)
-dmfr = {
-    "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
-    "feeds": feeds,
-    "license_spdx_identifier": "CDLA-Permissive-1.0",
-}
-print(json.dumps(dmfr, indent=2, sort_keys=True))
+    # Iterate through all rows to check for existing TLv2 feed and create DMFR record if needed
+    if data:
+        for row in data:
+            feed_url = row.get('url')
+            label = row.get('label', '')
+            license_name = row.get('license_name', '')
+            if feed_url in existing_feed_urls_to_skip:
+                logging.info("Skipping a feed URL that is managed in a different DMFR file")
+                continue
+            if feed_url:
+                result = check_for_feed_in_existing_dmfr(feed_url, existing_dmfr)
+                if not result:
+                    create_dmfr_record(feed_url, label, license_name, new_dmfr)
 
-# don't forget to format:
-# gfind ./feeds -type f -name "*.dmfr.json" -exec transitland dmfr format --save {} \;
+    output_path = '../feeds/tshimada291.github.com.dmfr.json'
+    with open(output_path, 'w', encoding='utf-8') as f:
+        json.dump(new_dmfr, f, indent=2)
+    logging.info(f"All Created DMFR Records have been written to {output_path}")
+
+    # Run transitland command to format and save the DMFR file
+    subprocess.run(["transitland", "dmfr", "format", "--save", output_path], check=True)
+
+    # Log summary of processing
+    logging.info(f"Total unique URLs loaded from CSV: {len(data)}")
+    logging.info(f"Total feed records loaded from existing DMFR: {len(existing_dmfr.get('feeds', []))}")
+    logging.info(f"Total feed records outputted: {len(new_dmfr.get('feeds', []))}")


### PR DESCRIPTION
new script to handle the format of https://github.com/tshimada291/gtfs-jp-list-datecheck/blob/main/GTFS_fixedURL_LastModified.csv

related to https://github.com/transitland/transitland-atlas/pull/880 and https://github.com/tshimada291/gtfs-jp-list-datecheck/issues/1