### PR TITLE
Transportes Coletivos do Barreiro new GTFS url due to new website hosting structure

### DIFF
--- a/feeds/tcbarreiro.pt.dmfr.json
+++ b/feeds/tcbarreiro.pt.dmfr.json
@@ -5,8 +5,9 @@
       "id": "f-transportes~colectivos~do~barreiro~pt",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.tcbarreiro.pt/front/files/sample_gtfs/GTFS-TCB_24.zip",
+        "static_current": "https://backend.tcbarreiro.pt/download-gtfs",
         "static_historic": [
+          "https://www.tcbarreiro.pt/front/files/sample_gtfs/GTFS-TCB_24.zip"
           "https://www.transporlis.pt/desktopmodules/trp_opendata/ajax/downloadFile.ashx?op=41&u=web"
         ]
       },


### PR DESCRIPTION
https://tcbarreiro.pt/