### PR TITLE
Update GRT (Region of Waterloo) feeds and remove deprecated

### DIFF
--- a/feeds/regionofwaterloo.ca.dmfr.json
+++ b/feeds/regionofwaterloo.ca.dmfr.json
@@ -5,7 +5,10 @@
       "id": "f-dpwz-grandrivertransit",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://webapps.regionofwaterloo.ca/api/grt-routes/api/staticfeeds/0"
+        "static_current": "https://webapps.regionofwaterloo.ca/api/grt-routes/api/staticfeeds/0",
+        "static_historic": [
+          "https://www.regionofwaterloo.ca/opendatadownloads/GRT_GTFS.zip"
+        ]
       },
       "license": {
         "url": "http://www.regionofwaterloo.ca/en/regionalGovernment/OpenDataLicence.asp",


### PR DESCRIPTION
As per https://www.grt.ca/en/about-grt/open-data.aspx, GRT will be discontinuing their merged feeds (which Transitland currently uses) after December 31st, this updates the DMFR as such.