### PR TITLE
Add GTFS Łódź Suburban feed

### DIFF
--- a/feeds/github.com.dmfr.json
+++ b/feeds/github.com.dmfr.json
@@ -376,6 +376,18 @@
           ]
         }
       ]
+    },
+    {
+      "id": "f-u3j-lodz-suburban",
+      "name": "GTFS Łódź Suburban",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://raw.githubusercontent.com/qbx-tt/gtfs-lodz-suburban/main/gtfs-lodz-suburban.zip"
+      },
+      "license": {
+        "url": "https://github.com/qbx-tt/gtfs-lodz-suburban/blob/main/LICENSE",
+        "use_without_attribution": "no"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

This pull request adds a new public GTFS Schedule feed for suburban bus services around Łódź, Poland.

### Feed

GTFS Łódź Suburban

### Feed URL

https://raw.githubusercontent.com/qbx-tt/gtfs-lodz-suburban/main/gtfs-lodz-suburban.zip

### Repository

https://github.com/qbx-tt/gtfs-lodz-suburban

### Notes

This is an unofficial community-maintained GTFS feed created from publicly available timetable information published by municipalities and transport operators.

The feed is published under the CC BY 4.0 license.