### PR TITLE
Update stale feed URLs for Tulare and Oswego

### DIFF
--- a/feeds/datatools-nysdot.dmfr.json
+++ b/feeds/datatools-nysdot.dmfr.json
@@ -818,14 +818,10 @@
       "id": "f-oswego~county",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://s3.amazonaws.com/datatools-511ny/public/Oswego_County_Public_Transit.zip"
-      },
-      "license": {
-        "url": "https://data.ny.gov/download/77gx-ii52/application/pdf",
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes",
-        "commercial_use_allowed": "yes",
-        "share_alike_optional": "yes"
+        "static_current": "https://gtfs.remix.com/oswego_county_us.zip",
+        "static_historic": [
+          "https://s3.amazonaws.com/datatools-511ny/public/Oswego_County_Public_Transit.zip"
+        ]
       }
     },
     {

--- a/feeds/datatools-nysdot.dmfr.json
+++ b/feeds/datatools-nysdot.dmfr.json
@@ -815,16 +815,6 @@
       ]
     },
     {
-      "id": "f-oswego~county",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://gtfs.remix.com/oswego_county_us.zip",
-        "static_historic": [
-          "https://s3.amazonaws.com/datatools-511ny/public/Oswego_County_Public_Transit.zip"
-        ]
-      }
-    },
-    {
       "id": "f-otsego~express",
       "spec": "gtfs",
       "urls": {

--- a/feeds/gtfs.remix.com.dmfr.json
+++ b/feeds/gtfs.remix.com.dmfr.json
@@ -261,6 +261,16 @@
       ]
     },
     {
+      "id": "f-oswego~county",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://gtfs.remix.com/oswego_county_us.zip",
+        "static_historic": [
+          "https://s3.amazonaws.com/datatools-511ny/public/Oswego_County_Public_Transit.zip"
+        ]
+      }
+    },
+    {
       "id": "f-ud-elron",
       "supersedes_ids": [
         "f-ud-atkoliinidoü~aktsiaseltshansabussiliinid~kihnuveeteedas~väi",

--- a/feeds/gtfs.remix.com.dmfr.json
+++ b/feeds/gtfs.remix.com.dmfr.json
@@ -268,7 +268,17 @@
         "static_historic": [
           "https://s3.amazonaws.com/datatools-511ny/public/Oswego_County_Public_Transit.zip"
         ]
-      }
+      },
+      "operators": [
+        {
+          "onestop_id": "o-dr9z-oswegocountypublictransit",
+          "name": "Oswego County Public Transit",
+          "website": "https://www.oco.org/services/transportation/full-transportation-schedule/",
+          "tags": {
+            "us_ntd_id": "20942"
+          }
+        }
+      ]
     },
     {
       "id": "f-ud-elron",

--- a/feeds/tularecog.org.dmfr.json
+++ b/feeds/tularecog.org.dmfr.json
@@ -9,8 +9,9 @@
       ],
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/tcrta-ca-us/tcrta-ca-us.zip",
+        "static_current": "https://data.peaktransit.com/staticgtfs/120/gtfs.zip",
         "static_historic": [
+          "https://data.trilliumtransit.com/gtfs/tcrta-ca-us/tcrta-ca-us.zip",
           "https://tularecog.org/tcag/data-gis-modeling/gtfs-data/tulare-county-regional-transit-agency-tcrta-gtfs/"
         ]
       },
@@ -23,6 +24,7 @@
           "name": "Tulare County Regional Transit Agency",
           "short_name": "TCRTA",
           "tags": {
+            "us_ntd_id": "90310",
             "wikidata_id": "Q110722692"
           }
         }

--- a/feeds/tularecog.org.dmfr.json
+++ b/feeds/tularecog.org.dmfr.json
@@ -23,12 +23,25 @@
           ],
           "name": "Tulare County Regional Transit Agency",
           "short_name": "TCRTA",
+          "associated_feeds": [
+            {
+              "feed_onestop_id": "f-tulare~county~regional~transit~agency~rt"
+            }
+          ],
           "tags": {
             "us_ntd_id": "90310",
             "wikidata_id": "Q110722692"
           }
         }
       ]
+    },
+    {
+      "id": "f-tulare~county~regional~transit~agency~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "http://data.peaktransit.com/gtfsrt/120/VehiclePosition.pb",
+        "realtime_trip_updates": "http://data.peaktransit.com/gtfsrt/120/TripUpdate.pb"
+      }
     }
   ]
 }


### PR DESCRIPTION
Two feed source migrations surfaced by comparing FTA-listed URLs against Atlas-known URLs:

- **Tulare County RTA**: Trillium → Peak Transit. Atlas calendar window was ending 2026-10-01; new URL extends to 2026-12-31. Old URL moved to `static_historic`. Also backfills the `us_ntd_id: 90310` tag.
- **Oswego County**: NYSDOT datatools S3 archive → Remix direct. Atlas calendar window was ending 2025-12-31; new URL extends to 2026-12-31. Old URL moved to `static_historic`. NYSDOT `license` block removed since it was specific to the aggregator.

Third fta_newer candidate (Ozark Regional Transit) was reviewed but skipped: the FTA-listed URL is a Wix-hosted archive snapshot with a hashed filename, not a stable current-feed URL. Atlas's existing passio3.com URL is a bit behind but vendor-stable; leaving in place pending a better source.