### PR TITLE
Rodoviária do Oeste (Portugal)

### DIFF
--- a/feeds/rodoviariadooeste.pt.dmfr.json
+++ b/feeds/rodoviariadooeste.pt.dmfr.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.1.json",
+  "feeds": [
+    {
+      "id": "f-e-rdoeste",
+      "name": "Rodoviária do Oeste",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://drive.google.com/uc?export=download&id=1uzZ2gGJelxkKpb5PQIDSrG5rLdmYYgkn"
+      },
+      "license": {
+        "spdx_identifier": "CC0-1.0",
+        "url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes",
+        "redistribution_allowed": "yes",
+        "commercial_use_allowed": "yes"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-e-rdoeste",
+          "name": "Rodiviária do Oeste",
+          "short_name": "RDO",
+          "website": "https://rodoviariadooeste.pt/",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "RDO"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "license_spdx_identifier": "CC0-1.0"
+}


### PR DESCRIPTION
This is the official feed for the Rodoviária do Oeste service.

We don't have a better (non-Google Drive) URL at hand. This is the very same URL that sources Google Maps.

I do have the authorization to publish it under this license.

Cheers,
Cláudio
