### PR TITLE
Update TMB static_current to new app_id

### DIFF
--- a/feeds/tmb.cat.dmfr.json
+++ b/feeds/tmb.cat.dmfr.json
@@ -5,7 +5,7 @@
       "id": "f-sp3e-tmb",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://api.tmb.cat/v1/static/datasets/gtfs.zip?app_key=8504ae3a636b155724a1c7e140ee039f&app_id=4c132798"
+        "static_current": "https://api.tmb.cat/v1/static/datasets/gtfs.zip?app_id=4687fa4e"
       },
       "license": {
         "url": "https://developer.tmb.cat/data/gtfs"


### PR DESCRIPTION
## Summary
Rotate TMB (Barcelona) to a freshly-registered developer app. Old credentials have been returning 401; replacement `app_id` goes in the URL and the new `app_key` is stored in the fetch-secrets mirror (unchanged auth shape — `query_param` on `app_key`).

## Test plan
- [x] Validated locally with new credentials: 117 routes, 3453 stops, 55924 trips, ~1.29M stop_times