### PR TITLE
Update gtfs.ovapi.nl.dmfr.json

### DIFF
--- a/feeds/gtfs.ovapi.nl.dmfr.json
+++ b/feeds/gtfs.ovapi.nl.dmfr.json
@@ -6,6 +6,23 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "http://gtfs.ovapi.nl/gtfs-nl.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "url": "http://gtfs.ovapi.nl/README"
+      }
+    },
+    {
+      "id": "f-u-nl~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "http://gtfs.ovapi.nl/nl/vehiclePositions.pb",
+        "realtime_trip_updates": "http://gtfs.ovapi.nl/nl/trainUpdates.pb",
+        "realtime_alerts": "http://gtfs.ovapi.nl/nl/alerts.pb"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "url": "http://gtfs.ovapi.nl/README"
       }
     }
   ],


### PR DESCRIPTION
Added license and real time info to ovapi.nl

License also show on this page: https://openov.nl/

![afbeelding](https://github.com/user-attachments/assets/090b1a12-57e3-4c67-b665-2e5d89b1f895)


Small issue is that there exists both a tripUpdates.pb and a trainUpdates.pb file for this feed. Picked the trainUpdates for now. See http://gtfs.ovapi.nl/nl/