### PR TITLE
Clear stale bot comments when issues are resolved

### DIFF
--- a/.github/workflows/check-feed-urls.yaml
+++ b/.github/workflows/check-feed-urls.yaml
@@ -78,20 +78,12 @@ jobs:
           path: reports/
 
       - name: Comment on PR
-        if: steps.changed.outputs.files != '' && steps.validate.outputs.summary != ''
         uses: actions/github-script@v8
         env:
           SUMMARY: ${{ steps.validate.outputs.summary }}
         with:
           script: |
-            const body =
-              `## Feed URL validation\n\n` +
-              `${process.env.SUMMARY}\n\n` +
-              `<sub>Pass criteria: static feed fetches, parses, and has ≥1 agency record; ` +
-              `RT feed returns a valid GTFS-RT message. Other counts shown for context only — ` +
-              `feed contributors often don't control source quality. ` +
-              `Auth-protected URLs are validated by tlv2 with private keys, not here. ` +
-              `Full reports attached as workflow artifacts.</sub>`;
+            const summary = (process.env.SUMMARY || '').trim();
 
             const existing = await github.paginate(github.rest.issues.listComments, {
               issue_number: context.issue.number,
@@ -100,6 +92,25 @@ jobs:
             const prior = existing.find(c =>
               c.user.type === 'Bot' && c.body.includes('Feed URL validation')
             );
+
+            let body;
+            if (summary) {
+              body =
+                `## Feed URL validation\n\n${summary}\n\n` +
+                `<sub>Pass criteria: static feed fetches, parses, and has ≥1 agency record; ` +
+                `RT feed returns a valid GTFS-RT message. Other counts shown for context only — ` +
+                `feed contributors often don't control source quality. ` +
+                `Auth-protected URLs are validated by tlv2 with private keys, not here. ` +
+                `Full reports attached as workflow artifacts.</sub>`;
+            } else if (prior) {
+              // No URL changes need validation in the latest push, but a prior
+              // bot comment exists — replace it with a resolved message.
+              body = `## Feed URL validation\n\n✅ No URL changes need validation in the latest push.`;
+            } else {
+              // Nothing to post and no prior comment to update.
+              return;
+            }
+
             if (prior) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner, repo: context.repo.repo,

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -63,56 +63,63 @@ jobs:
         fi
     
     - name: Comment on PR
-      if: ${{ steps.git-diff.outputs.git_diff != '' }}
       uses: actions/github-script@v7
       env:
         DIFF: ${{ steps.git-diff.outputs.git_diff }}
       with:
         script: |
-          const diff = process.env.DIFF;
-          
-          // Get existing bot comments to avoid duplicates
+          const diff = process.env.DIFF || '';
+
           const botComments = await github.paginate(github.rest.issues.listComments, {
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo
           });
-          
-          const botComment = botComments.find(comment => 
-            comment.user.type === 'Bot' && 
-            comment.body.includes('DMFR Format Check Results')
+          const prior = botComments.find(c =>
+            c.user.type === 'Bot' &&
+            c.body.includes('DMFR Format Check Results')
           );
-          
-          const commentBody = `## DMFR Format Check Results
-          
+
+          let body;
+          if (diff) {
+            body = `## DMFR Format Check Results
+
           This PR includes files that need formatting adjustments to follow the "opinionated" DMFR format.
-          
+
           ### Suggested Changes:
           \`\`\`diff
           ${diff}
           \`\`\`
-          
+
           You can apply these changes by:
           1. Using a code editor
           2. Running [transitland-lib](https://github.com/interline-io/transitland-lib/blob/main/dmfr-command.md) locally
           3. Waiting for a maintainer to help
-          
-          Thank you for contributing to Transitland Atlas! 🚀`;
 
-          if (botComment) {
-            // Update existing comment
+          Thank you for contributing to Transitland Atlas! 🚀`;
+          } else if (prior) {
+            // No formatting changes needed in the latest push, but a prior bot
+            // comment flagged issues — replace it with a resolved message.
+            body = `## DMFR Format Check Results
+
+          ✅ DMFR formatting is now correct.`;
+          } else {
+            // No diff and no prior comment — nothing to do.
+            return;
+          }
+
+          if (prior) {
             await github.rest.issues.updateComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              comment_id: botComment.id,
-              body: commentBody
+              comment_id: prior.id,
+              body
             });
           } else {
-            // Create new comment
             await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: commentBody
+              body
             });
           }


### PR DESCRIPTION
## Summary
- `format.yaml` and `check-feed-urls.yaml` both previously skipped the comment step when there was no current content to post — leaving prior "issue found" comments stale after a contributor pushed a fix.
- Now the comment step always runs. When there is no current content but a prior bot comment from the workflow exists, it is updated in place to a brief resolved message (`✅ DMFR formatting is now correct` / `✅ No URL changes need validation in the latest push`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)