### PR TITLE
Fix spelling mistake in Toronto Transit Commission

### DIFF
--- a/feeds/toronto.ca.dmfr.json
+++ b/feeds/toronto.ca.dmfr.json
@@ -61,7 +61,7 @@
   "operators": [
     {
       "onestop_id": "o-dpz8-ttc",
-      "name": "Toronto Transit Comission",
+      "name": "Toronto Transit Commission",
       "short_name": "TTC",
       "website": "http://www.ttc.ca",
       "associated_feeds": [


### PR DESCRIPTION
This seems to trickle through all the way to https://www.transit.land/operators/o-dpz8-ttc