### PR TITLE
Extract auto-PR step into scripts/auto-pr.sh

### DIFF
--- a/.github/workflows/update-es-nap.yaml
+++ b/.github/workflows/update-es-nap.yaml
@@ -33,45 +33,13 @@ jobs:
       run: uv run validate-feeds.py
       env:
         DMFR_SCHEMA_VERSION: v0.6.0
-    - name: Create or update branch, commit, and PR if changes exist
-      run: |
-        set -eu
-        git config user.name "Automated Bot"
-        git config user.email "info@interline.io"
-
-        if [ -z "$(git status --porcelain)" ]; then
-          echo "Working directory is clean."
-          exit 0
-        fi
-
-        echo "Working directory has uncommitted changes."
-        BRANCH_NAME="auto/spanish-nap"
-        PR_TITLE="Automatic update of Spanish NAP feeds"
-
-        # Check if a PR from this branch already exists
-        EXISTING_PR=$(gh pr list --head "${BRANCH_NAME}" --state open --json number --jq '.[0].number // empty')
-
-        if [ -n "${EXISTING_PR}" ]; then
-          echo "Found existing open PR #${EXISTING_PR} — updating branch."
-          git fetch origin "${BRANCH_NAME}"
-          git checkout -b "${BRANCH_NAME}" "origin/${BRANCH_NAME}" 2>/dev/null || git checkout -b "${BRANCH_NAME}"
-          git add -A
-          git commit -m "Updated Spanish NAP feeds from nap.transportes.gob.es at $(date -u)"
-          git push --force-with-lease origin "${BRANCH_NAME}"
-          gh workflow run validate.yaml --ref "${BRANCH_NAME}"
-        else
-          echo "No existing PR — creating new branch and PR."
-          git push origin --delete "${BRANCH_NAME}" 2>/dev/null || true
-          git checkout -b "${BRANCH_NAME}"
-          git add -A
-          git commit -m "Updated Spanish NAP feeds from nap.transportes.gob.es at $(date -u)"
-          git push --set-upstream origin "${BRANCH_NAME}"
-          gh pr create \
-            --title "${PR_TITLE}" \
-            --body "Automatically updated Spanish NAP feeds from nap.transportes.gob.es" \
-            --base main
-          gh workflow run validate.yaml --ref "${BRANCH_NAME}"
-        fi
+    - name: Open or update auto-PR if anything changed
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        scripts/auto-pr.sh \
+          --branch-name "auto/spanish-nap" \
+          --pr-title "Automatic update of Spanish NAP feeds" \
+          --pr-body "Automatically updated Spanish NAP feeds from nap.transportes.gob.es" \
+          --commit-message "Updated Spanish NAP feeds from nap.transportes.gob.es at $(date -u)"
 

--- a/.github/workflows/update-gbfs.yaml
+++ b/.github/workflows/update-gbfs.yaml
@@ -19,44 +19,12 @@ jobs:
     - name: Validate feeds
       working-directory: scripts
       run: uv run validate-feeds.py
-    - name: "If any changes: Create or update branch, commit, and PR"
-      run: |
-        set -eu
-        git config user.name "Automated Bot"
-        git config user.email "info@interline.io"
-
-        if [ -z "$(git status --porcelain)" ]; then
-          echo "Working directory is clean."
-          exit 0
-        fi
-
-        echo "Working directory has uncommitted changes."
-        BRANCH_NAME="auto/gbfs"
-        PR_TITLE="Automatic update of GBFS feeds"
-
-        # Check if a PR from this branch already exists
-        EXISTING_PR=$(gh pr list --head "${BRANCH_NAME}" --state open --json number --jq '.[0].number // empty')
-
-        if [ -n "${EXISTING_PR}" ]; then
-          echo "Found existing open PR #${EXISTING_PR} — updating branch."
-          git fetch origin "${BRANCH_NAME}"
-          git checkout -b "${BRANCH_NAME}" "origin/${BRANCH_NAME}" 2>/dev/null || git checkout -b "${BRANCH_NAME}"
-          git add -A
-          git commit -m "Updated GBFS feeds from https://github.com/NABSA/gbfs/blob/master/systems.csv at $(date -u)"
-          git push --force-with-lease origin "${BRANCH_NAME}"
-          gh workflow run validate.yaml --ref "${BRANCH_NAME}"
-        else
-          echo "No existing PR — creating new branch and PR."
-          git push origin --delete "${BRANCH_NAME}" 2>/dev/null || true
-          git checkout -b "${BRANCH_NAME}"
-          git add -A
-          git commit -m "Updated GBFS feeds from https://github.com/NABSA/gbfs/blob/master/systems.csv at $(date -u)"
-          git push --set-upstream origin "${BRANCH_NAME}"
-          gh pr create \
-            --title "${PR_TITLE}" \
-            --body "Automatically updated GBFS feeds from https://github.com/NABSA/gbfs/blob/master/systems.csv" \
-            --base main
-          gh workflow run validate.yaml --ref "${BRANCH_NAME}"
-        fi
+    - name: Open or update auto-PR if anything changed
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        scripts/auto-pr.sh \
+          --branch-name "auto/gbfs" \
+          --pr-title "Automatic update of GBFS feeds" \
+          --pr-body "Automatically updated GBFS feeds from https://github.com/NABSA/gbfs/blob/master/systems.csv" \
+          --commit-message "Updated GBFS feeds from https://github.com/NABSA/gbfs/blob/master/systems.csv at $(date -u)"

--- a/.github/workflows/update-jp.yaml
+++ b/.github/workflows/update-jp.yaml
@@ -35,48 +35,15 @@ jobs:
     - name: Validate feeds
       working-directory: scripts
       run: uv run validate-feeds.py
-    - name: Create or update branch, commit, and PR if changes exist
-      run: |
-        set -eu
-        git config user.name "Automated Bot"
-        git config user.email "info@interline.io"
-
-        if [ -z "$(git status --porcelain)" ]; then
-          echo "Working directory is clean."
-          exit 0
-        fi
-
-        echo "Working directory has uncommitted changes."
-        BRANCH_NAME="auto/japanese-feeds"
-        PR_TITLE="Automatic update of Japanese GTFS feeds"
-        PR_BODY="Automatically updated Japanese GTFS feeds from:
-          - gtfs-data.jp
-          - ODPT (Public Transportation Open Data Center)
-          - github.com/tshimada291/gtfs-jp-list-datecheck"
-
-        # Check if a PR from this branch already exists
-        EXISTING_PR=$(gh pr list --head "${BRANCH_NAME}" --state open --json number --jq '.[0].number // empty')
-
-        if [ -n "${EXISTING_PR}" ]; then
-          echo "Found existing open PR #${EXISTING_PR} — updating branch."
-          git fetch origin "${BRANCH_NAME}"
-          git checkout -b "${BRANCH_NAME}" "origin/${BRANCH_NAME}" 2>/dev/null || git checkout -b "${BRANCH_NAME}"
-          git add -A
-          git commit -m "Updated Japanese GTFS feeds from gtfs-data.jp, ODPT, and github.com/tshimada291/gtfs-jp-list-datecheck at $(date -u)"
-          git push --force-with-lease origin "${BRANCH_NAME}"
-          gh workflow run validate.yaml --ref "${BRANCH_NAME}"
-        else
-          echo "No existing PR — creating new branch and PR."
-          git push origin --delete "${BRANCH_NAME}" 2>/dev/null || true
-          git checkout -b "${BRANCH_NAME}"
-          git add -A
-          git commit -m "Updated Japanese GTFS feeds from gtfs-data.jp, ODPT, and github.com/tshimada291/gtfs-jp-list-datecheck at $(date -u)"
-          git push --set-upstream origin "${BRANCH_NAME}"
-          gh pr create \
-            --title "${PR_TITLE}" \
-            --body "${PR_BODY}" \
-            --base main
-          gh workflow run validate.yaml --ref "${BRANCH_NAME}"
-        fi
+    - name: Open or update auto-PR if anything changed
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        scripts/auto-pr.sh \
+          --branch-name "auto/japanese-feeds" \
+          --pr-title "Automatic update of Japanese GTFS feeds" \
+          --pr-body "Automatically updated Japanese GTFS feeds from:
+            - gtfs-data.jp
+            - ODPT (Public Transportation Open Data Center)
+            - github.com/tshimada291/gtfs-jp-list-datecheck" \
+          --commit-message "Updated Japanese GTFS feeds from gtfs-data.jp, ODPT, and github.com/tshimada291/gtfs-jp-list-datecheck at $(date -u)"

--- a/scripts/auto-pr.sh
+++ b/scripts/auto-pr.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Open or update an automated PR on the current repo.
+#
+# If the working tree has no changes, exits 0 silently.
+#
+# Otherwise:
+#   - If an open PR already exists with --branch-name as its head:
+#     fetches that branch, commits the working-tree changes on top,
+#     force-pushes (with lease).
+#   - Else: creates a fresh branch, commits the changes, pushes it,
+#     opens a new PR.
+#
+# Either way, optionally triggers a workflow on the new/updated branch
+# (default: validate.yaml; pass --trigger-workflow '' to skip).
+#
+# Requires: a checked-out git repo and `gh` authenticated with rights to
+# push to the repo and create/list PRs (GH_TOKEN in CI).
+#
+# Usage:
+#   scripts/auto-pr.sh \
+#     --branch-name auto/gbfs \
+#     --pr-title "Automatic update of GBFS feeds" \
+#     --pr-body "Automatically updated GBFS feeds from <url>" \
+#     --commit-message "Updated GBFS feeds at $(date -u)"
+
+set -euo pipefail
+
+BRANCH_NAME=""
+PR_TITLE=""
+PR_BODY=""
+COMMIT_MESSAGE=""
+BASE_BRANCH="main"
+GIT_USER_NAME="Automated Bot"
+GIT_USER_EMAIL="info@interline.io"
+TRIGGER_WORKFLOW="validate.yaml"
+
+usage() {
+  cat >&2 <<EOF
+Usage: $(basename "$0") --branch-name NAME --pr-title TITLE --pr-body BODY --commit-message MSG [options]
+
+Required:
+  --branch-name NAME       Branch to push (e.g. auto/gbfs)
+  --pr-title TITLE         PR title used when creating a new PR
+  --pr-body BODY           PR body used when creating a new PR
+  --commit-message MSG     Commit message
+
+Options:
+  --base-branch NAME       Base branch for new PRs (default: $BASE_BRANCH)
+  --git-user-name NAME     Git committer name (default: "$GIT_USER_NAME")
+  --git-user-email EMAIL   Git committer email (default: "$GIT_USER_EMAIL")
+  --trigger-workflow FILE  Workflow file to run on the pushed branch
+                           after commit (default: $TRIGGER_WORKFLOW;
+                           pass empty string to skip)
+EOF
+  exit 1
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --branch-name) BRANCH_NAME="$2"; shift 2;;
+    --pr-title) PR_TITLE="$2"; shift 2;;
+    --pr-body) PR_BODY="$2"; shift 2;;
+    --commit-message) COMMIT_MESSAGE="$2"; shift 2;;
+    --base-branch) BASE_BRANCH="$2"; shift 2;;
+    --git-user-name) GIT_USER_NAME="$2"; shift 2;;
+    --git-user-email) GIT_USER_EMAIL="$2"; shift 2;;
+    --trigger-workflow) TRIGGER_WORKFLOW="$2"; shift 2;;
+    -h|--help) usage;;
+    *) echo "Unknown argument: $1" >&2; usage;;
+  esac
+done
+
+if [ -z "$BRANCH_NAME" ];     then echo "Error: --branch-name is required"     >&2; usage; fi
+if [ -z "$PR_TITLE" ];        then echo "Error: --pr-title is required"        >&2; usage; fi
+if [ -z "$PR_BODY" ];         then echo "Error: --pr-body is required"         >&2; usage; fi
+if [ -z "$COMMIT_MESSAGE" ];  then echo "Error: --commit-message is required"  >&2; usage; fi
+
+git config user.name "$GIT_USER_NAME"
+git config user.email "$GIT_USER_EMAIL"
+
+if [ -z "$(git status --porcelain)" ]; then
+  echo "Working tree is clean — nothing to commit."
+  exit 0
+fi
+
+EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --state open --json number --jq '.[0].number // empty')
+
+if [ -n "$EXISTING_PR" ]; then
+  echo "Found existing open PR #$EXISTING_PR — updating branch $BRANCH_NAME"
+  git fetch origin "$BRANCH_NAME"
+  git checkout -b "$BRANCH_NAME" "origin/$BRANCH_NAME" 2>/dev/null || git checkout -b "$BRANCH_NAME"
+else
+  echo "No existing PR — creating new branch $BRANCH_NAME"
+  # Defensive: clear any stale remote branch with this name, in case a
+  # prior PR was closed without the branch being deleted.
+  git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
+  git checkout -b "$BRANCH_NAME"
+fi
+
+git add -A
+git commit -m "$COMMIT_MESSAGE"
+
+if [ -n "$EXISTING_PR" ]; then
+  git push --force-with-lease origin "$BRANCH_NAME"
+else
+  git push --set-upstream origin "$BRANCH_NAME"
+  gh pr create \
+    --title "$PR_TITLE" \
+    --body "$PR_BODY" \
+    --base "$BASE_BRANCH"
+fi
+
+if [ -n "$TRIGGER_WORKFLOW" ]; then
+  gh workflow run "$TRIGGER_WORKFLOW" --ref "$BRANCH_NAME"
+fi


### PR DESCRIPTION
## Summary
- The three `update-*.yaml` workflows (`update-gbfs`, `update-es-nap`, `update-jp`) each duplicated ~40 lines of near-identical bash for the "if anything changed, open or update an auto-PR" step.
- Moved the logic into `scripts/auto-pr.sh` with `--branch-name`, `--pr-title`, `--pr-body`, `--commit-message` (plus optional `--base-branch`, `--git-user-name`, `--git-user-email`, `--trigger-workflow`).
- Behavior preserved: same branch names, same commit messages, same `gh workflow run validate.yaml --ref <branch>` after push.

Each workflow's last step is now a ~6-line script invocation. Net change: -121 / +140 with the script's help text and error handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)