### PR TITLE
Add realtime_trip_updates for kolejedolnoslaskie

### DIFF
--- a/feeds/kolejedolnoslaskie.pl.dmfr.json
+++ b/feeds/kolejedolnoslaskie.pl.dmfr.json
@@ -22,7 +22,8 @@
       "id": "f-u3h-koleje~dolnoslaskie~rt",
       "spec": "gtfs-rt",
       "urls": {
-        "realtime_vehicle_positions": "https://gtfs.i.kiedyprzyjedzie.pl/rt/279/vehicles"
+        "realtime_vehicle_positions": "https://gtfs.i.kiedyprzyjedzie.pl/rt/279/feed",
+        "realtime_trip_updates": "https://gtfs.i.kiedyprzyjedzie.pl/rt/279/feed"
       },
       "license": {
         "url": "https://www.kolejedolnoslaskie.4bip.pl/index.php?idg=6&id=75&x=99"


### PR DESCRIPTION
I requested for GTFS creds for KD in https://github.com/transitland/transitland-atlas/issues/1034 so now I'm on their mailing list.

I' got an e-mail saying that the /vehicles endpoint provided GTFS-RT VehiclePositions, but now they have a /feed endpoint where they provide both VehiclePositions and TripUpdates

They explicitly ask to *switch* from /vehicles to /feed