### PR TITLE
Update Romanian railway feed URL and add TCDD Taşımacılık

### DIFF
--- a/feeds/github.com.dmfr.json
+++ b/feeds/github.com.dmfr.json
@@ -270,10 +270,37 @@
       ]
     },
     {
+      "id": "f-tcdd~tr",
+      "name": "TCDD Taşımacılık",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://github.com/yasinkaraaslan/tcdd-gtfs/raw/main/output/tcdd.zip"
+      },
+      "license": {
+        "url": "https://github.com/yasinkaraaslan/tcdd-gtfs"
+      },
+      "operators": [
+        {
+          "onestop_id": "o-tcdd~tr",
+          "name": "TCDD Taşımacılık A.Ş.",
+          "short_name": "TCDD",
+          "website": "https://www.tcddtasimacilik.gov.tr",
+          "associated_feeds": [
+            {
+              "gtfs_agency_id": "tcdd-tasimacilik"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "f-u8-romania~interregionalcalatori~regiotrans~cfrcălători~softrans~trans",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://github.com/vasile/data.gov.ro-gtfs-exporter/archive/feature/dataset-2025.zip"
+        "static_current": "https://jbb.ghsq.de/gtfs/ro-railway.gtfs.zip",
+        "static_historic": [
+          "https://github.com/vasile/data.gov.ro-gtfs-exporter/archive/feature/dataset-2025.zip"
+        ]
       }
     },
     {


### PR DESCRIPTION
**Romania** — the current URL's calendar expired on 2025-12-13 and returns no future service. This points the feed at a maintained rebuild of the same national dataset; the previous URL is kept in `static_historic`.

**Turkey** — adds TCDD Taşımacılık, the national railway. The atlas currently has İzmir urban transport but no Turkish national rail.