### PR TITLE
CIM Leiria / Rodoviária do Lis (Portugal)

### DIFF
--- a/feeds/cimrl.pt.dmfr.json
+++ b/feeds/cimrl.pt.dmfr.json
@@ -12,9 +12,8 @@
         "url": "https://creativecommons.org/publicdomain/zero/1.0/",
         "use_without_attribution": "yes",
         "create_derived_product": "yes",
-        "redistribute": "yes",
-        "commercial_use_allowed": "yes",
-        "attribution_text": ""
+        "redistribution_allowed": "yes",
+        "commercial_use_allowed": "yes"
       },
       "operators": [
         {

--- a/feeds/cimrl.pt.dmfr.json
+++ b/feeds/cimrl.pt.dmfr.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
+  "feeds": [
+    {
+      "id": "f-ez-cimrl",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://drive.google.com/uc?export=download&id=192Qat2jJKyv5hhO8T3eVT70M5NB0dtXC"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "commercial_use_allowed": "yes",
+        "attribution_text": ""
+      },
+      "operators": [
+        {
+          "onestop_id": "o-ez-rdlis",
+          "name": "RDL RODOVIÁRIA DO LIS II",
+          "short_name": "RDL II",
+          "website": "http://www.rodoviariadolis.pt/",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "cimrl"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "license_spdx_identifier": "CC0-1.0"
+}


### PR DESCRIPTION
This is the official feed for CIM Leiria / Rodoviária do Lis.

We don't have a better (non-Google Drive) URL at hand.  This is the very same URL that sources Google Maps.

I do have the authorization to publish it under this license.

The branding of the operation is "Rodoviária do Lis"; perhaps we should have that as an explicit feed name; what do you think? 

Cheers,
Cláudio