### PR TITLE
Mobilis Leiria (Portugal)

### DIFF
--- a/feeds/mobilis.pt.dmfr.json
+++ b/feeds/mobilis.pt.dmfr.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
+  "feeds": [
+    {
+      "id": "f-ez1-mobilis",
+      "name": "Mobilis",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://drive.google.com/uc?export=download&id=1NqcOk8IrlV73TBonJAxpzIUTjaAjF27M"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes",
+        "redistribute": "yes",
+        "commercial_use_allowed": "yes",
+        "attribution_text": ""
+      },
+      "operators": [
+        {
+          "onestop_id": "o-ez1-rdlis",
+          "name": "RDL RODOVIÁRIA DO LIS",
+          "short_name": "RDL",
+          "website": "https://mobilis.pt/",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "Mobilis"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "license_spdx_identifier": "CC0-1.0"
+}

--- a/feeds/mobilis.pt.dmfr.json
+++ b/feeds/mobilis.pt.dmfr.json
@@ -13,9 +13,8 @@
         "url": "https://creativecommons.org/publicdomain/zero/1.0/",
         "use_without_attribution": "yes",
         "create_derived_product": "yes",
-        "redistribute": "yes",
-        "commercial_use_allowed": "yes",
-        "attribution_text": ""
+        "redistribution_allowed": "yes",
+        "commercial_use_allowed": "yes"
       },
       "operators": [
         {


### PR DESCRIPTION
This is the official feed for the Leiria Mobilis service.

We don't have a better (non-Google Drive) URL at hand.  This is the very same URL that sources Google Maps.

I do have the authorization to publish it under this license.

Cheers,
Cláudio