### PR TITLE
Hamilton city feed url update

### DIFF
--- a/feeds/hamilton.ca.dmfr.json
+++ b/feeds/hamilton.ca.dmfr.json
@@ -7,6 +7,7 @@
       "urls": {
         "static_current": "https://opendata.hamilton.ca/GTFS-Static/2025Winter_GTFSStatic.zip",
         "static_historic": [
+          "https://opendata.hamilton.ca/GTFS-Static/Summer2024_GTFSstatic.zip",
           "http://googlehsrdocs.hamilton.ca/"
         ]
       },
@@ -17,7 +18,8 @@
         "attribution_text": "Contains public sector Data made available under the City of Hamilton's Open Data Licence"
       },
       "tags": {
-        "gtfs_data_exchange": "hamilton-street-railway"
+        "gtfs_data_exchange": "hamilton-street-railway",
+        "unstable_url": "true"
       },
       "operators": [
         {

--- a/feeds/hamilton.ca.dmfr.json
+++ b/feeds/hamilton.ca.dmfr.json
@@ -5,7 +5,7 @@
       "id": "f-dpxj-hamiltonstreetrailway",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.hamilton.ca/GTFS-Static/Summer2024_GTFSstatic.zip",
+        "static_current": "https://opendata.hamilton.ca/GTFS-Static/2025Winter_GTFSStatic.zip",
         "static_historic": [
           "http://googlehsrdocs.hamilton.ca/"
         ]


### PR DESCRIPTION
Since the city of Hamilton updates its feed 4 times a year, I left the old URL as is.