### PR TITLE
fix: authorization removed from trafiklab feed

### DIFF
--- a/feeds/api.resrobot.se.dmfr.json
+++ b/feeds/api.resrobot.se.dmfr.json
@@ -12,11 +12,6 @@
         "url": "https://www.trafiklab.se/api/trafiklab-apis/gtfs-sverige-2/licence/",
         "use_without_attribution": "yes",
         "create_derived_product": "yes"
-      },
-      "authorization": {
-        "type": "query_param",
-        "param_name": "key",
-        "info_url": "https://www.trafiklab.se/docs/using-trafiklab/getting-api-keys/"
       }
     }
   ],


### PR DESCRIPTION
There is no authorization needed for the trafiklab feed