### PR TITLE
Create mts.pt.dmfr.json

### DIFF
--- a/feeds/mts.pt.dmfr.json
+++ b/feeds/mts.pt.dmfr.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.1.json",
+  "feeds": [
+    {
+      "id": "f-eyc-mts",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://mts.pt/imt/MTS-20240129.zip",
+        "static_historic": [
+        ]
+      },
+      "license": {
+        "url": "https://nap-portugal.imt-ip.pt/nap/multimodalsupplydetail/200"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-eyc-mts",
+          "name": "Metro Transportes do Sul",
+          "short_name": "MTS",
+          "website": "https://www.mts.pt/",
+          "tags": {
+            "wikidata_id": "Q24663"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Extending Portugal GTFS database with Metro Transportes do Sul, which was recently made available at the official NAP (National Transport Information Access Point): https://nap-portugal.imt-ip.pt/nap/multimodalsupplydetail/200