### PR TITLE
Archive El Segundo and Sierra Madre feeds (service discontinued)

### DIFF
--- a/feeds/lacmta.github.com.dmfr.json
+++ b/feeds/lacmta.github.com.dmfr.json
@@ -24,10 +24,13 @@
       "id": "f-elsegundo~ca~us",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://github.com/LACMTA/los-angeles-regional-gtfs/raw/main/elsegundo-ca-us/elsegundo-ca-us.zip",
         "static_historic": [
-          "https://data.trilliumtransit.com/gtfs/elsegundo-ca-us/elsegundo-ca-us.zip"
+          "https://data.trilliumtransit.com/gtfs/elsegundo-ca-us/elsegundo-ca-us.zip",
+          "https://github.com/LACMTA/los-angeles-regional-gtfs/raw/main/elsegundo-ca-us/elsegundo-ca-us.zip"
         ]
+      },
+      "tags": {
+        "status": "archived"
       },
       "operators": [
         {
@@ -78,10 +81,13 @@
       "id": "f-sierramadre~ca~us",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://raw.githubusercontent.com/LACMTA/los-angeles-regional-gtfs/main/sierramadre-ca-us/sierramadre-ca-us.zip",
         "static_historic": [
-          "https://data.trilliumtransit.com/gtfs/sierramadre-ca-us/sierramadre-ca-us.zip"
+          "https://data.trilliumtransit.com/gtfs/sierramadre-ca-us/sierramadre-ca-us.zip",
+          "https://raw.githubusercontent.com/LACMTA/los-angeles-regional-gtfs/main/sierramadre-ca-us/sierramadre-ca-us.zip"
         ]
+      },
+      "tags": {
+        "status": "archived"
       },
       "operators": [
         {


### PR DESCRIPTION
Both feeds point at `static_current` URLs in LA Metro's regional GTFS repository that now return 404, and in both cases the underlying service has ended rather than moved.

| Feed | Status | Source |
|---|---|---|
| `f-elsegundo~ca~us` | 404 | LA Metro README, removed 7/9/26: "El Segundo no longer operates fixed-route service. There was a summer beach shuttle that ran during 2025, but it has ceased further operations." |
| `f-sierramadre~ca~us` | 404 | LA Metro README, removed 7/9/2026: "This service is no longer running as of at least 2/10/26." |

Both URLs verified returning 404 on 2026-08-08. Following the convention in `trilliumtransit.com.dmfr.json`: `static_current` moved into `static_historic`, and `tags.status` set to `archived`.

Note that `f-lapuente~ca~us` in the same file is still live and correct. La Puente is one of only three agencies LA Metro still hosts, so it is intentionally untouched here.

The other 21 references to that repository in this repo are already in `static_historic`, which is where they belong, so nothing else needed changing.
