### PR TITLE
Advise on multi-feed zip layouts in feed URL validation

### DIFF
--- a/scripts/validate-changed-feed-urls.py
+++ b/scripts/validate-changed-feed-urls.py
@@ -27,12 +27,21 @@ Usage:
 
 import argparse
 import json
+import os
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
+import urllib.request
+import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
+
+# Cap on suggested fragments per advisory (Victoria AU's outer zip has 8+
+# nested feeds; pathological zips could have many more).
+PREFIX_SUGGESTION_LIMIT = 8
 
 # short-name -> DMFR url key
 RT_KINDS: dict[str, str] = {
@@ -53,6 +62,63 @@ def trim(s: str, n: int = 300) -> str:
         if line.startswith("Error:"):
             return " ".join(line.split())[:n]
     return " ".join(s.split())[:n]
+
+
+def discover_zip_prefixes(url: str, timeout: int = 120) -> tuple[list[str], list[str]]:
+    """Download the zip at url and enumerate candidate URL-fragment prefixes.
+
+    Mirrors transitland-lib's prefix rule (tlcsv/adapter.go:findInternalPrefix):
+    any directory containing stops.txt is a folder prefix. Additionally returns
+    nested .zip entries, which transitland-lib resolves when a fragment ends in
+    .zip (tlcsv/adapter.go Open():193) but does not auto-discover.
+
+    Returns (folder_prefixes, nested_zip_paths). Either may be empty. On any
+    download/parse failure, returns ([], []) so callers can fall back to the
+    validator's own error message.
+    """
+    folders: set[str] = set()
+    nested: list[str] = []
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "transitland-atlas-ci"})
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+            tmp_name = tmp.name
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp, open(tmp_name, "wb") as out:
+                shutil.copyfileobj(resp, out)
+            with zipfile.ZipFile(tmp_name) as zf:
+                for info in zf.infolist():
+                    name = info.filename
+                    if info.is_dir() or name.startswith("."):
+                        continue
+                    base = os.path.basename(name)
+                    if base == "stops.txt":
+                        d = os.path.dirname(name)
+                        # Path-style suggestions: "." → "./", "GTFS" → "GTFS/".
+                        # transitland-lib accepts both, but the slash makes
+                        # folder prefixes visually distinct from nested-zip
+                        # fragments (e.g. "#google_bus.zip").
+                        folders.add(f"{d}/" if d else "./")
+                    if name.lower().endswith(".zip"):
+                        nested.append(name)
+        finally:
+            try:
+                os.remove(tmp_name)
+            except OSError:
+                pass
+    except (OSError, zipfile.BadZipFile, ValueError):
+        return [], []
+    return sorted(folders), sorted(nested)
+
+
+def render_prefix_suggestions(url: str, prefixes: list[str]) -> str:
+    """Render up to PREFIX_SUGGESTION_LIMIT URL#fragment suggestions for a
+    multi-prefix zip. Caller is responsible for setting the lead-in bullet."""
+    shown = prefixes[:PREFIX_SUGGESTION_LIMIT]
+    extra = len(prefixes) - len(shown)
+    lines = [f"    - `{url}#{p}`" for p in shown]
+    if extra > 0:
+        lines.append(f"    - …and {extra} more")
+    return "\n".join(lines)
 
 
 def parse_dmfr_file(path: Path) -> Optional[dict]:
@@ -145,6 +211,21 @@ def run_validate_static(url: str, report_path: Path) -> Outcome:
         )
     if res.returncode != 0:
         err_path.write_text(res.stderr)
+        # transitland-lib refuses to pick a prefix when a zip contains >1 GTFS
+        # feed (tlcsv/adapter.go:findInternalPrefix). Probe the zip and suggest
+        # URL fragments so the contributor can disambiguate.
+        if "more than one valid prefix found" in res.stderr:
+            folders, nested = discover_zip_prefixes(url)
+            options = folders + nested
+            if options:
+                head = (
+                    f"- ❌ static — `{url}` — multiple GTFS feeds detected "
+                    f"inside this zip; pick one by appending a URL fragment:"
+                )
+                return Outcome(
+                    bullet=head + "\n" + render_prefix_suggestions(url, options),
+                    blocker=True,
+                )
         return Outcome(
             bullet=f"- ❌ static — could not fetch or parse `{url}` — {trim(res.stderr)}",
             blocker=True,
@@ -171,6 +252,23 @@ def run_validate_static(url: str, report_path: Path) -> Outcome:
     warnings = data.get("warnings") or {}
 
     if not success or agencies < 1:
+        # An outer zip that contains only nested .zip files (SEPTA, Victoria AU
+        # patterns) makes the validator return success with zero files —
+        # transitland-lib only resolves nested zips when a fragment ending in
+        # .zip is supplied. Probe and suggest fragments instead of the
+        # misleading "no agency records" message.
+        if file_count == 0:
+            _, nested = discover_zip_prefixes(url)
+            if nested:
+                head = (
+                    f"- ❌ static — `{url}` — this zip contains nested `.zip` "
+                    f"files rather than a GTFS feed at the top level; pick one "
+                    f"by appending a URL fragment:"
+                )
+                return Outcome(
+                    bullet=head + "\n" + render_prefix_suggestions(url, nested),
+                    blocker=True,
+                )
         reason = data.get("failure_reason") or "no agency records"
         return Outcome(
             bullet=f"- ❌ static — `{url}` — {reason}",


### PR DESCRIPTION
## Summary
- Detect two real patterns where an outer zip holds more than one GTFS feed (Lauderhill/National RTAP, SEPTA, Victoria AU) and render `URL#fragment` suggestions instead of an opaque validator error
- Probe is on-failure only — no change to the happy path

## Background
Two failure modes the validator doesn't help contributors out of:

1. **Multiple folder prefixes** — outer zip has GTFS files under two valid prefixes (e.g. `./` and `GTFS/`). transitland-lib refuses to pick one (`tlcsv/adapter.go:findInternalPrefix`) and returns `more than one valid prefix found`. Current workflow surfaces that raw error.
2. **Top-level nested zips** — outer zip contains only `*.zip` entries (SEPTA's `google_bus.zip` + `google_rail.zip`, or Victoria AU's `1/google_transit.zip` ... `11/google_transit.zip`). transitland-lib only resolves nested zips when a fragment ends in `.zip`, so the bare URL "succeeds" with an empty result; the previous "no agency records" message was misleading.

In both cases the workflow now downloads the zip, enumerates candidate prefixes (mirroring the lib's `stops.txt` rule + finding `*.zip` entries), and prints copy-paste-ready URL suggestions. Capped at 8 to keep Victoria-style outer zips readable.

## Test plan
Verified locally against existing Atlas DMFR patterns:

| Case | URL | Expected | Result |
|---|---|---|---|
| Single auto-detected prefix (Sakay) | `master.zip` | ✅ passes unchanged | ✅ 6 agencies, 1717 routes |
| Multi-prefix zip (Lauderhill bare) | `GTFS.zip` | ❌ with `#./` + `#GTFS/` suggestions | ✅ both suggested |
| Multi-prefix with fragment | `GTFS.zip#./` | ✅ passes | ✅ 1 agency, 7 routes |
| Nested zips, no fragment (SEPTA bare) | `gtfs_public.zip` | ❌ with `#google_bus.zip` + `#google_rail.zip` | ✅ both suggested |
| Nested zips with fragment (SEPTA) | `gtfs_public.zip#google_bus.zip` | ✅ passes unchanged | ✅ 1 agency, 173 routes |
| Many nested zips (Victoria AU bare) | `gtfs.zip` | ❌ with up to 8 `#N/google_transit.zip` suggestions | ✅ 8 listed |

- [ ] CI workflow exercises both code paths on this PR (none of these feeds are touched here, so CI will mostly no-op — coverage comes from the test matrix above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)