### PR TITLE
Update suffolkva.us.dmfr.json

### DIFF
--- a/feeds/suffolkva.us.dmfr.json
+++ b/feeds/suffolkva.us.dmfr.json
@@ -6,9 +6,9 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://www.suffolkva.us/DocumentCenter/View/5568/Suffolk-Transit-GTFS?bidId=",
-         "static_historic": [
-           "https://www.c3VmZm9sa3ZhLnVz/DocumentCenter/View/5568/Suffolk-Transit-GTFS"
-         ]
+        "static_historic": [
+          "https://www.c3VmZm9sa3ZhLnVz/DocumentCenter/View/5568/Suffolk-Transit-GTFS"
+        ]
       },
       "operators": [
         {


### PR DESCRIPTION
Suffolk Transit - url taken from: https://www.suffolkva.us/Search?searchPhrase=gtfs&pageNumber=1&perPage=10&departmentId=-1