### PR TITLE
Point Swiss feed (f-u0-switzerland) at the 2026 timetable dataset

### DIFF
--- a/feeds/opentransportdata.swiss.dmfr.json
+++ b/feeds/opentransportdata.swiss.dmfr.json
@@ -6,8 +6,9 @@
       "name": "SBB/SKI+ Switzerland Mobility Open Data Feed",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://data.opentransportdata.swiss/en/dataset/timetable-2025-gtfs2020/permalink",
+        "static_current": "https://data.opentransportdata.swiss/en/dataset/timetable-2026-gtfs2020/permalink",
         "static_historic": [
+          "https://data.opentransportdata.swiss/en/dataset/timetable-2025-gtfs2020/permalink",
           "https://opentransportdata.swiss/en/dataset/timetable-2024-gtfs2020/permalink",
           "https://opentransportdata.swiss/en/dataset/timetable-2023-gtfs2020/permalink",
           "https://opentransportdata.swiss/de/dataset/timetable-2022-gtfs2020/permalink"


### PR DESCRIPTION
## Problem

`f-u0-switzerland` has been failing to fetch with `response status code: 401` and is serving expired data.

The feed's `static_current` points at the `timetable-2025-gtfs2020` dataset. Switzerland rolls its GTFS dataset over each timetable year, and the 2025 dataset has been retired — that URL now returns **401**:

```
$ curl -sIL https://data.opentransportdata.swiss/en/dataset/timetable-2025-gtfs2020/permalink
HTTP/2 401
```

As a result the newest imported feed version is from **2025-12-15**, with service dates ending **2025-12-18** — so the feed currently returns no trips for any present-day query.

## Fix

Point `static_current` at the current `timetable-2026-gtfs2020` dataset and move the 2025 URL into `static_historic`, per the "How to Update an Existing Feed" instructions.

Verified the new URL serves a current feed:

```
$ curl -sL -o ch.zip -w "%{http_code} %{size_download}\n" \
    https://data.opentransportdata.swiss/en/dataset/timetable-2026-gtfs2020/permalink
200 212924701
```

`feed_info.txt` from that download:

| field | value |
|---|---|
| `feed_publisher_name` | SBB |
| `feed_version` | 20260808 |
| `feed_start_date` | 20251214 |
| `feed_end_date` | 20261212 |

Contents look healthy — 473 agencies and ~5,100 routes, including 912 rail routes across SBB, BLS, RhB, SOB, THURBO, Zentralbahn, MGB and others.

## Checks run locally

- `transitland dmfr format` — no changes beyond the two lines in this diff
- `transitland dmfr lint feeds/opentransportdata.swiss.dmfr.json` — *Formatted properly*
- `check-jsonschema` against `dmfr.schema-v0.6.0.json` — ok
- `scripts/validate-feeds.py` — passes

## Note for maintainers

Because the dataset slug embeds the timetable year, this URL will retire again at the next rollover (roughly December 2026, with the 2027 dataset appearing early in the year). It might be worth an automated bump similar to the existing GBFS/Japan feed updater workflows, if that's of interest — happy to follow up.
