### PR TITLE
Update license in data.pid.cz.dmfr.json

### DIFF
--- a/feeds/data.pid.cz.dmfr.json
+++ b/feeds/data.pid.cz.dmfr.json
@@ -8,9 +8,8 @@
         "static_current": "http://data.pid.cz/PID_GTFS.zip"
       },
       "license": {
-        "url": "https://pid.cz/o-systemu/opendata",
-        "use_without_attribution": "no",
-        "create_derived_product": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "url": "https://pid.cz/o-systemu/opendata"
       },
       "operators": [
         {
@@ -27,5 +26,5 @@
       ]
     }
   ],
-  "license_spdx_identifier": "CDLA-Permissive-1.0"
+  "license_spdx_identifier": "CC-BY-4.0"
 }


### PR DESCRIPTION
Noticed that the license is wrong for this datasource as it should be "CC-BY-4.0" listed in "Licence" section of [PID's Opendata page](https://pid.cz/o-systemu/opendata/).