### PR TITLE
fix: embarkok authorization info_url replaced

### DIFF
--- a/feeds/embarkok.com.dmfr.json
+++ b/feeds/embarkok.com.dmfr.json
@@ -55,7 +55,7 @@
       "authorization": {
         "type": "query_param",
         "param_name": "apiKey",
-        "info_url": "https://embarkok.com/business/developer-resources/developer-registration"
+        "info_url": "https://embarkok.com/transit-data-resources"
       }
     }
   ],


### PR DESCRIPTION
Old url doesn't work anymore