### PR TITLE
Re-add Greenlink GTFS-RT feeds

### DIFF
--- a/feeds/cadavl.com.dmfr.json
+++ b/feeds/cadavl.com.dmfr.json
@@ -43,12 +43,26 @@
           "onestop_id": "o-dnjq-greenlink",
           "name": "Greenlink",
           "website": "http://www.ridegreenlink.com/",
+          "associated_feeds": [
+            {
+              "feed_onestop_id": "f-dnjq-greenlink~rt"
+            }
+          ],
           "tags": {
             "twitter_general": "ridegreenlink",
             "us_ntd_id": "40053"
           }
         }
       ]
+    },
+    {
+      "id": "f-dnjq-greenlink~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://gtfsrt.greenlink.cadavl.com/ProfilGtfsRt2_0RSProducer-GTA/VehiclePosition.pb",
+        "realtime_trip_updates": "https://gtfsrt.greenlink.cadavl.com/ProfilGtfsRt2_0RSProducer-GTA/TripUpdate.pb",
+        "realtime_alerts": "https://gtfsrt.greenlink.cadavl.com/ProfilGtfsRt2_0RSProducer-GTA/Alert.pb"
+      }
     },
     {
       "id": "f-green~bay~wi~us",


### PR DESCRIPTION
Greenlink GTFS-RT feeds were removed when updating the outdated static feeds. The new URLs are updated and current.