### PR TITLE
Update Nashua Transit System GTFS-static URL 

### DIFF
--- a/feeds/nationalrtap.org.dmfr.json
+++ b/feeds/nationalrtap.org.dmfr.json
@@ -689,7 +689,10 @@
       "id": "f-nashua~transit~system",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://rapid.nationalrtap.org/GTFSFileManagement/UserUploadFiles/0/Nashua_Transit_System_GTFS.zip"
+        "static_current": "https://swiftly-shared-gtfs-feeds.s3.us-west-2.amazonaws.com/nashua-transit-system/gtfs.zip", 
+        "static_historic": [
+          "https://rapid.nationalrtap.org/GTFSFileManagement/UserUploadFiles/0/Nashua_Transit_System_GTFS.zip"
+        ]
       },
       "operators": [
         {

--- a/feeds/nationalrtap.org.dmfr.json
+++ b/feeds/nationalrtap.org.dmfr.json
@@ -689,7 +689,7 @@
       "id": "f-nashua~transit~system",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://swiftly-shared-gtfs-feeds.s3.us-west-2.amazonaws.com/nashua-transit-system/gtfs.zip", 
+        "static_current": "https://swiftly-shared-gtfs-feeds.s3.us-west-2.amazonaws.com/nashua-transit-system/gtfs.zip",
         "static_historic": [
           "https://rapid.nationalrtap.org/GTFSFileManagement/UserUploadFiles/0/Nashua_Transit_System_GTFS.zip"
         ]


### PR DESCRIPTION
I am updating Nashua Transit System's GTFS static URL as Swiftly (my org) is now managing their GTFS static and will be supplying their GTFS-RT data soon. I have updated the nationalrtap.org file as that is where the NTS info lived previously, but lmk if I should create a new separate feed for NTS.