### PR TITLE
Add PL Silesian buses (Transport GZM)

### DIFF
--- a/feeds/transportgzm.pl.dmfr.json
+++ b/feeds/transportgzm.pl.dmfr.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
+  "feeds": [
+    {
+      "id": "f-transport~gzm~pl",
+      "name": "ZTM Transport GZM",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://github.com/TransportGZM-GTFS-mirror/TransportGZM-GTFS-mirror/releases/latest/download/TransportGZM-GTFS.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "url": "https://spdx.org/licenses/CC-BY-4.0.html"
+      }
+    },
+    {
+      "id": "f-transport~gzm~pl~rt",
+      "name": "ZTM Transport GZM GTFS-RT",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://gtfsrt.transportgzm.pl:5443/gtfsrt/gzm/vehiclePositions",
+        "realtime_trip_updates": "https://gtfsrt.transportgzm.pl:5443/gtfsrt/gzm/tripUpdates"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "url": "https://spdx.org/licenses/CC-BY-4.0.html"
+      }
+    }
+  ],
+  "operators": [
+    {
+      "onestop_id": "o-transport~gzm~pl",
+      "name": "ZTM Transport GZM",
+      "short_name": "TransportGZM",
+      "website": "https://transportgzm.pl/",
+      "associated_feeds": [
+        {
+          "feed_onestop_id": "f-transport~gzm~pl"
+        },
+        {
+          "feed_onestop_id": "f-transport~gzm~pl~tf"
+        }
+      ]
+    }
+  ],
+  "license_spdx_identifier": "CDLA-Permissive-1.0"
+}

--- a/feeds/transportgzm.pl.dmfr.json
+++ b/feeds/transportgzm.pl.dmfr.json
@@ -6,7 +6,7 @@
       "name": "ZTM Transport GZM",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://github.com/TransportGZM-GTFS-mirror/TransportGZM-GTFS-mirror/releases/latest/download/TransportGZM-GTFS.zip"
+        "static_current": "https://github.com/TransportGZM-GTFS-mirror/TransportGZM-GTFS-extended-ver/releases/latest/download/TransportGZM-GTFS.zip"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",

--- a/feeds/transportgzm.pl.dmfr.json
+++ b/feeds/transportgzm.pl.dmfr.json
@@ -11,6 +11,9 @@
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "url": "https://spdx.org/licenses/CC-BY-4.0.html"
+      },
+      "tags": {
+        "notes": "This feed has an unstable URL that changes on a daily basis. GitHub Actions at https://github.com/TransportGZM-GTFS-mirror/TransportGZM-GTFS-extended-ver fetches the latest zip from https://otwartedane.metropoliagzm.pl/dataset/rozklady-jazdy-i-lokalizacja-przystankow-gtfs-wersja-rozszerzona"
       }
     },
     {


### PR DESCRIPTION
Hello! 👋

`ZTM TransportGZM` is a public transport organization based in the Silesian Voivodeship, Poland. They manage buses, trams, trolleybuses and bikes. 
ZTM is the organization that governs it, "[TransportGZM](https://transportgzm.pl)" is a brand under which they run busses/trams/trolleybuses, and brand "[TransportGZM MetroRower](https://metrorower.transportgzm.pl/)" is for bikes. That's the reason I picked `o-transport~gzm~pl` and `f-transport~gzm~pl`/`o-transport~gzm~pl~tf`

This PR adds ZTM TransportGZM GTFS and GTFS-RT.
- The GTFS-RT has a static URL. Licensed under CC-BY-4.0
- The GTFS doesn't have a static URL. I [created an issue here](https://github.com/transitland/transitland-atlas/issues/1369) but got no response, so I just went with creating a mirror for their data. Data is licensed under CC-BY-4.0

If something is missing or please let me know :) 




