### PR TITLE
Create jizdnirady.pmdp.cz.dmfr.json

### DIFF
--- a/feeds/jizdnirady.pmdp.cz.dmfr.json
+++ b/feeds/jizdnirady.pmdp.cz.dmfr.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.1.json",
+  "feeds": [
+    {
+      "id": "f-plzen",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://jizdnirady.pmdp.cz/jr/gtfs"
+      }
+    }
+  ],
+  "operators": [
+    {
+      "onestop_id": "o-pmdp",
+      "name": "Plzeňské městské dopravní podniky, a.s.",
+      "short_name": "PMDP",
+      "website": "https://www.pmdp.cz",
+      "associated_feeds": [
+        {
+          "feed_onestop_id": "f-plzen"
+        }
+      ],
+      "tags": {
+        "wikidata_id": "Q2099900"
+      }
+    }
+  ],
+  "license_spdx_identifier": "CDLA-Permissive-1.0"
+}


### PR DESCRIPTION
Adding Pilsen's local transport feed from [their opendata listing](https://data.gov.cz/dataset?iri=https%3A%2F%2Fdata.gov.cz%2Fzdroj%2Fdatov%C3%A9-sady%2F00075370%2Fa4d3e3f723eb8f364703e3de464f59c8).

Unfortunately unable to add geohash as the useful site for calculating it doesn't load it's map tiles. :/