### PR TITLE
Updated OC, MD GTFS for 2026 Season

### DIFF
--- a/feeds/oceancitymd.gov.dmfr.json
+++ b/feeds/oceancitymd.gov.dmfr.json
@@ -5,8 +5,9 @@
       "id": "f-dqfd7-oceancitytransporation",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://oceancitymd.gov/oc/wp-content/uploads/gtfs.zip",
+        "static_current": "https://oceancitymd.gov/oc/wp-content/uploads/2026-04-08-Ocean-City-MD-Transit-static-GTFS.zip",
         "static_historic": [
+          "https://oceancitymd.gov/oc/wp-content/uploads/gtfs.zip",
           "https://api.tost.app/v1/gtfs/download?agencyId=83f7d05c-6ba1-495a-9add-194833634688",
           "https://github.com/mobilityequity/maryland-local-gtfs/raw/master/OC_GTFS.zip"
         ]


### PR DESCRIPTION
Updated for the 2026 Beach Bus Season

_Side Note:
Really wish that their tracking solution provided GTFS-RT since the buses will frequently back up during the summer months._