### PR TITLE
License change for ZDiTM Szczecin (Poland)

### DIFF
--- a/feeds/zditm.szczecin.pl.dmfr.json
+++ b/feeds/zditm.szczecin.pl.dmfr.json
@@ -12,7 +12,7 @@
         ]
       },
       "license": {
-        "url": "https://www.zditm.szczecin.pl/pl/zditm/dla-programistow/gtfs"
+        "spdx_identifier": "CC0-1.0"
       }
     },
     {
@@ -25,7 +25,7 @@
         "realtime_alerts": "https://www.zditm.szczecin.pl/storage/gtfs/gtfs-rt-alerts.pb"
       },
       "license": {
-        "url": "https://www.zditm.szczecin.pl/pl/zditm/dla-programistow/gtfs"
+        "spdx_identifier": "CC0-1.0"
       }
     }
   ],


### PR DESCRIPTION
GTFS data for ZDiTM Szczecin (Poland) are now [published under the CC0 license](https://www.zditm.szczecin.pl/en/zditm/for-developers/gtfs):

> The data are provided free of charge under the [CC0 1.0 licence](https://creativecommons.org/publicdomain/zero/1.0/), for use in any context, with no prior notification required.