### PR TITLE
Add batch of feed updates from Trillium

### DIFF
--- a/feeds/datatools-nysdot.dmfr.json
+++ b/feeds/datatools-nysdot.dmfr.json
@@ -779,7 +779,17 @@
         "create_derived_product": "yes",
         "commercial_use_allowed": "yes",
         "share_alike_optional": "yes"
-      }
+      },
+      "operators": [
+        {
+          "onestop_id": "o-dr75f-middletownareatransit",
+          "name": "Middletown Area Transit",
+          "website": "https://www.ridetransitorange.com/middletown",
+          "tags": {
+            "us_ntd_id": "20216"
+          }
+        }
+      ]
     },
     {
       "id": "f-monroe~bus~lines~kiryas~joel~ny",

--- a/feeds/datatools-nysdot.dmfr.json
+++ b/feeds/datatools-nysdot.dmfr.json
@@ -594,7 +594,10 @@
       "id": "f-hudson~rail~link",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://s3.amazonaws.com/datatools-511ny/public/Hudson_Rail_Link.zip"
+        "static_current": "https://s3.amazonaws.com/datatools-511ny/public/Hudson_Rail_Link.zip",
+        "static_historic": [
+          "https://data.trilliumtransit.com/gtfs/mnrraillink-ny-us/mnrraillink-ny-us.zip"
+        ]
       },
       "license": {
         "url": "https://data.ny.gov/download/77gx-ii52/application/pdf",
@@ -804,20 +807,6 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://s3.amazonaws.com/datatools-511ny/public/Newburgh_Beacon_Shuttle.zip"
-      },
-      "license": {
-        "url": "https://data.ny.gov/download/77gx-ii52/application/pdf",
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "commercial_use_allowed": "yes",
-        "share_alike_optional": "yes"
-      }
-    },
-    {
-      "id": "f-newburgh~bus",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://oc-otp-gtfs.s3.amazonaws.com/newburgh.zip"
       },
       "license": {
         "url": "https://data.ny.gov/download/77gx-ii52/application/pdf",

--- a/feeds/gtfs.calitp.org.dmfr.json
+++ b/feeds/gtfs.calitp.org.dmfr.json
@@ -180,13 +180,6 @@
       }
     },
     {
-      "id": "f-move~stanislaus~vetsvan~flex",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gtfs.calitp.org/production/MOVEStanislausVetsvanFlex.zip"
-      }
-    },
-    {
       "id": "f-placer~county~dial~a~ride~flex",
       "spec": "gtfs",
       "urls": {
@@ -224,20 +217,6 @@
       }
     },
     {
-      "id": "f-san~joaquin~rtd~dial~a~rideand~van~go~flex",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gtfs.calitp.org/production/SanJoaquinRTDDialARideandVanGoFlex.zip"
-      }
-    },
-    {
-      "id": "f-stan~rta~modesto~newman~oakdale~pattersomand~riverbank~flex",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gtfs.calitp.org/production/StanRTAModestoNewmanOakdalePattersomandRiverbankFlex.zip"
-      }
-    },
-    {
       "id": "f-taft~ca~us",
       "spec": "gtfs",
       "urls": {
@@ -265,13 +244,6 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://gtfs.calitp.org/production/ThousandOaksDialARideParatransitandConnectFlex.zip"
-      }
-    },
-    {
-      "id": "f-tracy~tracer~plusand~paratransit~flex",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gtfs.calitp.org/production/TracyTRACERPlusandParatransitFlex.zip"
       }
     },
     {

--- a/feeds/nationalrtap.org.dmfr.json
+++ b/feeds/nationalrtap.org.dmfr.json
@@ -643,23 +643,6 @@
       ]
     },
     {
-      "id": "f-rioc~nyc",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "http://rapid.nationalrtap.org/GTFSFileManagement/UserUploadFiles/7707/gtfs.zip"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-rioc~nyc",
-          "name": "Roosevelt Island Operating Corporation Tramway",
-          "short_name": "RIOC Tramway",
-          "tags": {
-            "wikidata_id": "Q641980"
-          }
-        }
-      ]
-    },
-    {
       "id": "f-rock~hill~sc~us",
       "spec": "gtfs",
       "urls": {

--- a/feeds/oregon-gtfs.com.dmfr.json
+++ b/feeds/oregon-gtfs.com.dmfr.json
@@ -1492,45 +1492,6 @@
       ]
     },
     {
-      "id": "f-wahkiakumferry~or~us",
-      "spec": "gtfs",
-      "urls": {
-        "static_historic": [
-          "https://oregon-gtfs.trilliumtransit.com/gtfs_data/wahkiakumferry-or-us/wahkiakumferry-or-us.zip"
-        ]
-      },
-      "license": {
-        "url": "https://oregon-gtfs.trilliumtransit.com",
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes"
-      },
-      "tags": {
-        "status": "archived"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-c20q82-wahkiakumferry",
-          "name": "Wahkiakum Ferry",
-          "website": "https://www.co.wahkiakum.wa.us/252/Ferry",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1732"
-            }
-          ],
-          "tags": {
-            "wikidata_id": "Q7959804"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f-wahkiakumferry~wa~us",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/wahkiakumferry-wa-us/wahkiakumferry-wa-us.zip"
-      }
-    },
-    {
       "id": "f-wheatlandferry~or~us",
       "spec": "gtfs",
       "urls": {

--- a/feeds/ridetransfort.com.dmfr.json
+++ b/feeds/ridetransfort.com.dmfr.json
@@ -20,6 +20,11 @@
           "onestop_id": "o-9xj-transfortcityoffortcollins",
           "name": "Transfort",
           "website": "https://ridetransfort.com/",
+          "associated_feeds": [
+            {
+              "feed_onestop_id": "f-transfort~co~us~flex"
+            }
+          ],
           "tags": {
             "twitter_general": "RideTransfort",
             "us_ntd_id": "80011",

--- a/feeds/s3.amazonaws.com.dmfr.json
+++ b/feeds/s3.amazonaws.com.dmfr.json
@@ -12,34 +12,6 @@
       }
     },
     {
-      "id": "f-dr7-nywaterway",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://s3.amazonaws.com/data.bytemark.co/nywaterway/nywaterway.zip"
-      },
-      "tags": {
-        "gtfs_data_exchange": "ny-waterway"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dr7-nywaterway",
-          "name": "NY Waterway",
-          "website": "http://www.nywaterway.com",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "NYW",
-              "feed_onestop_id": "f-dr7-nywaterway"
-            }
-          ],
-          "tags": {
-            "twitter_general": "ridetheferry",
-            "us_ntd_id": "20190",
-            "wikidata_id": "Q6956135"
-          }
-        }
-      ]
-    },
-    {
       "id": "f-gary~public~transportation~in~us",
       "spec": "gtfs",
       "urls": {

--- a/feeds/transitland.github.com.dmfr.json
+++ b/feeds/transitland.github.com.dmfr.json
@@ -232,33 +232,6 @@
       ]
     },
     {
-      "id": "f-piercecountyferries~wa~us",
-      "spec": "gtfs",
-      "urls": {
-        "static_historic": [
-          "https://github.com/transitland/gtfs-archives-not-hosted-elsewhere/raw/master/piercecountyferries-wa-us.zip"
-        ]
-      },
-      "license": {
-        "url": "https://github.com/transitland/gtfs-archives-not-hosted-elsewhere/blob/master/interline-gtfs-license.md"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-c22u3-piercecountyferries",
-          "name": "Pierce County Ferries",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1777"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "00028",
-            "wikidata_id": "Q7606736"
-          }
-        }
-      ]
-    },
-    {
       "id": "f-saginaw~stars",
       "spec": "gtfs",
       "urls": {

--- a/feeds/trilliumtransit.com.dmfr.json
+++ b/feeds/trilliumtransit.com.dmfr.json
@@ -4392,12 +4392,6 @@
           "onestop_id": "o-dr7-nywaterway",
           "name": "NY Waterway",
           "website": "http://www.nywaterway.com",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "NYW",
-              "feed_onestop_id": "f-dr7-nywaterway"
-            }
-          ],
           "tags": {
             "twitter_general": "ridetheferry",
             "us_ntd_id": "20190",

--- a/feeds/trilliumtransit.com.dmfr.json
+++ b/feeds/trilliumtransit.com.dmfr.json
@@ -6367,13 +6367,16 @@
           "https://oc-otp-gtfs.s3.amazonaws.com/newburgh.zip"
         ]
       },
-      "license": {
-        "url": "https://data.ny.gov/download/77gx-ii52/application/pdf",
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "commercial_use_allowed": "yes",
-        "share_alike_optional": "yes"
-      }
+      "operators": [
+        {
+          "onestop_id": "o-newburgh~transit",
+          "name": "Newburgh Area Transit",
+          "website": "https://www.ridetransitorange.com/middletown",
+          "tags": {
+            "us_ntd_id": "20216"
+          }
+        }
+      ]
     },
     {
       "id": "f-nisqually~wa~us",

--- a/feeds/trilliumtransit.com.dmfr.json
+++ b/feeds/trilliumtransit.com.dmfr.json
@@ -7258,11 +7258,24 @@
       }
     },
     {
-      "id": "f-wahkiakumferry~wa~us",
+      "id": "f-wahkiakumferry~or~us",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/wahkiakumferry-wa-us/wahkiakumferry-wa-us.zip"
-      }
+        "static_current": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/wahkiakumferry-wa-us/wahkiakumferry-wa-us.zip",
+        "static_historic": [
+          "https://oregon-gtfs.trilliumtransit.com/gtfs_data/wahkiakumferry-or-us/wahkiakumferry-or-us.zip"
+        ]
+      },
+      "operators": [
+        {
+          "onestop_id": "o-c20q82-wahkiakumferry",
+          "name": "Wahkiakum Ferry",
+          "website": "https://www.co.wahkiakum.wa.us/252/Ferry",
+          "tags": {
+            "wikidata_id": "Q7959804"
+          }
+        }
+      ]
     },
     {
       "id": "f-wausau~wi~us",

--- a/feeds/trilliumtransit.com.dmfr.json
+++ b/feeds/trilliumtransit.com.dmfr.json
@@ -4376,6 +4376,37 @@
       ]
     },
     {
+      "id": "f-dr7-nywaterway",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/nywaterway-nj-us/nywaterway-nj-us.zip",
+        "static_historic": [
+          "https://s3.amazonaws.com/data.bytemark.co/nywaterway/nywaterway.zip"
+        ]
+      },
+      "tags": {
+        "gtfs_data_exchange": "ny-waterway"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-dr7-nywaterway",
+          "name": "NY Waterway",
+          "website": "http://www.nywaterway.com",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "NYW",
+              "feed_onestop_id": "f-dr7-nywaterway"
+            }
+          ],
+          "tags": {
+            "twitter_general": "ridetheferry",
+            "us_ntd_id": "20190",
+            "wikidata_id": "Q6956135"
+          }
+        }
+      ]
+    },
+    {
       "id": "f-dr7f-greaterbridgeporttransit",
       "spec": "gtfs",
       "urls": {
@@ -6152,6 +6183,13 @@
       ]
     },
     {
+      "id": "f-miamigardens~fl~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/miamigardens-fl-us/miamigardens-fl-us.zip"
+      }
+    },
+    {
       "id": "f-moccasinexpress~wa~us",
       "spec": "gtfs",
       "urls": {
@@ -6232,6 +6270,20 @@
       ]
     },
     {
+      "id": "f-mountainexpress~co~us~flex",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/mountainexpress-co-us/mountainexpress-co-us--flex-v2.zip"
+      }
+    },
+    {
+      "id": "f-mountainfamilycenter~co~us~flex",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/mountainfamilycenter-co-us/mountainfamilycenter-co-us--flex-v2.zip"
+      }
+    },
+    {
       "id": "f-mountainvillage~co~us",
       "spec": "gtfs",
       "urls": {
@@ -6261,6 +6313,16 @@
           }
         }
       ]
+    },
+    {
+      "id": "f-move~stanislaus~vetsvan~flex",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/movestanislaus-ca-us/movestanislaus-ca-us--flex-v2.zip",
+        "static_historic": [
+          "https://gtfs.calitp.org/production/MOVEStanislausVetsvanFlex.zip"
+        ]
+      }
     },
     {
       "id": "f-muckleshoot~wa~us",
@@ -6297,6 +6359,30 @@
       ]
     },
     {
+      "id": "f-newburgh~bus",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/newburgh-ny-us/newburgh-ny-us.zip",
+        "static_historic": [
+          "https://oc-otp-gtfs.s3.amazonaws.com/newburgh.zip"
+        ]
+      },
+      "license": {
+        "url": "https://data.ny.gov/download/77gx-ii52/application/pdf",
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes",
+        "commercial_use_allowed": "yes",
+        "share_alike_optional": "yes"
+      }
+    },
+    {
+      "id": "f-nisqually~wa~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/nisqually-wa-us/nisqually-wa-us.zip"
+      }
+    },
+    {
       "id": "f-nlte~nv~us",
       "spec": "gtfs",
       "urls": {
@@ -6304,10 +6390,38 @@
       }
     },
     {
+      "id": "f-nsn~nz",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/nsn-nz/nsn-nz.zip"
+      }
+    },
+    {
+      "id": "f-ocpt~nc~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/ocpt-nc-us/ocpt-nc-us.zip"
+      }
+    },
+    {
+      "id": "f-omnibus~co~us~flex",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/omnibus-co-us/omnibus-co-us--flex-v2.zip"
+      }
+    },
+    {
       "id": "f-pahtopublicpassage~wa~us",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://data.trilliumtransit.com/gtfs/pahtopublicpassage-wa-us/pahtopublicpassage-wa-us.zip"
+      }
+    },
+    {
+      "id": "f-paratransitservices~wa~us~flex",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/paratransitservices-wa-us/paratransitservices-wa-us--flex-v2.zip"
       }
     },
     {
@@ -6338,6 +6452,31 @@
               "gtfs_agency_id": "1789"
             }
           ]
+        }
+      ]
+    },
+    {
+      "id": "f-piercecountyferries~wa~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/piercecountyferries-wa-us/piercecountyferries-wa-us.zip",
+        "static_historic": [
+          "https://github.com/transitland/gtfs-archives-not-hosted-elsewhere/raw/master/piercecountyferries-wa-us.zip"
+        ]
+      },
+      "operators": [
+        {
+          "onestop_id": "o-c22u3-piercecountyferries",
+          "name": "Pierce County Ferries",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1777"
+            }
+          ],
+          "tags": {
+            "us_ntd_id": "00028",
+            "wikidata_id": "Q7606736"
+          }
         }
       ]
     },
@@ -6402,6 +6541,20 @@
       ]
     },
     {
+      "id": "f-prowerscounty~co~us~flex",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/prowerscounty-co-us/prowerscounty-co-us--flex-v2.zip"
+      }
+    },
+    {
+      "id": "f-psesd~wa~us~flex",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/psesd-wa-us/psesd-wa-us--flex-v2.zip"
+      }
+    },
+    {
       "id": "f-pueblo~co~us",
       "spec": "gtfs",
       "urls": {
@@ -6464,6 +6617,33 @@
       "urls": {
         "static_current": "https://data.trilliumtransit.com/gtfs/rainbowrider-mn-us/rainbowrider-mn-us.zip"
       }
+    },
+    {
+      "id": "f-rccoa~co~us~flex",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/rccoa-co-us/rccoa-co-us--flex-v2.zip"
+      }
+    },
+    {
+      "id": "f-rioc~nyc",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/rooseveltisland-ny-us/rooseveltisland-ny-us.zip",
+        "static_historic": [
+          "http://rapid.nationalrtap.org/GTFSFileManagement/UserUploadFiles/7707/gtfs.zip"
+        ]
+      },
+      "operators": [
+        {
+          "onestop_id": "o-rioc~nyc",
+          "name": "Roosevelt Island Operating Corporation Tramway",
+          "short_name": "RIOC Tramway",
+          "tags": {
+            "wikidata_id": "Q641980"
+          }
+        }
+      ]
     },
     {
       "id": "f-rivervalley~ct~us",
@@ -6564,6 +6744,30 @@
       ]
     },
     {
+      "id": "f-san~joaquin~rtd~dial~a~rideand~van~go~flex",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/sanjoaquin-ca-us/sanjoaquin-ca-us--flex-v2.zip",
+        "static_historic": [
+          "https://gtfs.calitp.org/production/SanJoaquinRTDDialARideandVanGoFlex.zip"
+        ]
+      }
+    },
+    {
+      "id": "f-scania~se",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/scania-se/scania-se.zip"
+      }
+    },
+    {
+      "id": "f-sccog~co~us~flex",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/sccog-co-us/sccog-co-us--flex-v2.zip"
+      }
+    },
+    {
       "id": "f-sheridan~wy~us",
       "spec": "gtfs",
       "urls": {
@@ -6591,6 +6795,13 @@
           ]
         }
       ]
+    },
+    {
+      "id": "f-silverkey~co~us~flex",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/silverkey-co-us/silverkey-co-us--flex-v2.zip"
+      }
     },
     {
       "id": "f-smart~mn~us",
@@ -6637,10 +6848,48 @@
       }
     },
     {
+      "id": "f-soundgenerations~wa~us~flex",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/soundgenerations-wa-us/soundgenerations-wa-us-hyde--flex-v2.zip"
+      }
+    },
+    {
+      "id": "f-southwestrides~co~us~flex",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/southwestrides-co-us/southwestrides-co-us--flex-v2.zip"
+      }
+    },
+    {
       "id": "f-specialmobilityservices~wa~us",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://data.trilliumtransit.com/gtfs/specialmobilityservices-wa-us/specialmobilityservices-wa-us.zip"
+      }
+    },
+    {
+      "id": "f-squaxinisland~wa~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/squaxinisland-wa-us/squaxinisland-wa-us.zip"
+      }
+    },
+    {
+      "id": "f-srda~co~us~flex",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/srda-co-us/srda-co-us--flex-v2.zip"
+      }
+    },
+    {
+      "id": "f-stan~rta~modesto~newman~oakdale~pattersomand~riverbank~flex",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/stanrta-ca-us/stanrta-ca-us--flex-v2.zip",
+        "static_historic": [
+          "https://gtfs.calitp.org/production/StanRTAModestoNewmanOakdalePattersomandRiverbankFlex.zip"
+        ]
       }
     },
     {
@@ -6788,6 +7037,30 @@
       ]
     },
     {
+      "id": "f-tracy~tracer~plusand~paratransit~flex",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/tracy-ca-us/tracy-ca-us--flex-v2.zip",
+        "static_historic": [
+          "https://gtfs.calitp.org/production/TracyTRACERPlusandParatransitFlex.zip"
+        ]
+      }
+    },
+    {
+      "id": "f-transfort~co~us~flex",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/transfort-co-us/transfort-co-us--flex-v2.zip"
+      }
+    },
+    {
+      "id": "f-trc~nz",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/trc-nz/trc-nz.zip"
+      }
+    },
+    {
       "id": "f-tricap~mn~us",
       "spec": "gtfs",
       "urls": {
@@ -6890,10 +7163,24 @@
       ]
     },
     {
+      "id": "f-uaacog~co~us~flex",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/uaacog-co-us/uaacog-co-us--flex-v2.zip"
+      }
+    },
+    {
       "id": "f-unitedcap~mn~us",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://data.trilliumtransit.com/gtfs/unitedcap-mn-us/unitedcap-mn-us.zip"
+      }
+    },
+    {
+      "id": "f-vailskishuttles~co~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/vailskishuttles-co-us/vailskishuttles-co-us.zip"
       }
     },
     {
@@ -6968,6 +7255,13 @@
       },
       "license": {
         "url": "https://virginia-gtfs.com/"
+      }
+    },
+    {
+      "id": "f-wahkiakumferry~wa~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.trilliumtransit.com/gtfs/wahkiakumferry-wa-us/wahkiakumferry-wa-us.zip"
       }
     },
     {

--- a/feeds/tularecog.org.dmfr.json
+++ b/feeds/tularecog.org.dmfr.json
@@ -8,7 +8,10 @@
       ],
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://tularecog.org/tcag/data-gis-modeling/gtfs-data/tulare-county-regional-transit-agency-tcrta-gtfs/"
+        "static_current": "https://data.trilliumtransit.com/gtfs/tcrta-ca-us/tcrta-ca-us.zip",
+        "static_historic": [
+          "https://tularecog.org/tcag/data-gis-modeling/gtfs-data/tulare-county-regional-transit-agency-tcrta-gtfs/"
+        ]
       },
       "operators": [
         {


### PR DESCRIPTION
Add:
- f-miamigardens\~fl\~us
- f-mountainexpress\~co\~us\~flex
- f-mountainfamilycenter\~co\~us\~flex
- f-nisqually\~wa\~us
- f-nsn\~nz
- f-ocpt\~nc\~us
- f-omnibus\~co\~us\~flex
- f-paratransitservices\~wa\~us\~flex
- f-prowerscounty\~co\~us\~flex
- f-psesd\~wa\~us\~flex
- f-rccoa\~co\~us\~flex
- f-scania\~se
- f-sccog\~co\~us\~flex
- f-silverkey\~co\~us\~flex
- f-soundgenerations\~wa\~us\~flex
- f-southwestrides\~co\~us\~flex
- f-squaxinisland\~wa\~us
- f-srda\~co\~us\~flex
- f-transfort\~co\~us\~flex
- f-trc\~nz
- f-uaacog\~co\~us\~flex
- f-vailskishuttles\~co\~us
- f-wahkiakumferry\~wa\~us*

*An archived feed for whkiakuferry\~or\~us exists in atlas, but given this is WA and not OR, even though likely the same service in practice, I created a new entry.

Update URL:
- f-newburgh\~bus
- f-move\~stanislaus\~vetsvan\~flex
- f-san\~joaquin\~rtd\~dial\~a\~rideand\~van\~go\~flex
- f-stan\~rta\~modesto\~newman\~oakdale\~pattersomand\~riverbank\~flex
- f-tracy\~tracer\~plusand\~paratransit\~flex
- f-rioc\~nyc
- f-dr7-nywaterway
- f-piercecountyferries\~wa\~us
- f-tulare\~county\~regional\~transit\~agency
