### PR TITLE
Updated Roseville Transit, California, USA

### DIFF
--- a/feeds/sacrt.com.dmfr.json
+++ b/feeds/sacrt.com.dmfr.json
@@ -53,45 +53,6 @@
       }
     },
     {
-      "id": "f-9qcs-rosevilletransit",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://iportal.sacrt.com/gtfs/Roseville/google_transit.zip"
-      },
-      "license": {
-        "url": "http://www.sacrt.com/gtfs.stm",
-        "use_without_attribution": "unknown",
-        "create_derived_product": "yes"
-      },
-      "tags": {
-        "gtfs_data_exchange": "roseville-transit"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9qcs-rosevilletransit",
-          "name": "Roseville Transit",
-          "associated_feeds": [
-            {
-              "feed_onestop_id": "f-rosevilletransit~rt"
-            }
-          ],
-          "tags": {
-            "twitter_general": "RSVL_Transit",
-            "us_ntd_id": "90168",
-            "wikidata_id": "Q7368740"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f-rosevilletransit~rt",
-      "spec": "gtfs-rt",
-      "urls": {
-        "realtime_vehicle_positions": "https://rosevillebustracker.com/gtfs-rt/vehiclepositions",
-        "realtime_alerts": "https://rosevillebustracker.com/gtfs-rt/alerts"
-      }
-    },
-    {
       "id": "f-southcountytransitlink~ca~us",
       "spec": "gtfs",
       "urls": {

--- a/feeds/tripshot.com.dmfr.json
+++ b/feeds/tripshot.com.dmfr.json
@@ -83,6 +83,42 @@
       }
     },
     {
+      "id": "f-9qcs-rosevilletransit",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://cityofroseville.tripshot.com/v1/gtfs.zip?regionId=CA558DDC-D7F2-4B48-9CAC-DEEA1134F820"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-9qcs-rosevilletransit",
+          "name": "Roseville Transit",
+          "website": "https://www.roseville.ca.us/residents/roseville_transit",
+          "associated_feeds": [
+            {
+              "feed_onestop_id": "f-9qcs-rosevilletransit~rt"
+            }
+          ],
+          "tags": {
+            "twitter_general": "RSVL_Transit",
+            "us_ntd_id": "90168",
+            "wikidata_id": "Q7368740"
+          }
+        }
+      ]
+    },
+    {
+      "id": "f-9qcs-rosevilletransit~rt",
+      "supersedes_ids": [
+        "f-rosevilletransit~rt"
+      ],
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://cityofroseville.tripshot.com/v1/gtfs/realtime/vehiclePosition/CA558DDC-D7F2-4B48-9CAC-DEEA1134F820",
+        "realtime_trip_updates": "https://cityofroseville.tripshot.com/v1/gtfs/realtime/tripUpdate/CA558DDC-D7F2-4B48-9CAC-DEEA1134F820",
+        "realtime_alerts": "https://cityofroseville.tripshot.com/v1/gtfs/realtime/serviceAlert/CA558DDC-D7F2-4B48-9CAC-DEEA1134F820"
+      }
+    },
+    {
       "id": "f-9qh0-anaheim~ca~us",
       "spec": "gtfs",
       "urls": {


### PR DESCRIPTION
Background: Prior to August 2025, Roseville Transit partnered with Sacramento Regional Transit (SacRT) to host a static GTFS feed, and with GMV for a GTFS-RT feed. As of October 2025, Roseville Transit changed data providers to Tripshot, which now hosts the replacement static and real-time feeds. The GMV feed is no longer operational, and the SacRT static feed is seemingly out-of-date.

Changes:
 - f-9qcs-rosevilletransit moved from sacrt.com.dmfs.json to tripshot.com.dmfr.json, with new feed URL and additional operator data
 - `f-rosevilletransit~rt` deprecated, and replaced with `f-9qcs-rosevilletransit~rt`, to match the static GTFS feed's Onestop ID, and using the new real-time feed URLs

References:
https://reports.dds.dot.ca.gov/gtfs_schedule/2025/09/271/index.html
https://cityofroseville.tripshot.com/
https://www.roseville.ca.us/news/what_s_happening_in_roseville/plan_track_ride_with_roseville_transits_new_app