### PR TITLE
Update Sonoma-Marin Area Rail Transit

### DIFF
--- a/feeds/511.org.dmfr.json
+++ b/feeds/511.org.dmfr.json
@@ -707,7 +707,10 @@
       ],
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://api.511.org/transit/datafeeds?operator_id=SA"
+        "static_current": "http://api.511.org/transit/datafeeds?operator_id=SA",
+        "static_historic": [
+          "https://data.trilliumtransit.com/gtfs/smart-ca-us/smart-ca-us.zip"
+        ]
       },
       "license": {
         "url": "https://511.org/sites/default/files/pdfs/511_Data_Agreement_Final.pdf",

--- a/feeds/511.org.dmfr.json
+++ b/feeds/511.org.dmfr.json
@@ -707,11 +707,22 @@
       ],
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/smart-ca-us/smart-ca-us.zip"
+        "static_current": "http://api.511.org/transit/datafeeds?operator_id=SA"
       },
       "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes"
+        "url": "https://511.org/sites/default/files/pdfs/511_Data_Agreement_Final.pdf",
+        "use_without_attribution": "no",
+        "create_derived_product": "yes",
+        "redistribution_allowed": "yes",
+        "commercial_use_allowed": "yes",
+        "share_alike_optional": "yes",
+        "attribution_text": "data provided by 511.org",
+        "attribution_instructions": "MUST acknowledge the source of the Provided Data with the tag line \"powered by 511.org,\" or \"data provided by 511.org,\" or a variant approved in writing by MTC, and a link to http://www.511.org.  The acknowledgement must be in visual proximity to the user's access to the Provided Data.  If space allows, Registered Data Disseminators are encouraged to provide the MTC 511 + Design logo with the link to 511.org."
+      },
+      "authorization": {
+        "type": "query_param",
+        "param_name": "api_key",
+        "info_url": "https://511.org/open-data/token"
       },
       "tags": {
         "exclude_from_global_query": "true",
@@ -1169,7 +1180,7 @@
     },
     {
       "onestop_id": "o-9qb-sonomamarinarearailtransit",
-      "name": "Sonoma Marin Area Rail Transit",
+      "name": "Sonoma-Marin Area Rail Transit",
       "short_name": "SMART",
       "website": "https://www.sonomamarintrain.org/",
       "associated_feeds": [


### PR DESCRIPTION
* Update static GTFS URL to use 511.org
* Update name to use dash "Sonoma-Marin Area Rail Transit"