### PR TITLE
fix: metrarail gtfs url updated and authorization removed

### DIFF
--- a/feeds/metrarail.com.dmfr.json
+++ b/feeds/metrarail.com.dmfr.json
@@ -5,16 +5,12 @@
       "id": "f-dp3-metra",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gtfsapi.metrarail.com/gtfs/raw/schedule.zip"
+        "static_current": "https://schedules.metrarail.com/gtfs/schedule.zip"
       },
       "license": {
         "url": "https://metrarail.com/developers",
         "use_without_attribution": "yes",
         "create_derived_product": "yes"
-      },
-      "authorization": {
-        "type": "basic_auth",
-        "info_url": "https://metrarail.com/developers"
       },
       "tags": {
         "gtfs_data_exchange": "metra"


### PR DESCRIPTION
In the [developer docs](https://metra.com/developers) they are recommending to use a different url for the gtfs feed that isn't secured by any type of authentication