### PR TITLE
Change status on Trillium Groome feed from 'outdated' to 'archived'

### DIFF
--- a/feeds/trilliumtransit.com.dmfr.json
+++ b/feeds/trilliumtransit.com.dmfr.json
@@ -1275,7 +1275,7 @@
         "create_derived_product": "yes"
       },
       "tags": {
-        "status": "outdated"
+        "status": "archived"
       }
     },
     {


### PR DESCRIPTION
Change status on Trillium Transit  -  Groome Transportation Sandia Shuttle feed from 'outdated' to 'archived'. Target URL leads to broken link.