### PR TITLE
Charm City Circulator - Baltimore, MD

### DIFF
--- a/feeds/baltimorecity.gov.dmfr.json
+++ b/feeds/baltimorecity.gov.dmfr.json
@@ -5,8 +5,9 @@
       "id": "f-dqcx8-charmcitycirculator",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://transportation.baltimorecity.gov/gtfsfile",
+        "static_current": "https://transportation.baltimorecity.gov/files/cccgtfs824zip",
         "static_historic": [
+          "https://transportation.baltimorecity.gov/gtfsfile",
           "https://github.com/mobilityequity/maryland-local-gtfs/raw/master/CCC_GTFS.zip"
         ]
       },


### PR DESCRIPTION
The current Charm City Circulator (Baltimore, MD) [feed](https://www.transit.land/operators/o-dqcx8-charmcitycirculator#routes) only has 4 routes - it is missing [the new Cherry Route](https://baltimorebeat.com/charm-city-circulator-adds-cherry-hill-route-connecting-the-neighborhood-to-downtown/).

I found a feed on Baltimore City's DOT's website with this [new route here](https://transportation.baltimorecity.gov/charm-city-circulator/developer-resources). I have updated `static_current` to point to this new download URL, and added the previously used URL to `static_historic`. I don't see any other relevant changes in the feed, either

For reference: old feed's `routes.txt` on the left, new feed's `routes.txt` on the right
<img width="1368" alt="image" src="https://github.com/user-attachments/assets/0bff14b0-867b-494b-8b5a-1e35e373f505" />
