### PR TITLE
fix: authorization in tcl feed removed

### DIFF
--- a/feeds/grandlyon.com.dmfr.json
+++ b/feeds/grandlyon.com.dmfr.json
@@ -11,10 +11,6 @@
         "url": "https://data.grandlyon.com/cgu",
         "use_without_attribution": "no"
       },
-      "authorization": {
-        "type": "basic_auth",
-        "info_url": "https://data.grandlyon.com/portail/fr/connexion"
-      },
       "operators": [
         {
           "onestop_id": "o-u05-tcl~systral",


### PR DESCRIPTION
No authorization is needed to download this feed and no authorization is mentioned in the [official documentation](https://transport.data.gouv.fr/resources/65812?locale=en)