### PR TITLE
Add TEP Parma GTFS and GTFS-RT feeds

### DIFF
--- a/feeds/tep.pr.it.dmfr.json
+++ b/feeds/tep.pr.it.dmfr.json
@@ -16,7 +16,12 @@
           "onestop_id": "o-spz3-tep",
           "name": "TEP Parma",
           "short_name": "TEP",
-          "website": "https://www.tep.pr.it/"
+          "website": "https://www.tep.pr.it/",
+          "associated_feeds": [
+            {
+              "feed_onestop_id": "f-spz3-tep-parma~rt"
+            }
+          ]
         }
       ]
     },
@@ -25,8 +30,7 @@
       "spec": "gtfs-rt",
       "urls": {
         "realtime_vehicle_positions": "https://temporeale.cl.tep.pr.it/temporeale/vehicle_positions.pb",
-        "realtime_trip_updates": "https://temporeale.cl.tep.pr.it/temporeale/trip_updates.pb",
-        "realtime_alerts": "https://temporeale.cl.tep.pr.it/temporeale/service_alerts.pb"
+        "realtime_trip_updates": "https://temporeale.cl.tep.pr.it/temporeale/trip_updates.pb"
       },
       "license": {
         "spdx_identifier": "CC-BY-4.0",

--- a/feeds/tep.pr.it.dmfr.json
+++ b/feeds/tep.pr.it.dmfr.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.6.0.json",
+  "feeds": [
+    {
+      "id": "f-spz3-tep-parma",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://temporeale.cl.tep.pr.it/temporeale/gtfs.zip"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "url": "https://temporeale.cl.tep.pr.it/"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-spz3-tep",
+          "name": "TEP Parma",
+          "short_name": "TEP",
+          "website": "https://www.tep.pr.it/"
+        }
+      ]
+    },
+    {
+      "id": "f-spz3-tep-parma~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://temporeale.cl.tep.pr.it/temporeale/vehicle_positions.pb",
+        "realtime_trip_updates": "https://temporeale.cl.tep.pr.it/temporeale/trip_updates.pb",
+        "realtime_alerts": "https://temporeale.cl.tep.pr.it/temporeale/service_alerts.pb"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "url": "https://temporeale.cl.tep.pr.it/"
+      }
+    }
+  ]
+}

--- a/feeds/tep.pr.it.dmfr.json
+++ b/feeds/tep.pr.it.dmfr.json
@@ -2,7 +2,7 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.6.0.json",
   "feeds": [
     {
-      "id": "f-spz3-tep-parma",
+      "id": "f-spz3-tepparma",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://temporeale.cl.tep.pr.it/temporeale/gtfs.zip"
@@ -19,14 +19,14 @@
           "website": "https://www.tep.pr.it/",
           "associated_feeds": [
             {
-              "feed_onestop_id": "f-spz3-tep-parma~rt"
+              "feed_onestop_id": "f-spz3-tepparma~rt"
             }
           ]
         }
       ]
     },
     {
-      "id": "f-spz3-tep-parma~rt",
+      "id": "f-spz3-tepparma~rt",
       "spec": "gtfs-rt",
       "urls": {
         "realtime_vehicle_positions": "https://temporeale.cl.tep.pr.it/temporeale/vehicle_positions.pb",


### PR DESCRIPTION
## Summary

This PR adds the official GTFS and GTFS-Realtime feeds for TEP Parma, the public transport operator serving Parma and the surrounding province in Emilia-Romagna, Italy.

## Included feeds

### GTFS Static
- Schedule data
- Routes
- Stops
- Trips
- Calendars

### GTFS Realtime
- Vehicle Positions
- Trip Updates
- Service Alerts

## Operator

- Name: TEP Parma
- Short name: TEP
- Website: https://www.tep.pr.it/

## Feed URLs

### Static GTFS
https://temporeale.cl.tep.pr.it/temporeale/gtfs.zip

### GTFS-RT Vehicle Positions
https://temporeale.cl.tep.pr.it/temporeale/vehicle_positions.pb

### GTFS-RT Trip Updates
https://temporeale.cl.tep.pr.it/temporeale/trip_updates.pb

### GTFS-RT Service Alerts
https://temporeale.cl.tep.pr.it/temporeale/service_alerts.pb

## License

CC-BY-4.0

## Notes

The GTFS-Realtime Vehicle Positions and Trip Updates feeds validate correctly.

The Service Alerts endpoint currently returns an empty payload upstream, so it has been temporarily omitted until a valid GTFS-RT FeedMessage is provided by the operator.

All feed URLs are official TEP Parma realtime endpoints.

The feeds are publicly accessible and provided by TEP Parma realtime services infrastructure.