### PR TITLE
Update Cecil Transit GTFS URL

### DIFF
--- a/feeds/passio3.com.dmfr.json
+++ b/feeds/passio3.com.dmfr.json
@@ -1193,7 +1193,7 @@
       "id": "f-dr41-ceciltransit",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://passio3.com/cecil/passioTransit/gtfs/google_transit.zip",
+        "static_current": "https://www.cecilcountymd.gov/DocumentCenter/View/5246/Cecil-County-MD---GTFS",
         "static_historic": [
           "https://www.ccgov.org/home/showpublisheddocument/51736/638418521708670000",
           "https://www.ccgov.org/home/showpublisheddocument/50900/638330494895530000",


### PR DESCRIPTION
It seems like they are re-introduced GTFS data on the county's website. In addition, they still use passioGO for GTFS-RT but the GTFS data on passioGO is out of date according to calendar.txt