### PR TITLE
Lowercase remaining uppercase operator Onestop IDs & fix some Greek feeds

### DIFF
--- a/feeds/armadina.hu.dmfr.json
+++ b/feeds/armadina.hu.dmfr.json
@@ -15,7 +15,10 @@
       },
       "operators": [
         {
-          "onestop_id": "o-u2mmz-budaörsvárosÖnkormányzata",
+          "onestop_id": "o-u2mmz-budaörsvárosönkormányzata",
+          "supersedes_ids": [
+            "o-u2mmz-budaörsvárosÖnkormányzata"
+          ],
           "name": "Budaörs Város Önkormányzata",
           "website": "http://www.budaors.hu/"
         }

--- a/feeds/datahub.io.dmfr.json
+++ b/feeds/datahub.io.dmfr.json
@@ -12,7 +12,10 @@
       },
       "operators": [
         {
-          "onestop_id": "o-sgg5z-gr~ΠροστιακόςΣιδηρόδρομοςΠατρών",
+          "onestop_id": "o-sgg5z-gr~προστιακόςσιδηρόδρομοςπατρών",
+          "supersedes_ids": [
+            "o-sgg5z-gr~ΠροστιακόςΣιδηρόδρομοςΠατρών"
+          ],
           "name": "Προστιακός Σιδηρόδρομος Πατρών",
           "short_name": "Suburban Railway of Patras",
           "website": "https://www.trainose.gr/en/passenger-activity/suburban-railway/patras-suburban-railway/",
@@ -35,7 +38,10 @@
       },
       "operators": [
         {
-          "onestop_id": "o-sqz-greece~ΚΤΕΛΝzΑΚΥΝΘΟΥΑΕ",
+          "onestop_id": "o-sqz-greece~κτελνzακυνθουαε",
+          "supersedes_ids": [
+            "o-sqz-greece~ΚΤΕΛΝzΑΚΥΝΘΟΥΑΕ"
+          ],
           "name": "ΚΤΕΛ Ν. ZΑΚΥΝΘΟΥ Α.Ε.",
           "website": "http://ktel-zakynthos.gr/",
           "associated_feeds": [
@@ -57,7 +63,10 @@
       },
       "operators": [
         {
-          "onestop_id": "o-sqz-greece~ΥΠΕΡΑΣΤΙΚΟΚΤΕΛΝΘΕΣΠΡΩΤΙΑΣ",
+          "onestop_id": "o-sqz-greece~υπεραστικοκτελνθεσπρωτιας",
+          "supersedes_ids": [
+            "o-sqz-greece~ΥΠΕΡΑΣΤΙΚΟΚΤΕΛΝΘΕΣΠΡΩΤΙΑΣ"
+          ],
           "name": "ΥΠΕΡΑΣΤΙΚΟ ΚΤΕΛ Ν. ΘΕΣΠΡΩΤΙΑΣ",
           "website": "https://www.ktel-thesprotias.gr/",
           "associated_feeds": [

--- a/feeds/datahub.io.dmfr.json
+++ b/feeds/datahub.io.dmfr.json
@@ -38,11 +38,11 @@
       },
       "operators": [
         {
-          "onestop_id": "o-sqz-greece~κτελνzακυνθουαε",
+          "onestop_id": "o-sqz-greece~κτελνζακυνθουαε",
           "supersedes_ids": [
             "o-sqz-greece~ΚΤΕΛΝzΑΚΥΝΘΟΥΑΕ"
           ],
-          "name": "ΚΤΕΛ Ν. ZΑΚΥΝΘΟΥ Α.Ε.",
+          "name": "ΚΤΕΛ Ν. ΖΑΚΥΝΘΟΥ Α.Ε.",
           "website": "http://ktel-zakynthos.gr/",
           "associated_feeds": [
             {

--- a/feeds/datahub.io.dmfr.json
+++ b/feeds/datahub.io.dmfr.json
@@ -9,7 +9,9 @@
       ],
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://datahub.io/angelou/proastiakos-patras-gtfs-20171128/r/prostiakos-patras-gtfs-20171128.zip"
+        "static_historic": [
+          "https://datahub.io/angelou/proastiakos-patras-gtfs-20171128/r/prostiakos-patras-gtfs-20171128.zip"
+        ]
       },
       "operators": [
         {
@@ -20,7 +22,7 @@
           ],
           "name": "Προαστιακός Σιδηρόδρομος Πατρών",
           "short_name": "Suburban Railway of Patras",
-          "website": "https://www.trainose.gr/en/passenger-activity/suburban-railway/patras-suburban-railway/",
+          "website": "https://www.hellenictrain.gr/en/patras-suburban-railway",
           "associated_feeds": [
             {
               "gtfs_agency_id": "ProastiakosPatras"
@@ -40,7 +42,9 @@
       ],
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://datahub.io/angelou/ktel-zakynthou-gtfs-20171128/r/ktel-zakynthou-gtfs-20171128.zip"
+        "static_historic": [
+          "https://datahub.io/angelou/ktel-zakynthou-gtfs-20171128/r/ktel-zakynthou-gtfs-20171128.zip"
+        ]
       },
       "operators": [
         {
@@ -65,7 +69,9 @@
       ],
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://datahub.io/angelou/ktel-thesprotias-gtfs-20171128/r/ktel-thesprotias-gtfs-20171128.zip"
+        "static_historic": [
+          "https://datahub.io/angelou/ktel-thesprotias-gtfs-20171128/r/ktel-thesprotias-gtfs-20171128.zip"
+        ]
       },
       "operators": [
         {

--- a/feeds/datahub.io.dmfr.json
+++ b/feeds/datahub.io.dmfr.json
@@ -2,9 +2,10 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.6.0.json",
   "feeds": [
     {
-      "id": "f-sgg5z-gr~προστιακόςσιδηρόδρομοςπατρών",
+      "id": "f-sgg5z-gr~προαστιακόςσιδηρόδρομοςπατρών",
       "supersedes_ids": [
-        "f-sgg5z-gr~ΠροστιακόςΣιδηρόδρομοςΠατρών"
+        "f-sgg5z-gr~ΠροστιακόςΣιδηρόδρομοςΠατρών",
+        "f-sgg5z-gr~προστιακόςσιδηρόδρομοςπατρών"
       ],
       "spec": "gtfs",
       "urls": {
@@ -12,25 +13,30 @@
       },
       "operators": [
         {
-          "onestop_id": "o-sgg5z-gr~προστιακόςσιδηρόδρομοςπατρών",
+          "onestop_id": "o-sgg5z-gr~προαστιακόςσιδηρόδρομοςπατρών",
           "supersedes_ids": [
-            "o-sgg5z-gr~ΠροστιακόςΣιδηρόδρομοςΠατρών"
+            "o-sgg5z-gr~ΠροστιακόςΣιδηρόδρομοςΠατρών",
+            "o-sgg5z-gr~προστιακόςσιδηρόδρομοςπατρών"
           ],
-          "name": "Προστιακός Σιδηρόδρομος Πατρών",
+          "name": "Προαστιακός Σιδηρόδρομος Πατρών",
           "short_name": "Suburban Railway of Patras",
           "website": "https://www.trainose.gr/en/passenger-activity/suburban-railway/patras-suburban-railway/",
           "associated_feeds": [
             {
               "gtfs_agency_id": "ProastiakosPatras"
             }
-          ]
+          ],
+          "tags": {
+            "wikidata_id": "Q3536559"
+          }
         }
       ]
     },
     {
-      "id": "f-sqz-greece~κτελνzακυνθουαε",
+      "id": "f-sqz-greece~κτελνζακυνθουαε",
       "supersedes_ids": [
-        "f-sqz-greece~ΚΤΕΛΝzΑΚΥΝΘΟΥΑΕ"
+        "f-sqz-greece~ΚΤΕΛΝzΑΚΥΝΘΟΥΑΕ",
+        "f-sqz-greece~κτελνzακυνθουαε"
       ],
       "spec": "gtfs",
       "urls": {

--- a/feeds/download.vrsinfo.de.dmfr.json
+++ b/feeds/download.vrsinfo.de.dmfr.json
@@ -167,7 +167,10 @@
           ]
         },
         {
-          "onestop_id": "o-u1hck-svhstadtverkehrhürthaörabtÖpnv",
+          "onestop_id": "o-u1hck-svhstadtverkehrhürthaörabtöpnv",
+          "supersedes_ids": [
+            "o-u1hck-svhstadtverkehrhürthaörabtÖpnv"
+          ],
           "name": "Stadtverkehr Hürth AöR, Abt. ÖPNV",
           "short_name": "SVH",
           "website": "http://www.svh-direkt.de/",

--- a/feeds/geodata.gov.gr.dmfr.json
+++ b/feeds/geodata.gov.gr.dmfr.json
@@ -15,11 +15,11 @@
       },
       "operators": [
         {
-          "onestop_id": "o-swb-οργανισμόςαστικώνσυγκοινωνιώνοασα~αthensurbantransportorga",
+          "onestop_id": "o-swb-οργανισμόςαστικώνσυγκοινωνιώνοασα~athensurbantransportorga",
           "supersedes_ids": [
             "o-swb-ΟργανισμόςΑστικώνΣυγκοινωνιώνΟΑΣΑ~Αthensurbantransportorga"
           ],
-          "name": "Οργανισμός Αστικών Συγκοινωνιών ΟΑΣΑ - Αthens Urban Transport Organisation",
+          "name": "Οργανισμός Αστικών Συγκοινωνιών ΟΑΣΑ - Athens Urban Transport Organisation",
           "website": "http://www.oasa.gr"
         }
       ]

--- a/feeds/geodata.gov.gr.dmfr.json
+++ b/feeds/geodata.gov.gr.dmfr.json
@@ -2,9 +2,10 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.6.0.json",
   "feeds": [
     {
-      "id": "f-swb-οργανισμόςαστικώνσυγκοινωνιώνοασα~αthensurbantransportorga",
+      "id": "f-swb-οργανισμόςαστικώνσυγκοινωνιώνοασα~athensurbantransportorga",
       "supersedes_ids": [
-        "f-swb-ΟργανισμόςΑστικώνΣυγκοινωνιώνΟΑΣΑ~Αthensurbantransportorga"
+        "f-swb-ΟργανισμόςΑστικώνΣυγκοινωνιώνΟΑΣΑ~Αthensurbantransportorga",
+        "f-swb-οργανισμόςαστικώνσυγκοινωνιώνοασα~αthensurbantransportorga"
       ],
       "spec": "gtfs",
       "urls": {

--- a/feeds/geodata.gov.gr.dmfr.json
+++ b/feeds/geodata.gov.gr.dmfr.json
@@ -15,7 +15,10 @@
       },
       "operators": [
         {
-          "onestop_id": "o-swb-ΟργανισμόςΑστικώνΣυγκοινωνιώνΟΑΣΑ~Αthensurbantransportorga",
+          "onestop_id": "o-swb-οργανισμόςαστικώνσυγκοινωνιώνοασα~αthensurbantransportorga",
+          "supersedes_ids": [
+            "o-swb-ΟργανισμόςΑστικώνΣυγκοινωνιώνΟΑΣΑ~Αthensurbantransportorga"
+          ],
           "name": "Οργανισμός Αστικών Συγκοινωνιών ΟΑΣΑ - Αthens Urban Transport Organisation",
           "website": "http://www.oasa.gr"
         }

--- a/feeds/geodata.gov.gr.dmfr.json
+++ b/feeds/geodata.gov.gr.dmfr.json
@@ -9,9 +9,10 @@
       ],
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://catalog.growthfund.gr/dataset/956ed989-1e5c-4766-8289-a27373071f0f/resource/70120dd5-928a-476a-a2b5-b6bbef26253f/download/-.zip",
+        "static_current": "https://data.gov.gr/dataset/fb049bb1-aea6-4443-95fa-8b941dd6a057/resource/119db488-16ea-4c76-b560-41c472872390/download/osy_gtfs.zip",
         "static_historic": [
-          "http://geodata.gov.gr/dataset/244cfb87-21a0-4f9f-90af-25e9a232af41/resource/d94179a0-a2bd-432f-8c5e-e05eae2886cf/download/googletransit.zip"
+          "http://geodata.gov.gr/dataset/244cfb87-21a0-4f9f-90af-25e9a232af41/resource/d94179a0-a2bd-432f-8c5e-e05eae2886cf/download/googletransit.zip",
+          "https://catalog.growthfund.gr/dataset/956ed989-1e5c-4766-8289-a27373071f0f/resource/70120dd5-928a-476a-a2b5-b6bbef26253f/download/-.zip"
         ]
       },
       "operators": [

--- a/feeds/mkuran.pl.dmfr.json
+++ b/feeds/mkuran.pl.dmfr.json
@@ -346,9 +346,10 @@
       },
       "operators": [
         {
-          "onestop_id": "o-u3qc-komunikacjamiejskaŁomianki",
+          "onestop_id": "o-u3qc-komunikacjamiejskałomianki",
           "supersedes_ids": [
-            "o-u3qc-komunikacjamiejskaŁomiankispzoo"
+            "o-u3qc-komunikacjamiejskaŁomiankispzoo",
+            "o-u3qc-komunikacjamiejskaŁomianki"
           ],
           "name": "Komunikacja Miejska Łomianki",
           "short_name": "KMŁ",

--- a/feeds/porolakka.github.com.dmfr.json
+++ b/feeds/porolakka.github.com.dmfr.json
@@ -15,7 +15,10 @@
       },
       "operators": [
         {
-          "onestop_id": "o-HanedaINL_ShuttleBus20230528",
+          "onestop_id": "o-hanedainl_shuttlebus20230528",
+          "supersedes_ids": [
+            "o-HanedaINL_ShuttleBus20230528"
+          ],
           "name": "羽田空港無料シャトルバス",
           "website": "https://tokyo-haneda.com/access/travel_between_terminals/index.html",
           "associated_feeds": [

--- a/feeds/stops.lt.dmfr.json
+++ b/feeds/stops.lt.dmfr.json
@@ -190,7 +190,10 @@
       ]
     },
     {
-      "onestop_id": "o-u99z-sĮsusisiekimopaslaugos",
+      "onestop_id": "o-u99z-sįsusisiekimopaslaugos",
+      "supersedes_ids": [
+        "o-u99z-sĮsusisiekimopaslaugos"
+      ],
       "name": "SĮ Susisiekimo paslaugos",
       "short_name": "JUDU",
       "website": "https://judu.lt",

--- a/feeds/transport.orgp.spb.ru.dmfr.json
+++ b/feeds/transport.orgp.spb.ru.dmfr.json
@@ -21,7 +21,10 @@
   ],
   "operators": [
     {
-      "onestop_id": "o-udt-Петербургский~метрополитен",
+      "onestop_id": "o-udt-петербургский~метрополитен",
+      "supersedes_ids": [
+        "o-udt-Петербургский~метрополитен"
+      ],
       "name": "Петербургский метрополитен",
       "website": "http://orgp.spb.ru/",
       "associated_feeds": [

--- a/feeds/transportforireland.ie.dmfr.json
+++ b/feeds/transportforireland.ie.dmfr.json
@@ -1860,7 +1860,10 @@
       },
       "operators": [
         {
-          "onestop_id": "o-gc-busÉireann",
+          "onestop_id": "o-gc-buséireann",
+          "supersedes_ids": [
+            "o-gc-busÉireann"
+          ],
           "name": "Bus Éireann",
           "website": "https://www.buseireann.ie",
           "associated_feeds": [

--- a/feeds/ztm.poznan.pl.dmfr.json
+++ b/feeds/ztm.poznan.pl.dmfr.json
@@ -135,21 +135,6 @@
       ]
     },
     {
-      "onestop_id": "o-u3k4-SwarzędzkiePrzedsiębiorstwoKomunalne",
-      "name": "Swarzędzkie Przedsiębiorstwo Komunalne Sp. z o.o.",
-      "short_name": "SPK Swarzędz",
-      "website": "http://www.spk.swarzedz.pl",
-      "associated_feeds": [
-        {
-          "gtfs_agency_id": "11",
-          "feed_onestop_id": "f-u3k4-miejskieprzedsiębiorstwokomunikacyjnespzoowpoznaniu~kórni"
-        },
-        {
-          "feed_onestop_id": "f-u3k4-poznan~rt"
-        }
-      ]
-    },
-    {
       "onestop_id": "o-u3k4-miejskieprzedsiębiorstwokomunikacyjnespzoowpoznaniu",
       "name": "Miejskie Przedsiębiorstwo Komunikacyjne Sp. z o.o. w Poznaniu",
       "short_name": "MPK Poznań",
@@ -172,6 +157,24 @@
       "associated_feeds": [
         {
           "gtfs_agency_id": "5",
+          "feed_onestop_id": "f-u3k4-miejskieprzedsiębiorstwokomunikacyjnespzoowpoznaniu~kórni"
+        },
+        {
+          "feed_onestop_id": "f-u3k4-poznan~rt"
+        }
+      ]
+    },
+    {
+      "onestop_id": "o-u3k4-swarzędzkieprzedsiębiorstwokomunalne",
+      "supersedes_ids": [
+        "o-u3k4-SwarzędzkiePrzedsiębiorstwoKomunalne"
+      ],
+      "name": "Swarzędzkie Przedsiębiorstwo Komunalne Sp. z o.o.",
+      "short_name": "SPK Swarzędz",
+      "website": "http://www.spk.swarzedz.pl",
+      "associated_feeds": [
+        {
+          "gtfs_agency_id": "11",
           "feed_onestop_id": "f-u3k4-miejskieprzedsiębiorstwokomunikacyjnespzoowpoznaniu~kórni"
         },
         {


### PR DESCRIPTION
Onestop IDs are lowercase by convention, and #1256 made a pass at this in 2023, but twelve operator records survived it. All twelve carry uppercase in non-Latin scripts, which is presumably why a Latin-oriented sweep missed them: Greek, Cyrillic, Polish, Hungarian, Lithuanian, German and Irish, plus one Latin-script holdout in a hand-contributed Japanese file.

Each keeps its former id in `supersedes_ids`, so existing references still resolve.

## Checked before applying

Lowercasing non-Latin text is not automatically safe, so each was verified: **no length change, still NFC, idempotent**, and satisfying the Onestop format rules afterwards. Each id appeared exactly once in the registry, so there were no cross-references to update.

## Not caused by the generating scripts

All four generators that mint Onestop IDs already lowercase — `convert-gbfs-csv-to-dmfr.py`, `collect-gtfs-data-jp.py`, `collect-odpt-gtfs.py`, `collect-nap-gtfs.py`. These twelve are in hand-contributed files, so no generator change is needed.

## Two homoglyphs, fixed here rather than later

Both Greek operators mixed scripts mid-word, in the id and in the name. Since the ids were being rewritten anyway, fixing them now avoids superseding the same id twice:

- Athens wrote the English half of its name with a **Greek capital alpha**, `Αthens Urban Transport Organisation` (U+0391 rather than U+0041), which carried into the id as a Greek small alpha. Both are now Latin.
- Zakynthos is ΚΤΕΛ Ν. ΖΑΚΥΝΘΟΥ Α.Ε., but wrote ΖΑΚΥΝΘΟΥ with a **Latin capital Z** (U+005A rather than Greek zeta U+0396), which carried into the id as a Latin `z` between Greek nu and alpha. Both are now Greek zeta.

The names are the evidence for each reading and are corrected alongside the ids. The matching feed ids are brought into line too — an earlier pass had already lowercased feed ids but not operator ids, so leaving the feeds alone would have left the pair disagreeing.

Also corrects Patras, which spelled Προαστιακός ("suburban") as Προστιακός in its feed id, operator id and operator name; the word is προ-αστιακός, so the α is not optional. Adds `wikidata_id` Q3536559 to that operator. No `wikidata_id` for the others: every search for ΟΑΣΑ returns Q1814382, but that is instance-of "public transport network" and describes the Athens network rather than the organisation running it, so tagging the operator with it would assert something false. ΚΤΕΛ Ζακύνθου and ΚΤΕΛ Θεσπρωτίας have no entity at all.

## Greek URLs, forced by CI

Renaming these feed ids made the URL check validate their URLs for the first time — it keys its changed-set on feed id as well as URL, so a rename presents every URL on the feed as new. All four Greek feeds turned out to be dead, and none has ever produced a feed version.

Athens now points at the Ο.ΣΥ. export on `data.gov.gr`, the Greek national open data portal, published by ΟΑΣΑ itself: 485 routes, 97,217 trips, 8,040 stops, calendar 20260706 to 20261006. It validates with no errors. The dead `catalog.growthfund.gr` URL joins the older `geodata.gov.gr` one in `static_historic`.

Patras, Zakynthos and Thesprotias have no replacement — their 2017 datahub.io URLs 404 and nothing in the Mobility Database, the Greek portal or the operators' own sites offers another. All three operators still run, so the URLs move to `static_historic` rather than the records being deleted. Patras also gets its website updated, since trainose.gr now redirects to hellenictrain.gr.

Worth knowing for later: the portal's canonical resource URL for the Athens dataset ends `.rar` and really does serve a RAR archive, which transitland cannot read. Only the `.zip` variant is usable, and a made-up extension 404s, so the endpoint is not simply extension-agnostic.

## Why it matters

The registry now has **zero uppercase Onestop IDs across 2,728 operators and 6,221 feeds**. That means the lowercase check can be enforced on operators as well as feeds, rather than exempted — which is what interline-io/tlv2#489 asks transitland-lib to support, and what the Atlas-side validator currently has to skip for operators.

## Test plan

- `transitland dmfr format` and `dmfr lint` clean on all changed files.
- `validate-feeds.py` passes; `check-jsonschema` passes against the v0.6.0 schema.
- Re-scan of every DMFR file confirms zero uppercase ids remain, operators or feeds.
- `transitland validate` on the new Athens source reports no errors.
