### PR TITLE
Prince George's County

### DIFF
--- a/feeds/trilliumtransit.com.dmfr.json
+++ b/feeds/trilliumtransit.com.dmfr.json
@@ -4277,16 +4277,11 @@
       "id": "f-dqc-thebusofprincegeorgescounty",
       "spec": "gtfs",
       "urls": {
-        "static_historic": [
-          "https://data.trilliumtransit.com/gtfs/princegeorgescounty-md-us/princegeorgescounty-md-us.zip"
-        ]
+        "static_current": "https://data.trilliumtransit.com/gtfs/princegeorgescounty-md-us/princegeorgescounty-md-us.zip"
       },
       "license": {
         "use_without_attribution": "yes",
         "create_derived_product": "yes"
-      },
-      "tags": {
-        "status": "outdated"
       },
       "operators": [
         {
@@ -4296,15 +4291,12 @@
           "website": "https://www.princegeorgescountymd.gov/1120/Countys-TheBus",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "2166"
-            },
-            {
               "feed_onestop_id": "f-dqc-thebusofprincegeorgescounty~rt"
             }
           ],
           "tags": {
             "twitter_general": "PGCountyDPWT",
-            "us_ntd_id": "30035",
+            "us_ntd_id": "30085",
             "wikidata_id": "Q7711628"
           }
         }


### PR DESCRIPTION
had been previously deprecated by Trillium staff, but is now maintained again