### PR TITLE
Update Hamilton Street Railway GTFS current link

### DIFF
--- a/feeds/hamilton.ca.dmfr.json
+++ b/feeds/hamilton.ca.dmfr.json
@@ -5,9 +5,10 @@
       "id": "f-dpxj-hamiltonstreetrailway",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://opendata.hamilton.ca/GTFS-Static/2025Winter_GTFSStatic.zip",
+        "static_current": "https://opendata.hamilton.ca/GTFS-Static/google_transit.zip",
         "static_historic": [
-          "https://opendata.hamilton.ca/GTFS-Static/Summer2024_GTFSstatic.zip",
+          "https://opendata.hamilton.ca/GTFS-Static/Archive/2025Winter_GTFSStatic.zip",
+          "https://opendata.hamilton.ca/GTFS-Static/Archive/2024Summer_GTFSstatic.zip",
           "http://googlehsrdocs.hamilton.ca/"
         ]
       },


### PR DESCRIPTION
The link marked as current on the feed's page is dead: https://www.transit.land/feeds/f-dpxj-hamiltonstreetrailway
![image](https://github.com/user-attachments/assets/d3003897-37f2-4780-8043-3a372f4d7e29)


This replaces and updates it.