### PR TITLE
Update Luxembourg national feed URL

### DIFF
--- a/feeds/openov.lu.dmfr.json
+++ b/feeds/openov.lu.dmfr.json
@@ -5,12 +5,17 @@
       "id": "f-u0-openov~lu",
       "spec": "gtfs",
       "urls": {
-        "static_current": "http://openov.lu/data/gtfs/gtfs-openov-lu.zip"
+        "static_current": "https://download.data.public.lu/resources/horaires-et-arrets-des-transport-publics-gtfs/20260806-071316/gtfs-20260805-20261011.zip",
+        "static_historic": [
+          "http://openov.lu/data/gtfs/gtfs-openov-lu.zip"
+        ]
       },
       "license": {
-        "url": "http://openov.lu/data/gtfs/LICENSE.TXT",
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes"
+        "spdx_identifier": "CC-BY-4.0",
+        "url": "https://data.public.lu/en/datasets/horaires-et-arrets-des-transport-publics-gtfs/"
+      },
+      "tags": {
+        "unstable_url": "true"
       },
       "operators": [
         {
@@ -20,7 +25,7 @@
           "website": "http://cfl.lu",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "2"
+              "gtfs_agency_id": "171"
             }
           ]
         },
@@ -31,7 +36,7 @@
           "website": "http://mobiliteit.lu",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "3"
+              "gtfs_agency_id": "1"
             }
           ]
         },
@@ -42,7 +47,7 @@
           "website": "http://tice.lu",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "4"
+              "gtfs_agency_id": "16"
             }
           ]
         },
@@ -53,7 +58,7 @@
           "website": "http://autobus.lu",
           "associated_feeds": [
             {
-              "gtfs_agency_id": "1"
+              "gtfs_agency_id": "6"
             }
           ]
         }


### PR DESCRIPTION
openov.lu was last fetched in October 2024 and its calendar expired on 2024-12-14. This points the feed at the official data.public.lu publication and updates the operator agency IDs to match it.

The publisher issues dated weekly snapshots rather than a stable URL, so the feed is tagged `unstable_url`.