### PR TITLE
fix: updated authorization info_url in opendata.transport.nsw.gov.au feed

### DIFF
--- a/feeds/opendata.transport.nsw.gov.au.dmfr.json
+++ b/feeds/opendata.transport.nsw.gov.au.dmfr.json
@@ -19,7 +19,7 @@
       "authorization": {
         "type": "header",
         "param_name": "Authorization",
-        "info_url": "https://opendata.transport.nsw.gov.au/get-started"
+        "info_url": "https://opendata.transport.nsw.gov.au/developers/userguide"
       },
       "operators": [
         {


### PR DESCRIPTION
Old info_url doesn't work