### PR TITLE
Use Syncromatics static feeds where RT is Syncromatics

### DIFF
--- a/feeds/syncromatics.com.dmfr.json
+++ b/feeds/syncromatics.com.dmfr.json
@@ -2,16 +2,37 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.6.0.json",
   "feeds": [
     {
-      "id": "f-9myr-paloverdevalley~ca~us~rt",
-      "spec": "gtfs-rt",
+      "id": "f-9myr-paloverdevalley~ca~us",
+      "spec": "gtfs",
       "urls": {
-        "realtime_vehicle_positions": "https://ridepvvta.com/gtfs-rt/vehiclepositions",
-        "realtime_trip_updates": "https://ridepvvta.com/gtfs-rt/tripupdates",
-        "realtime_alerts": "https://ridepvvta.com/gtfs-rt/alerts"
+        "static_current": "https://ridepvvta.com/gtfs",
+        "static_historic": [
+          "https://data.trilliumtransit.com/gtfs/paloverde-valley-ca-us/paloverde-valley-ca-us.zip"
+        ]
       },
       "license": {
-        "url": "https://gtfs-directory.syncromatics.com/"
-      }
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes"
+      },
+      "tags": {
+        "gtfs_data_exchange": "palo-verde-valley-transit-agency"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-9myr-paloverdevalleytransitagency",
+          "name": "Palo Verde Valley Transit Agency",
+          "short_name": "PVVTA",
+          "website": "https://pvvta.com/",
+          "associated_feeds": [
+            {
+              "feed_onestop_id": "f-9myr-paloverdevalley~ca~us~rt"
+            }
+          ],
+          "tags": {
+            "us_ntd_id": "99454"
+          }
+        }
+      ]
     },
     {
       "id": "f-9myr-paloverdevalley~ca~us~rt",
@@ -196,6 +217,43 @@
         "realtime_trip_updates": "https://ridedowneylink.com/gtfs-rt/tripupdates",
         "realtime_alerts": "https://ridedowneylink.com/gtfs-rt/alerts"
       }
+    },
+    {
+      "id": "f-dp9k-waukeshacounty~wi~us",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://mywaukeshametro.com/gtfs",
+        "static_historic": [
+          "https://data.trilliumtransit.com/gtfs/waukeshacounty-wi-us/waukeshacounty-wi-us.zip"
+        ]
+      },
+      "license": {
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-dp9k-waukeshacountytransit",
+          "name": "Waukesha County Transit",
+          "website": "https://www.waukesha-wi.gov/residents/getting_around/public-transportation.php",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "189"
+            },
+            {
+              "feed_onestop_id": "f-dp9k-waukeshacounty~wi~us~rt"
+            },
+            {
+              "gtfs_agency_id": "2356",
+              "feed_onestop_id": "f-megabus~us"
+            }
+          ],
+          "tags": {
+            "us_ntd_id": "50096",
+            "wikidata_id": "Q7975163"
+          }
+        }
+      ]
     },
     {
       "id": "f-dp9k-waukeshacounty~wi~us~rt",

--- a/feeds/thebuslive.com.dmfr.json
+++ b/feeds/thebuslive.com.dmfr.json
@@ -5,7 +5,10 @@
       "id": "f-9qd-mercedthebus~ca~us",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/mercedthebus-ca-us/mercedthebus-ca-us.zip"
+        "static_current": "https://thebuslive.com/gtfs",
+        "static_historic": [
+          "https://data.trilliumtransit.com/gtfs/mercedthebus-ca-us/mercedthebus-ca-us.zip"
+        ]
       },
       "license": {
         "use_without_attribution": "yes",

--- a/feeds/trilliumtransit.com.dmfr.json
+++ b/feeds/trilliumtransit.com.dmfr.json
@@ -56,36 +56,6 @@
       ]
     },
     {
-      "id": "f-9myr-paloverdevalley~ca~us",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/paloverde-valley-ca-us/paloverde-valley-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes"
-      },
-      "tags": {
-        "gtfs_data_exchange": "palo-verde-valley-transit-agency"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9myr-paloverdevalleytransitagency",
-          "name": "Palo Verde Valley Transit Agency",
-          "short_name": "PVVTA",
-          "website": "https://pvvta.com/",
-          "associated_feeds": [
-            {
-              "feed_onestop_id": "f-9myr-paloverdevalley~ca~us~rt"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "99454"
-          }
-        }
-      ]
-    },
-    {
       "id": "f-9pp-humboldtcounty~ca~us",
       "spec": "gtfs",
       "urls": {
@@ -3678,40 +3648,6 @@
           "tags": {
             "us_ntd_id": "50053",
             "wikidata_id": "Q7703361"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f-dp9k-waukeshacounty~wi~us",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/waukeshacounty-wi-us/waukeshacounty-wi-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-dp9k-waukeshacountytransit",
-          "name": "Waukesha County Transit",
-          "website": "https://www.waukesha-wi.gov/residents/getting_around/public-transportation.php",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "189"
-            },
-            {
-              "feed_onestop_id": "f-dp9k-waukeshacounty~wi~us~rt"
-            },
-            {
-              "gtfs_agency_id": "2356",
-              "feed_onestop_id": "f-megabus~us"
-            }
-          ],
-          "tags": {
-            "us_ntd_id": "50096",
-            "wikidata_id": "Q7975163"
           }
         }
       ]


### PR DESCRIPTION
- Trip IDs in the Trillium and Syncromatics feeds for these agencies do not overlap at all, so the real-time could not resolve against the scheduled trips
- Also removes a duplicate PVVTA realtime entry