### PR TITLE
Add MATBUS and Winston Salem Transit realtime feeds

### DIFF
--- a/feeds/matbus.com.dmfr.json
+++ b/feeds/matbus.com.dmfr.json
@@ -20,6 +20,11 @@
           "name": "Fargo Moorhead Metro Area Transit",
           "short_name": "MATBUS",
           "website": "http://www.matbus.com/",
+          "associated_feeds": [
+            {
+              "feed_onestop_id": "f-cb74-matbus~rt"
+            }
+          ],
           "tags": {
             "twitter_general": "matbus",
             "us_ntd_id": "80003",
@@ -27,6 +32,15 @@
           }
         }
       ]
+    },
+    {
+      "id": "f-cb74-matbus~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://ridematbus.com/gtfs-rt/vehiclepositions",
+        "realtime_trip_updates": "https://ridematbus.com/gtfs-rt/tripupdates",
+        "realtime_alerts": "https://ridematbus.com/gtfs-rt/alerts"
+      }
     }
   ]
 }

--- a/feeds/ridewsta.com.dmfr.json
+++ b/feeds/ridewsta.com.dmfr.json
@@ -9,6 +9,31 @@
         "static_historic": [
           "https://wstransit.com/wp-content/uploads/2024/01/GTFS-TRIPS_5fa76ace_2024-01-02-18-53-02.zip"
         ]
+      },
+      "operators": [
+        {
+          "onestop_id": "o-dnq-wsta",
+          "name": "Winston Salem Transit",
+          "short_name": "WSTA",
+          "website": "https://wstransit.com/",
+          "associated_feeds": [
+            {
+              "feed_onestop_id": "f-dnq-wsta~rt"
+            }
+          ],
+          "tags": {
+            "us_ntd_id": "40012"
+          }
+        }
+      ]
+    },
+    {
+      "id": "f-dnq-wsta~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://ridewsta.com/gtfs-rt/vehiclepositions",
+        "realtime_trip_updates": "https://ridewsta.com/gtfs-rt/tripupdates",
+        "realtime_alerts": "https://ridewsta.com/gtfs-rt/alerts"
       }
     }
   ],


### PR DESCRIPTION
Both agencies already use their Syncromatics static feed; the matching realtime feeds were not registered. Adds an operator record for WSTA, which had none.