### PR TITLE
Use GitHub App token for auto-PR workflows so PR checks fire

### DIFF
--- a/.github/workflows/update-es-nap.yaml
+++ b/.github/workflows/update-es-nap.yaml
@@ -9,7 +9,14 @@ jobs:
   scheduled:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+      id: app-token
+      with:
+        app-id: ${{ secrets.GH_BOT_APP_ID }}
+        private-key: ${{ secrets.GH_BOT_APP_PRIVATE_KEY }}
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        token: ${{ steps.app-token.outputs.token }}
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: '3.10'
@@ -35,11 +42,12 @@ jobs:
         DMFR_SCHEMA_VERSION: v0.6.0
     - name: Open or update auto-PR if anything changed
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         scripts/auto-pr.sh \
           --branch-name "auto/spanish-nap" \
           --pr-title "Automatic update of Spanish NAP feeds" \
           --pr-body "Automatically updated Spanish NAP feeds from nap.transportes.gob.es" \
-          --commit-message "Updated Spanish NAP feeds from nap.transportes.gob.es at $(date -u)"
+          --commit-message "Updated Spanish NAP feeds from nap.transportes.gob.es at $(date -u)" \
+          --trigger-workflow ""
 

--- a/.github/workflows/update-gbfs.yaml
+++ b/.github/workflows/update-gbfs.yaml
@@ -7,7 +7,14 @@ jobs:
   scheduled:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+      id: app-token
+      with:
+        app-id: ${{ secrets.GH_BOT_APP_ID }}
+        private-key: ${{ secrets.GH_BOT_APP_PRIVATE_KEY }}
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        token: ${{ steps.app-token.outputs.token }}
     - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
     - name: Install transitland-lib
       run: scripts/install-transitland-lib.sh
@@ -21,10 +28,11 @@ jobs:
       run: uv run validate-feeds.py
     - name: Open or update auto-PR if anything changed
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         scripts/auto-pr.sh \
           --branch-name "auto/gbfs" \
           --pr-title "Automatic update of GBFS feeds" \
           --pr-body "Automatically updated GBFS feeds from https://github.com/NABSA/gbfs/blob/master/systems.csv" \
-          --commit-message "Updated GBFS feeds from https://github.com/NABSA/gbfs/blob/master/systems.csv at $(date -u)"
+          --commit-message "Updated GBFS feeds from https://github.com/NABSA/gbfs/blob/master/systems.csv at $(date -u)" \
+          --trigger-workflow ""

--- a/.github/workflows/update-jp.yaml
+++ b/.github/workflows/update-jp.yaml
@@ -9,7 +9,14 @@ jobs:
   scheduled:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+      id: app-token
+      with:
+        app-id: ${{ secrets.GH_BOT_APP_ID }}
+        private-key: ${{ secrets.GH_BOT_APP_PRIVATE_KEY }}
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        token: ${{ steps.app-token.outputs.token }}
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: '3.10'
@@ -37,7 +44,7 @@ jobs:
       run: uv run validate-feeds.py
     - name: Open or update auto-PR if anything changed
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         scripts/auto-pr.sh \
           --branch-name "auto/japanese-feeds" \
@@ -46,4 +53,5 @@ jobs:
             - gtfs-data.jp
             - ODPT (Public Transportation Open Data Center)
             - github.com/tshimada291/gtfs-jp-list-datecheck" \
-          --commit-message "Updated Japanese GTFS feeds from gtfs-data.jp, ODPT, and github.com/tshimada291/gtfs-jp-list-datecheck at $(date -u)"
+          --commit-message "Updated Japanese GTFS feeds from gtfs-data.jp, ODPT, and github.com/tshimada291/gtfs-jp-list-datecheck at $(date -u)" \
+          --trigger-workflow ""


### PR DESCRIPTION
## Summary

PRs opened by `update-jp.yaml`, `update-gbfs.yaml`, and `update-es-nap.yaml` currently use the default `GITHUB_TOKEN`. GitHub suppresses downstream workflow runs from `GITHUB_TOKEN`-triggered events (anti-recursion safety), so `format.yaml` and `check-feed-urls.yaml` have never run on the daily auto-PRs (e.g. #2035 has empty checks).

This PR switches those three workflows to mint a token from a GitHub App (`GH_BOT_APP_ID` / `GH_BOT_APP_PRIVATE_KEY` already configured in repo secrets) via [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token), pinned to commit `bcd2ba49218906704ab6c1aa796996da409d3eb1` (v3). The token is passed to:

- `actions/checkout` so `git push` uses it
- the `auto-pr.sh` step's `GH_TOKEN` so `gh pr create` uses it

With a non-`GITHUB_TOKEN` actor, `pull_request_target` workflows fire normally on the PR.

Also drops the explicit `--trigger-workflow validate.yaml` call from `auto-pr.sh` since `validate.yaml` will now fire on its own via `pull_request_target` (and `push` to the auto branch).

## Test plan

- [ ] After merge, manually trigger one of the three auto workflows from the Actions tab
- [ ] Confirm the resulting PR is authored by `transitland-atlas-bot[bot]` (or whatever name the App uses)
- [ ] Confirm `Validate`, `Check DMFR Formatting`, and `Validate static and RT URLs in changed DMFR files` all appear as checks on the PR
- [ ] Confirm `gh pr checks <num>` shows the runs (not "no checks reported")
- [ ] Close existing PR #2035 manually before tomorrow's 09:00 UTC schedule so the new App opens a clean PR (the old one's commits will look weird mixed with new App-authored ones)

## Notes

- App permissions required (already granted): Contents: write, Pull requests: write, scoped to this repo only
- Old `ATLAS_REPO_GH_PERSONAL_ACCESS_TOKEN` secret was deleted in the same setup pass — it had been orphaned since #1167
- `validate.yaml` will now fire twice per push (once for `push`, once for `pull_request_target`); harmless but wasteful, addressable in a separate PR by restricting `push:` to `branches: [main]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)