### PR TITLE
Add Concord Coach Lines

### DIFF
--- a/feeds/github.com.dmfr.json
+++ b/feeds/github.com.dmfr.json
@@ -277,7 +277,27 @@
           ]
         }
       ]
+    },
+    {
+      "id": "f-concord~coach~lines",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://github.com/maxtkc/concord-coach-gtfs/raw/refs/heads/main/concord_coach_gtfs.zip"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-concord~coach~lines",
+          "name": "Concord Coach Lines",
+          "website": "https://concordcoachlines.com/",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "CC"
+            }
+          ]
+        }
+      ]
     }
   ],
   "license_spdx_identifier": "CDLA-Permissive-1.0"
 }
+


### PR DESCRIPTION
I generated a feed for Concord Coach Lines. This is an unofficial feed, but I haven't seen an official one from them yet. It is currently hosted on GitHub. [This is the repo](https://github.com/maxtkc/concord-coach-gtfs) where the feed is generated.