### PR TITLE
Update static gtfs feed link of Rhein-Neckar-Verkehr GmbH

### DIFF
--- a/feeds/opendata.rnv-online.de.dmfr.json
+++ b/feeds/opendata.rnv-online.de.dmfr.json
@@ -21,12 +21,7 @@
           "onestop_id": "o-u0y1-rhein~neckar~verkehrgmbhrnv",
           "name": "Rhein-Neckar-Verkehr",
           "short_name": "rnv",
-          "website": "http://www.rnv-online.de",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "19"
-            }
-          ]
+          "website": "http://www.rnv-online.de"
         }
       ]
     }

--- a/feeds/opendata.rnv-online.de.dmfr.json
+++ b/feeds/opendata.rnv-online.de.dmfr.json
@@ -5,7 +5,7 @@
       "id": "f-u0y1-rhein~neckar~verkehrgmbhrnv",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.rnv-online.de/sites/default/files/2021_rnv-GTFS.zip"
+        "static_current": "https://gtfs-sandbox-dds.rnv-online.de/latest/gtfs.zip"
       },
       "license": {
         "url": "https://www.govdata.de/dl-de/by-2-0",

--- a/feeds/opendata.rnv-online.de.dmfr.json
+++ b/feeds/opendata.rnv-online.de.dmfr.json
@@ -5,7 +5,10 @@
       "id": "f-u0y1-rhein~neckar~verkehrgmbhrnv",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://gtfs-sandbox-dds.rnv-online.de/latest/gtfs.zip"
+        "static_current": "https://gtfs-sandbox-dds.rnv-online.de/latest/gtfs.zip",
+        "static_historic": [
+          "https://opendata.rnv-online.de/sites/default/files/2021_rnv-GTFS.zip"
+        ]
       },
       "license": {
         "url": "https://www.govdata.de/dl-de/by-2-0",


### PR DESCRIPTION
See https://www.opendata-oepnv.de//ht/de/organisation/verkehrsunternehmen/rnv/openrnv/datensaetze?tx_vrrkit_view%5Bdataset_name%5D=soll-fahrplandaten-rnv&tx_vrrkit_view%5Baction%5D=details&tx_vrrkit_view%5Bcontroller%5D=View