### PR TITLE
Retire Peter Pan static URL to historic

### DIFF
--- a/feeds/trilliumtransit.com.dmfr.json
+++ b/feeds/trilliumtransit.com.dmfr.json
@@ -3855,7 +3855,9 @@
       "id": "f-dr-peterpanbuslines",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/peterpan-ma-us/peterpan-ma-us.zip"
+        "static_historic": [
+          "https://data.trilliumtransit.com/gtfs/peterpan-ma-us/peterpan-ma-us.zip"
+        ]
       },
       "license": {
         "url": "https://www.massdot.state.ma.us/Portals/0/docs/developers/develop_license_agree.pdf",


### PR DESCRIPTION
The Trillium-hosted feed has not updated since 2024 and its service period ended 2024-12-31. Moving it to static_historic stops fetching a stale file while keeping the source visible.