### PR TITLE
Annotate Spanish NAP feeds as scraper-handled

### DIFF
--- a/external-data-for-reference/spain/collect-nap-gtfs.py
+++ b/external-data-for-reference/spain/collect-nap-gtfs.py
@@ -212,7 +212,8 @@ def create_dmfr_feed(feed_data: Dict) -> Dict:
     }
 
     dmfr_feed["tags"] = {
-        "es_nap_fichero_id": str(fichero_id)
+        "es_nap_fichero_id": str(fichero_id),
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
     }
 
     # Add license

--- a/feeds/nap.transportes.gob.es.dmfr.json
+++ b/feeds/nap.transportes.gob.es.dmfr.json
@@ -22,7 +22,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1362"
+        "es_nap_fichero_id": "1362",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       }
     },
     {
@@ -46,7 +47,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1133"
+        "es_nap_fichero_id": "1133",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -77,7 +79,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2071"
+        "es_nap_fichero_id": "2071",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -108,7 +111,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2151"
+        "es_nap_fichero_id": "2151",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -139,7 +143,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2116"
+        "es_nap_fichero_id": "2116",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -170,7 +175,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1914"
+        "es_nap_fichero_id": "1914",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -201,7 +207,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1913"
+        "es_nap_fichero_id": "1913",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -232,7 +239,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1578"
+        "es_nap_fichero_id": "1578",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -263,7 +271,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1361"
+        "es_nap_fichero_id": "1361",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -294,7 +303,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1769"
+        "es_nap_fichero_id": "1769",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       }
     },
     {
@@ -318,7 +328,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1266"
+        "es_nap_fichero_id": "1266",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -349,7 +360,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1165"
+        "es_nap_fichero_id": "1165",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       }
     },
     {
@@ -373,7 +385,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1581"
+        "es_nap_fichero_id": "1581",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -404,7 +417,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1580"
+        "es_nap_fichero_id": "1580",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -435,7 +449,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1607"
+        "es_nap_fichero_id": "1607",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -466,7 +481,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1599"
+        "es_nap_fichero_id": "1599",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       }
     },
     {
@@ -490,7 +506,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1566"
+        "es_nap_fichero_id": "1566",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -521,7 +538,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1582"
+        "es_nap_fichero_id": "1582",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -552,7 +570,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2153"
+        "es_nap_fichero_id": "2153",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -583,7 +602,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1584"
+        "es_nap_fichero_id": "1584",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -614,7 +634,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2060"
+        "es_nap_fichero_id": "2060",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       }
     },
     {
@@ -638,7 +659,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2059"
+        "es_nap_fichero_id": "2059",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -669,7 +691,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1579"
+        "es_nap_fichero_id": "1579",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -700,7 +723,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1561"
+        "es_nap_fichero_id": "1561",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -734,7 +758,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1177"
+        "es_nap_fichero_id": "1177",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -765,7 +790,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1273"
+        "es_nap_fichero_id": "1273",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       }
     },
     {
@@ -789,7 +815,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1363"
+        "es_nap_fichero_id": "1363",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       }
     },
     {
@@ -813,7 +840,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1560"
+        "es_nap_fichero_id": "1560",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       }
     },
     {
@@ -837,7 +865,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1526"
+        "es_nap_fichero_id": "1526",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       }
     },
     {
@@ -864,7 +893,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1364"
+        "es_nap_fichero_id": "1364",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       }
     },
     {
@@ -892,7 +922,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1164"
+        "es_nap_fichero_id": "1164",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       }
     },
     {
@@ -916,7 +947,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1331"
+        "es_nap_fichero_id": "1331",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -947,7 +979,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1496"
+        "es_nap_fichero_id": "1496",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       }
     },
     {
@@ -971,7 +1004,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1178"
+        "es_nap_fichero_id": "1178",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       }
     },
     {
@@ -995,7 +1029,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2083"
+        "es_nap_fichero_id": "2083",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1026,7 +1061,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2150"
+        "es_nap_fichero_id": "2150",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1057,7 +1093,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1572"
+        "es_nap_fichero_id": "1572",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1088,7 +1125,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1493"
+        "es_nap_fichero_id": "1493",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1119,7 +1157,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1573"
+        "es_nap_fichero_id": "1573",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1150,7 +1189,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1710"
+        "es_nap_fichero_id": "1710",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1181,7 +1221,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1570"
+        "es_nap_fichero_id": "1570",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1212,7 +1253,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1564"
+        "es_nap_fichero_id": "1564",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1243,7 +1285,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1172"
+        "es_nap_fichero_id": "1172",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1274,7 +1317,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1295"
+        "es_nap_fichero_id": "1295",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1305,7 +1349,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1097"
+        "es_nap_fichero_id": "1097",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1336,7 +1381,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1173"
+        "es_nap_fichero_id": "1173",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1367,7 +1413,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1586"
+        "es_nap_fichero_id": "1586",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1398,7 +1445,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1495"
+        "es_nap_fichero_id": "1495",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1429,7 +1477,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1844"
+        "es_nap_fichero_id": "1844",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1460,7 +1509,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1174"
+        "es_nap_fichero_id": "1174",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1497,7 +1547,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1175"
+        "es_nap_fichero_id": "1175",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1529,7 +1580,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1563"
+        "es_nap_fichero_id": "1563",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1560,7 +1612,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1170"
+        "es_nap_fichero_id": "1170",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1594,7 +1647,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1567"
+        "es_nap_fichero_id": "1567",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1625,7 +1679,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1169"
+        "es_nap_fichero_id": "1169",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1656,7 +1711,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2069"
+        "es_nap_fichero_id": "2069",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1687,7 +1743,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2081"
+        "es_nap_fichero_id": "2081",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1718,7 +1775,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2082"
+        "es_nap_fichero_id": "2082",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1749,7 +1807,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2072"
+        "es_nap_fichero_id": "2072",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1780,7 +1839,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2076"
+        "es_nap_fichero_id": "2076",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1811,7 +1871,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2050"
+        "es_nap_fichero_id": "2050",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1843,7 +1904,7 @@
       },
       "tags": {
         "es_nap_fichero_id": "1843",
-        "notes": "Operators: Autocares Rias Baixas S. L., TREN TURÍSTICO"
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1874,7 +1935,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2070"
+        "es_nap_fichero_id": "2070",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1905,7 +1967,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1574"
+        "es_nap_fichero_id": "1574",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1936,7 +1999,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2063"
+        "es_nap_fichero_id": "2063",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1967,7 +2031,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1460"
+        "es_nap_fichero_id": "1460",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -1998,7 +2063,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1559"
+        "es_nap_fichero_id": "1559",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2029,7 +2095,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1163"
+        "es_nap_fichero_id": "1163",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2063,7 +2130,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1130"
+        "es_nap_fichero_id": "1130",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2118,7 +2186,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2009"
+        "es_nap_fichero_id": "2009",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2149,7 +2218,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1983"
+        "es_nap_fichero_id": "1983",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2181,7 +2251,7 @@
       },
       "tags": {
         "es_nap_fichero_id": "1984",
-        "notes": "Operators: AMB, Transports Generals d'Olesa"
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2212,7 +2282,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1969"
+        "es_nap_fichero_id": "1969",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2243,7 +2314,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2152"
+        "es_nap_fichero_id": "2152",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2274,7 +2346,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1694"
+        "es_nap_fichero_id": "1694",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2305,7 +2378,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2066"
+        "es_nap_fichero_id": "2066",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2336,7 +2410,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2065"
+        "es_nap_fichero_id": "2065",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2367,7 +2442,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1494"
+        "es_nap_fichero_id": "1494",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2402,7 +2478,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1135"
+        "es_nap_fichero_id": "1135",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2436,7 +2513,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1427"
+        "es_nap_fichero_id": "1427",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2470,7 +2548,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1134"
+        "es_nap_fichero_id": "1134",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2504,7 +2583,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1166"
+        "es_nap_fichero_id": "1166",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2540,7 +2620,8 @@
       },
       "tags": {
         "es_nap_fichero_id": "1262",
-        "gtfs_data_exchange": "bizkaibus"
+        "gtfs_data_exchange": "bizkaibus",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2578,7 +2659,8 @@
       },
       "tags": {
         "es_nap_fichero_id": "1229",
-        "gtfs_data_exchange": "lurraldebus_goierrialdea"
+        "gtfs_data_exchange": "lurraldebus_goierrialdea",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2618,7 +2700,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1235"
+        "es_nap_fichero_id": "1235",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2655,7 +2738,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1267"
+        "es_nap_fichero_id": "1267",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2689,7 +2773,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1264"
+        "es_nap_fichero_id": "1264",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2723,7 +2808,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1263"
+        "es_nap_fichero_id": "1263",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       }
     },
     {
@@ -2747,7 +2833,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1271"
+        "es_nap_fichero_id": "1271",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2781,7 +2868,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1196"
+        "es_nap_fichero_id": "1196",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2812,7 +2900,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1571"
+        "es_nap_fichero_id": "1571",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2843,7 +2932,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2068"
+        "es_nap_fichero_id": "2068",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2874,7 +2964,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2117"
+        "es_nap_fichero_id": "2117",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2905,7 +2996,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2061"
+        "es_nap_fichero_id": "2061",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2936,7 +3028,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1198"
+        "es_nap_fichero_id": "1198",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2967,7 +3060,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1199"
+        "es_nap_fichero_id": "1199",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -2998,7 +3092,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1200"
+        "es_nap_fichero_id": "1200",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3029,7 +3124,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1201"
+        "es_nap_fichero_id": "1201",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3060,7 +3156,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1202"
+        "es_nap_fichero_id": "1202",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3091,7 +3188,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1204"
+        "es_nap_fichero_id": "1204",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3122,7 +3220,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1230"
+        "es_nap_fichero_id": "1230",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3153,7 +3252,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1231"
+        "es_nap_fichero_id": "1231",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3184,7 +3284,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1232"
+        "es_nap_fichero_id": "1232",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3215,7 +3316,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1233"
+        "es_nap_fichero_id": "1233",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3246,7 +3348,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1234"
+        "es_nap_fichero_id": "1234",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3277,7 +3380,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1608"
+        "es_nap_fichero_id": "1608",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3308,7 +3412,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1237"
+        "es_nap_fichero_id": "1237",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3339,7 +3444,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1690"
+        "es_nap_fichero_id": "1690",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3370,7 +3476,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1568"
+        "es_nap_fichero_id": "1568",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3401,7 +3508,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1583"
+        "es_nap_fichero_id": "1583",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3432,7 +3540,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1168"
+        "es_nap_fichero_id": "1168",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3467,7 +3576,8 @@
       },
       "tags": {
         "es_nap_fichero_id": "1497",
-        "mdb_source_id": "1017"
+        "mdb_source_id": "1017",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3501,7 +3611,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1766"
+        "es_nap_fichero_id": "1766",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3532,7 +3643,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1577"
+        "es_nap_fichero_id": "1577",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3563,7 +3675,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2079"
+        "es_nap_fichero_id": "2079",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3594,7 +3707,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1098"
+        "es_nap_fichero_id": "1098",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3625,7 +3739,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1788"
+        "es_nap_fichero_id": "1788",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3656,7 +3771,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2074"
+        "es_nap_fichero_id": "2074",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3686,7 +3802,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1598"
+        "es_nap_fichero_id": "1598",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3717,7 +3834,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1576"
+        "es_nap_fichero_id": "1576",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3748,7 +3866,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2064"
+        "es_nap_fichero_id": "2064",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3779,7 +3898,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2075"
+        "es_nap_fichero_id": "2075",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3810,7 +3930,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1270"
+        "es_nap_fichero_id": "1270",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3841,7 +3962,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1597"
+        "es_nap_fichero_id": "1597",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3872,7 +3994,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1602"
+        "es_nap_fichero_id": "1602",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3903,7 +4026,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2077"
+        "es_nap_fichero_id": "2077",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       }
     },
     {
@@ -3927,7 +4051,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1562"
+        "es_nap_fichero_id": "1562",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       }
     },
     {
@@ -3951,7 +4076,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2078"
+        "es_nap_fichero_id": "2078",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -3982,7 +4108,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1328"
+        "es_nap_fichero_id": "1328",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -4013,7 +4140,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1272"
+        "es_nap_fichero_id": "1272",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       }
     },
     {
@@ -4037,7 +4165,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2080"
+        "es_nap_fichero_id": "2080",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -4068,7 +4197,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1176"
+        "es_nap_fichero_id": "1176",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       }
     },
     {
@@ -4092,7 +4222,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1569"
+        "es_nap_fichero_id": "1569",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -4123,7 +4254,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1687"
+        "es_nap_fichero_id": "1687",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -4154,7 +4286,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1329"
+        "es_nap_fichero_id": "1329",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -4185,7 +4318,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1330"
+        "es_nap_fichero_id": "1330",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -4216,7 +4350,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1167"
+        "es_nap_fichero_id": "1167",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -4247,7 +4382,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1575"
+        "es_nap_fichero_id": "1575",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -4278,7 +4414,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2062"
+        "es_nap_fichero_id": "2062",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -4309,7 +4446,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2067"
+        "es_nap_fichero_id": "2067",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -4340,7 +4478,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1713"
+        "es_nap_fichero_id": "1713",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -4371,7 +4510,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1711"
+        "es_nap_fichero_id": "1711",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -4402,7 +4542,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1132"
+        "es_nap_fichero_id": "1132",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -4433,7 +4574,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "1712"
+        "es_nap_fichero_id": "1712",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {
@@ -4464,7 +4606,8 @@
         "info_url": "https://nap.transportes.gob.es/"
       },
       "tags": {
-        "es_nap_fichero_id": "2073"
+        "es_nap_fichero_id": "2073",
+        "notes": "Fetched by transitland-gtfs-scraper (NAP requires two-stage /api/Fichero/downloadLink flow)"
       },
       "operators": [
         {


### PR DESCRIPTION
Annotate generated Spanish NAP feed entries with a `tags.notes` explaining that fetches are handled out-of-band by a separate scraper