### PR TITLE
Tulare

### DIFF
--- a/feeds/tularecog.org.dmfr.json
+++ b/feeds/tularecog.org.dmfr.json
@@ -4,6 +4,7 @@
     {
       "id": "f-tulare~county~regional~transit~agency",
       "supersedes_ids": [
+        "f-tulare~time",
         "f-tulare~tcat"
       ],
       "spec": "gtfs",
@@ -23,23 +24,6 @@
           "short_name": "TCRTA",
           "tags": {
             "wikidata_id": "Q110722692"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f-tulare~time",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://tularetransit.com/gtfs"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9q7j-time",
-          "name": "Tulare InterModal Express ",
-          "short_name": "TIME",
-          "tags": {
-            "us_ntd_id": "90244"
           }
         }
       ]


### PR DESCRIPTION
As July 1, 2021, the Tulare InterModal Express became part of the Tulare County Regional Transit Agency (“TCRTA")