### PR TITLE
Add North Macedonian, Moldovan and Kosovan rail feeds

### DIFF
--- a/feeds/hoermalmeister.github.io.dmfr.json
+++ b/feeds/hoermalmeister.github.io.dmfr.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.6.0.json",
+  "feeds": [
+    {
+      "id": "f-cfm~md",
+      "name": "Calea Ferată din Moldova",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://hoermalmeister.github.io/gtfs-rehost/cfm/cfm.zip"
+      },
+      "license": {
+        "url": "https://github.com/hoermalmeister/gtfs-rehost"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-cfm~md",
+          "name": "Calea Ferată din Moldova",
+          "short_name": "CFM",
+          "website": "http://cfm.md",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "CFM"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "f-trainkos~xk",
+      "name": "Trainkos",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://hoermalmeister.github.io/gtfs-rehost/trainkos/trainkos.zip"
+      },
+      "license": {
+        "url": "https://github.com/hoermalmeister/gtfs-rehost"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-trainkos~xk",
+          "name": "Trainkos Sh.A.",
+          "short_name": "Trainkos",
+          "website": "https://www.trainkos.com",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "KOS"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "f-zrsm~mk",
+      "name": "ŽRSM Transport",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://hoermalmeister.github.io/gtfs-rehost/mzi/mzi.zip"
+      },
+      "license": {
+        "url": "https://github.com/hoermalmeister/gtfs-rehost"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-zrsm~mk",
+          "name": "ŽRSM Transport a.d.",
+          "short_name": "ŽRSM",
+          "website": "https://mzt.mk/",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "ZRSM"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds three national rail feeds:

- North Macedonia — ŽRSM Transport
- Moldova — Calea Ferată din Moldova
- Kosovo — Trainkos

None of these three currently has a rail feed in the atlas. Each network runs only a handful of passenger trains a day, so the trip counts are small but correct.

Source: https://github.com/hoermalmeister/gtfs-rehost