### PR TITLE
Update BJCTA (maxtransit) static_current URL to 2026 path

### DIFF
--- a/feeds/maxtransit.org.dmfr.json
+++ b/feeds/maxtransit.org.dmfr.json
@@ -5,8 +5,9 @@
       "id": "f-djfq-birminghamjeffersoncountytransitauthority",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://maxtransit.org/wp-content/uploads/2024/09/google_transit_Working.zip",
+        "static_current": "https://maxtransit.org/GTFS/2026/google_transit_Working.zip",
         "static_historic": [
+          "https://maxtransit.org/wp-content/uploads/2024/09/google_transit_Working.zip",
           "https://maxtransit.org/wp-content/uploads/2023/05/google_transit.zip",
           "https://maxtransit.org/wp-content/uploads/2020/12/BJCTA-Working-GTFS-File.zip",
           "https://maxtransit.org/wp-content/uploads/2017/05/BJCTA_GTFS_0317.zip",


### PR DESCRIPTION
Our contacts at BJCTA notified us that they updated the GTFS URL on their webpage. Updating `static_current` here to reflect the latest feed, and adding the 2024/09 link to `static_historic`