### PR TITLE
Add license in jizdnirady.pmdp.cz.dmfr.json 

### DIFF
--- a/feeds/jizdnirady.pmdp.cz.dmfr.json
+++ b/feeds/jizdnirady.pmdp.cz.dmfr.json
@@ -6,6 +6,9 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://jizdnirady.pmdp.cz/jr/gtfs"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0"
       }
     }
   ],

--- a/feeds/jizdnirady.pmdp.cz.dmfr.json
+++ b/feeds/jizdnirady.pmdp.cz.dmfr.json
@@ -8,7 +8,8 @@
         "static_current": "https://jizdnirady.pmdp.cz/jr/gtfs"
       },
       "license": {
-        "spdx_identifier": "CC-BY-4.0"
+        "spdx_identifier": "CC-BY-4.0",
+        "url": "https://opendata.plzen.eu/public/opendata/detail/187"
       }
     }
   ],


### PR DESCRIPTION
Today, after contacting the administrators, an informational text was added to the open data of Pilsen's website regarding the license on GTFS data. Such should now be reflected in the DMFR file.