### PR TITLE
Update static_current URL for transit feed

### DIFF
--- a/feeds/sitka.land.dmfr.json
+++ b/feeds/sitka.land.dmfr.json
@@ -5,8 +5,9 @@
       "id": "f-bfpu-theride",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.sitka.land/transit/the-ride/transit_feed.zip",
+        "static_current": "https://transit.sitka.land/the-ride/transit_feed.zip",
         "static_historic": [
+          "https://www.sitka.land/transit/the-ride/transit_feed.zip",
           "https://www.jfactory.xyz/gtfs/the-ride/transit_feed.zip",
           "http://jfact0ry.com/theRIDE/transit_feed.zip"
         ]


### PR DESCRIPTION
www.sitka.land has a firewall blocking mircrosoft azure (or something similar) so transit.sitka.land was setup to circumvent that as it's hosted on github