### PR TITLE
Water Ave Shuttle shut down in 2019

### DIFF
--- a/feeds/oregon-gtfs.com.dmfr.json
+++ b/feeds/oregon-gtfs.com.dmfr.json
@@ -1054,26 +1054,6 @@
       ]
     },
     {
-      "id": "f-c20fb-ceic~or~us",
-      "spec": "gtfs",
-      "urls": {
-        "static_historic": [
-          "https://oregon-gtfs.trilliumtransit.com/gtfs_data/ceic-or-us/ceic-or-us.zip"
-        ]
-      },
-      "license": {
-        "url": "https://oregon-gtfs.trilliumtransit.com",
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-c20fb-wateravenueshuttle",
-          "name": "Water Avenue Shuttle"
-        }
-      ]
-    },
-    {
       "id": "f-c21-hoodriver~or~us",
       "spec": "gtfs",
       "urls": {


### PR DESCRIPTION
https://www.portlandmercury.com/news/2019/12/17/27661589/central-eastsides-shuttle-has-shut-down