### PR TITLE
Add Greek feeds: ΣΤΑΣΥ Athens and ΟΣΕΘ Thessaloniki

### DIFF
--- a/feeds/data.gov.gr.dmfr.json
+++ b/feeds/data.gov.gr.dmfr.json
@@ -2,6 +2,27 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.6.0.json",
   "feeds": [
     {
+      "id": "f-oseth~thessaloniki~gr",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.gov.gr/dataset/42c9a7da-c86c-48b1-914c-f340e8bef00d/resource/8edcc617-7d0e-4832-9804-96c9811fabfd/download/20260717_gtfs.zip"
+      },
+      "tags": {
+        "unstable_url": "true"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-oseth~thessaloniki~gr",
+          "name": "Οργανισμός Συγκοινωνιακού Έργου Θεσσαλονίκης - Thessaloniki Transport Authority",
+          "short_name": "ΟΣΕΘ",
+          "website": "https://oseth.com.gr",
+          "tags": {
+            "wikidata_id": "Q40209345"
+          }
+        }
+      ]
+    },
+    {
       "id": "f-stasy~urbanrailtransport~gr",
       "spec": "gtfs",
       "urls": {

--- a/feeds/data.gov.gr.dmfr.json
+++ b/feeds/data.gov.gr.dmfr.json
@@ -2,6 +2,29 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.6.0.json",
   "feeds": [
     {
+      "id": "f-stasy~urbanrailtransport~gr",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://data.gov.gr/dataset/4e897a75-975a-4ce7-af65-f32ea01f93b9/resource/5e3858ee-d9ba-48c2-9015-744ea160976d/download/stasy_gtfs.zip"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-stasy~urbanrailtransport~gr",
+          "name": "Σταθερές Συγκοινωνίες ΣΤΑΣΥ - Urban Rail Transport",
+          "short_name": "ΣΤΑΣΥ",
+          "website": "https://www.stasy.gr",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "1"
+            }
+          ],
+          "tags": {
+            "wikidata_id": "Q109331635"
+          }
+        }
+      ]
+    },
+    {
       "id": "f-swb-οργανισμόςαστικώνσυγκοινωνιώνοασα~athensurbantransportorga",
       "supersedes_ids": [
         "f-swb-ΟργανισμόςΑστικώνΣυγκοινωνιώνΟΑΣΑ~Αthensurbantransportorga",

--- a/feeds/data.gov.gr.dmfr.json
+++ b/feeds/data.gov.gr.dmfr.json
@@ -13,11 +13,6 @@
           "name": "Σταθερές Συγκοινωνίες ΣΤΑΣΥ - Urban Rail Transport",
           "short_name": "ΣΤΑΣΥ",
           "website": "https://www.stasy.gr",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "1"
-            }
-          ],
           "tags": {
             "wikidata_id": "Q109331635"
           }


### PR DESCRIPTION
Two feeds from `data.gov.gr`, the Greek open data portal.

**ΣΤΑΣΥ** runs the Athens metro, tram and ISAP electric railway as a separate company from ΟΑΣΑ, whose feed covers only buses and trolleys, so the two do not overlap. 5 routes, 75,730 trips, 252 stops, valid through 20260831.

**ΟΣΕΘ** is the Thessaloniki transport authority. 351 routes, 20,655 trips, 3,673 stops. Expired 20260803, but the publisher is active with ten releases since March on a roughly fortnightly cadence. Each release gets its own dated URL, so this one will freeze rather than follow the publisher, hence `unstable_url` and expect to update it by hand.

Both validate with no errors.

## ΟΑΣΘ deliberately not added

ΟΑΣΘ publishes the same Thessaloniki network as ΟΣΕΘ. Folding Greek and Latin homoglyphs in the route names (`01Α` against `01A`), the two share 208 of 245 and 227 routes, and 3,158 stops sit at identical coordinates. ΟΑΣΘ has the better URL, stable rather than dated, but it has not been republished since April and its data expired in June, so the stability buys nothing. One network, one feed.

## File rename

Both Greek feeds now come from the same portal, so `geodata.gov.gr.dmfr.json` is renamed to `data.gov.gr.dmfr.json`. Its old URL survives in `static_historic` on the ΟΑΣΑ record.

## Note for the next update

ΣΤΑΣΥ publishes `agency_lang` as `hi`, which is wrong, and has no `calendar.txt`, only `calendar_dates` covering a two month window.

## Test plan

- `dmfr format`, `dmfr lint`, `check-jsonschema` and `validate-feeds.py` all clean.
- `transitland validate` on both new sources reports no errors.