### PR TITLE
Fix feed URL validation: bump transitland-lib and surface real errors

### DIFF
--- a/scripts/install-transitland-lib.sh
+++ b/scripts/install-transitland-lib.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-wget https://github.com/interline-io/transitland-lib/releases/download/v1.2.14/transitland-linux -O transitland
+wget https://github.com/interline-io/transitland-lib/releases/download/v1.3.2/transitland-linux -O transitland
 chmod a+rx transitland
 sudo mv transitland /usr/local/bin

--- a/scripts/validate-changed-feed-urls.py
+++ b/scripts/validate-changed-feed-urls.py
@@ -49,7 +49,10 @@ def slugify(s: str) -> str:
 
 
 def trim(s: str, n: int = 300) -> str:
-    return " ".join(s.split())[-n:]
+    for line in s.splitlines():
+        if line.startswith("Error:"):
+            return " ".join(line.split())[:n]
+    return " ".join(s.split())[:n]
 
 
 def parse_dmfr_file(path: Path) -> Optional[dict]:


### PR DESCRIPTION
## Summary
- Bump `scripts/install-transitland-lib.sh` from v1.2.14 → v1.3.2 so `transitland validate --include-service-levels` is recognized
- Fix `trim()` in `scripts/validate-changed-feed-urls.py` to surface the real `Error:` line from stderr instead of the tail (which was hiding actual errors behind help-text fragments)

## Background
Every static check on #2021 reported errors that looked like "S-RT proto message in validation report --rt-json Include GTFS-RT proto messages as JSON in validation report ...". That wasn't a real error — it was the **tail** of `transitland validate --help`. The v1.2.14 binary doesn't support `--include-service-levels`, so it dumped its help text to stderr and exited 1. `trim()` then took the last 300 chars (chopping off the `Error: unknown flag: ...` line) and reported what remained. v1.3.2 adds the flag, and `trim()` now prefers the `Error:` line.

## Test plan
Verified locally with `transitland` v1.3.3-dev (same flag surface as v1.3.2):
- [x] Known-good static (TriMet GTFS): ✅ pass, agency/route/stop counts populate
- [x] Previously-"failing" nationalrtap URL: ✅ actually passes — proves PR #2021's failures were entirely the flag rejection, not the URLs
- [x] Genuine 404 static: `Error: could not open reader '...': response status code: 404`
- [x] DNS failure: `Error: ... dial tcp: lookup invalid.nope.example: no such host`
- [x] Non-zip URL: `Error: ... file does not exist or invalid data`
- [x] Bad RT URL: `Error: Get "...": dial tcp: lookup example.invalid: no such host`
- [ ] CI runs the workflow on this PR
- [ ] After merge, re-run the check on #2021 and confirm those static checks turn green

🤖 Generated with [Claude Code](https://claude.com/claude-code)