### PR TITLE
Fix CTtransit static URL; tag as unstable

### DIFF
--- a/feeds/cttransit.com.dmfr.json
+++ b/feeds/cttransit.com.dmfr.json
@@ -44,12 +44,18 @@
       ],
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://www.cttransit.com/sites/default/files/gtfs/googlect_transit.zip"
+        "static_current": "https://www.cttransit.com/sites/default/files/2026-07/googlect_transit.zip",
+        "static_historic": [
+          "https://www.cttransit.com/sites/default/files/gtfs/googlect_transit.zip"
+        ]
       },
       "license": {
         "url": "https://www.cttransit.com/about/developers/terms-of-use",
         "use_without_attribution": "yes",
         "create_derived_product": "yes"
+      },
+      "tags": {
+        "unstable_url": "true"
       }
     }
   ],


### PR DESCRIPTION
Unfortunately will need to check https://www.cttransit.com/about/developers in the future