### PR TITLE
British Columbia

### DIFF
--- a/feeds/apps2.saskatoon.ca.dmfr.json
+++ b/feeds/apps2.saskatoon.ca.dmfr.json
@@ -25,7 +25,7 @@
     {
       "onestop_id": "o-c9k0-saskatoontransit",
       "name": "Saskatoon Transit",
-      "website": "http://transit.saskatoon.ca",
+      "website": "https://saskatoontransit.ca",
       "associated_feeds": [
         {
           "feed_onestop_id": "f-c9k0-saskatoontransit"

--- a/feeds/aquabusferries.github.io.dmfr.json
+++ b/feeds/aquabusferries.github.io.dmfr.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.6.0.json",
+  "feeds": [
+    {
+      "id": "f-c2b2-aquabus~bc~ca",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://aquabusferries.github.io/gtfs-feed/aquabus-bc-ca.zip"
+      }
+    }
+  ]
+}

--- a/feeds/bctracker.ca.dmfr.json
+++ b/feeds/bctracker.ca.dmfr.json
@@ -5,7 +5,10 @@
       "id": "f-denman~bc~ca",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://bctracker.ca/feeds/denman/denman-feed.zip"
+        "static_current": "https://github.com/colinjstepney/Stepney-Transit-Consulting/raw/refs/heads/main/DENMAN_feed/feed-Denman.zip",
+        "static_historic": [
+          "https://bctracker.ca/feeds/denman/denman-feed.zip"
+        ]
       },
       "tags": {
         "unofficial": "true"
@@ -15,7 +18,10 @@
       "id": "f-gabriola~bc~ca",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://bctracker.ca/feeds/gabriola/gabriola-feed.zip"
+        "static_current": "https://github.com/colinjstepney/Stepney-Transit-Consulting/raw/refs/heads/main/GABRIOLA_feed/feed-GERTIE.zip",
+        "static_historic": [
+          "https://bctracker.ca/feeds/gabriola/gabriola-feed.zip"
+        ]
       },
       "tags": {
         "unofficial": "true"
@@ -25,7 +31,40 @@
       "id": "f-hornby~bc~ca",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://bctracker.ca/feeds/hornby/hornby-feed.zip"
+        "static_current": "https://github.com/colinjstepney/Stepney-Transit-Consulting/raw/refs/heads/main/HORNBY_feed/feed-hornby.zip",
+        "static_historic": [
+          "https://bctracker.ca/feeds/hornby/hornby-feed.zip"
+        ]
+      },
+      "tags": {
+        "unofficial": "true"
+      }
+    },
+    {
+      "id": "f-mountain~man~mikes~bc~ca",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://github.com/colinjstepney/Stepney-Transit-Consulting/raw/refs/heads/main/MMM_feed/feed-MMM.zip"
+      },
+      "tags": {
+        "unofficial": "true"
+      }
+    },
+    {
+      "id": "f-protection~island~bc~ca",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://github.com/colinjstepney/Stepney-Transit-Consulting/raw/refs/heads/main/PROTECTIONISLAND_feed/feed-ProtectionIsland.zip"
+      },
+      "tags": {
+        "unofficial": "true"
+      }
+    },
+    {
+      "id": "f-tofino~shuttle~bc~ca",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://github.com/colinjstepney/Stepney-Transit-Consulting/raw/refs/heads/main/TOFINO_feed/feed-tofino.zip"
       },
       "tags": {
         "unofficial": "true"
@@ -35,7 +74,10 @@
       "id": "f-west~coast~trail~express~bc~ca",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://bctracker.ca/feeds/trailbus/trailbus-feed.zip"
+        "static_current": "https://github.com/colinjstepney/Stepney-Transit-Consulting/raw/refs/heads/main/TRAILBUS_feed/feed-trailbus.zip",
+        "static_historic": [
+          "https://bctracker.ca/feeds/trailbus/trailbus-feed.zip"
+        ]
       },
       "tags": {
         "unofficial": "true"

--- a/feeds/bctransit.com.dmfr.json
+++ b/feeds/bctransit.com.dmfr.json
@@ -9,6 +9,20 @@
       }
     },
     {
+      "id": "f-bctransit~100~mile~house~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://bct.tmix.se/gtfs-realtime/vehicleupdates.pb?operatorIds=34",
+        "realtime_trip_updates": "https://bct.tmix.se/gtfs-realtime/tripupdates.pb?operatorIds=34",
+        "realtime_alerts": "https://bct.tmix.se/gtfs-realtime/alerts.pb?operatorIds=34"
+      },
+      "license": {
+        "url": "https://www.bctransit.com/open-data/terms-of-use",
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes"
+      }
+    },
+    {
       "id": "f-bctransit~ashcroft~cache~creek~clinton",
       "spec": "gtfs",
       "urls": {
@@ -16,10 +30,38 @@
       }
     },
     {
+      "id": "f-bctransit~ashcroft~cache~creek~clinton~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://bct.tmix.se/gtfs-realtime/vehicleupdates.pb?operatorIds=38",
+        "realtime_trip_updates": "https://bct.tmix.se/gtfs-realtime/tripupdates.pb?operatorIds=38",
+        "realtime_alerts": "https://bct.tmix.se/gtfs-realtime/alerts.pb?operatorIds=38"
+      },
+      "license": {
+        "url": "https://www.bctransit.com/open-data/terms-of-use",
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes"
+      }
+    },
+    {
       "id": "f-bctransit~clearwater",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://bct.tmix.se/Tmix.Cap.TdExport.WebApi/gtfs/?operatorIds=35"
+      }
+    },
+    {
+      "id": "f-bctransit~clearwater~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://bct.tmix.se/gtfs-realtime/vehicleupdates.pb?operatorIds=35",
+        "realtime_trip_updates": "https://bct.tmix.se/gtfs-realtime/tripupdates.pb?operatorIds=35",
+        "realtime_alerts": "https://bct.tmix.se/gtfs-realtime/alerts.pb?operatorIds=35"
+      },
+      "license": {
+        "url": "https://www.bctransit.com/open-data/terms-of-use",
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes"
       }
     },
     {
@@ -70,6 +112,20 @@
       }
     },
     {
+      "id": "f-bctransit~hazeltons~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://bct.tmix.se/gtfs-realtime/vehicleupdates.pb?operatorIds=26",
+        "realtime_trip_updates": "https://bct.tmix.se/gtfs-realtime/tripupdates.pb?operatorIds=26",
+        "realtime_alerts": "https://bct.tmix.se/gtfs-realtime/alerts.pb?operatorIds=26"
+      },
+      "license": {
+        "url": "https://www.bctransit.com/open-data/terms-of-use",
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes"
+      }
+    },
+    {
       "id": "f-bctransit~merritt",
       "spec": "gtfs",
       "urls": {
@@ -77,10 +133,38 @@
       }
     },
     {
+      "id": "f-bctransit~merritt~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://bct.tmix.se/gtfs-realtime/vehicleupdates.pb?operatorIds=37",
+        "realtime_trip_updates": "https://bct.tmix.se/gtfs-realtime/tripupdates.pb?operatorIds=37",
+        "realtime_alerts": "https://bct.tmix.se/gtfs-realtime/alerts.pb?operatorIds=37"
+      },
+      "license": {
+        "url": "https://www.bctransit.com/open-data/terms-of-use",
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes"
+      }
+    },
+    {
       "id": "f-bctransit~mount~waddington",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://bct.tmix.se/Tmix.Cap.TdExport.WebApi/gtfs/?operatorIds=17"
+      }
+    },
+    {
+      "id": "f-bctransit~mount~waddington~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://bct.tmix.se/gtfs-realtime/vehicleupdates.pb?operatorIds=17",
+        "realtime_trip_updates": "https://bct.tmix.se/gtfs-realtime/tripupdates.pb?operatorIds=17",
+        "realtime_alerts": "https://bct.tmix.se/gtfs-realtime/alerts.pb?operatorIds=17"
+      },
+      "license": {
+        "url": "https://www.bctransit.com/open-data/terms-of-use",
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes"
       }
     },
     {
@@ -107,6 +191,20 @@
       "spec": "gtfs",
       "urls": {
         "static_current": "https://bct.tmix.se/Tmix.Cap.TdExport.WebApi/gtfs/?operatorIds=50"
+      }
+    },
+    {
+      "id": "f-bctransit~pemberton~valley~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://bct.tmix.se/gtfs-realtime/vehicleupdates.pb?operatorIds=50",
+        "realtime_trip_updates": "https://bct.tmix.se/gtfs-realtime/tripupdates.pb?operatorIds=50",
+        "realtime_alerts": "https://bct.tmix.se/gtfs-realtime/alerts.pb?operatorIds=50"
+      },
+      "license": {
+        "url": "https://www.bctransit.com/open-data/terms-of-use",
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes"
       }
     },
     {
@@ -173,10 +271,38 @@
       }
     },
     {
+      "id": "f-bctransit~quesnel~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://bct.tmix.se/gtfs-realtime/vehicleupdates.pb?operatorIds=32",
+        "realtime_trip_updates": "https://bct.tmix.se/gtfs-realtime/tripupdates.pb?operatorIds=32",
+        "realtime_alerts": "https://bct.tmix.se/gtfs-realtime/alerts.pb?operatorIds=32"
+      },
+      "license": {
+        "url": "https://www.bctransit.com/open-data/terms-of-use",
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes"
+      }
+    },
+    {
       "id": "f-bctransit~revelstoke",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://bct.tmix.se/Tmix.Cap.TdExport.WebApi/gtfs/?operatorIds=36"
+      }
+    },
+    {
+      "id": "f-bctransit~revelstoke~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://bct.tmix.se/gtfs-realtime/vehicleupdates.pb?operatorIds=36",
+        "realtime_trip_updates": "https://bct.tmix.se/gtfs-realtime/tripupdates.pb?operatorIds=36",
+        "realtime_alerts": "https://bct.tmix.se/gtfs-realtime/alerts.pb?operatorIds=36"
+      },
+      "license": {
+        "url": "https://www.bctransit.com/open-data/terms-of-use",
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes"
       }
     },
     {
@@ -187,10 +313,38 @@
       }
     },
     {
+      "id": "f-bctransit~salt~spring~island~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://bct.tmix.se/gtfs-realtime/vehicleupdates.pb?operatorIds=39",
+        "realtime_trip_updates": "https://bct.tmix.se/gtfs-realtime/tripupdates.pb?operatorIds=39",
+        "realtime_alerts": "https://bct.tmix.se/gtfs-realtime/alerts.pb?operatorIds=39"
+      },
+      "license": {
+        "url": "https://www.bctransit.com/open-data/terms-of-use",
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes"
+      }
+    },
+    {
       "id": "f-bctransit~smithers",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://bct.tmix.se/Tmix.Cap.TdExport.WebApi/gtfs/?operatorIds=31"
+      }
+    },
+    {
+      "id": "f-bctransit~smithers~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://bct.tmix.se/gtfs-realtime/vehicleupdates.pb?operatorIds=31",
+        "realtime_trip_updates": "https://bct.tmix.se/gtfs-realtime/tripupdates.pb?operatorIds=31",
+        "realtime_alerts": "https://bct.tmix.se/gtfs-realtime/alerts.pb?operatorIds=31"
+      },
+      "license": {
+        "url": "https://www.bctransit.com/open-data/terms-of-use",
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes"
       }
     },
     {
@@ -210,10 +364,50 @@
       }
     },
     {
+      "id": "f-bctransit~west~coast",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://bct.tmix.se/Tmix.Cap.TdExport.WebApi/gtfs/?operatorIds=51"
+      },
+      "license": {
+        "url": "https://www.bctransit.com/open-data/terms-of-use",
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes"
+      }
+    },
+    {
+      "id": "f-bctransit~west~coast~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://bct.tmix.se/gtfs-realtime/vehicleupdates.pb?operatorIds=51",
+        "realtime_trip_updates": "https://bct.tmix.se/gtfs-realtime/tripupdates.pb?operatorIds=51",
+        "realtime_alerts": "https://bct.tmix.se/gtfs-realtime/alerts.pb?operatorIds=51"
+      },
+      "license": {
+        "url": "https://www.bctransit.com/open-data/terms-of-use",
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes"
+      }
+    },
+    {
       "id": "f-bctransit~williams~lake",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://bct.tmix.se/Tmix.Cap.TdExport.WebApi/gtfs/?operatorIds=33"
+      }
+    },
+    {
+      "id": "f-bctransit~williams~lake~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://bct.tmix.se/gtfs-realtime/vehicleupdates.pb?operatorIds=33",
+        "realtime_trip_updates": "https://bct.tmix.se/gtfs-realtime/tripupdates.pb?operatorIds=33",
+        "realtime_alerts": "https://bct.tmix.se/gtfs-realtime/alerts.pb?operatorIds=33"
+      },
+      "license": {
+        "url": "https://www.bctransit.com/open-data/terms-of-use",
+        "use_without_attribution": "yes",
+        "create_derived_product": "yes"
       }
     },
     {
@@ -666,10 +860,19 @@
           "feed_onestop_id": "f-bctransit~100~mile~house"
         },
         {
+          "feed_onestop_id": "f-bctransit~100~mile~house~rt"
+        },
+        {
           "feed_onestop_id": "f-bctransit~ashcroft~cache~creek~clinton"
         },
         {
+          "feed_onestop_id": "f-bctransit~ashcroft~cache~creek~clinton~rt"
+        },
+        {
           "feed_onestop_id": "f-bctransit~clearwater"
+        },
+        {
+          "feed_onestop_id": "f-bctransit~clearwater~rt"
         },
         {
           "feed_onestop_id": "f-bctransit~east~kootenay~region"
@@ -687,10 +890,19 @@
           "feed_onestop_id": "f-bctransit~hazeltons"
         },
         {
+          "feed_onestop_id": "f-bctransit~hazeltons~rt"
+        },
+        {
           "feed_onestop_id": "f-bctransit~merritt"
         },
         {
+          "feed_onestop_id": "f-bctransit~merritt~rt"
+        },
+        {
           "feed_onestop_id": "f-bctransit~mount~waddington"
+        },
+        {
+          "feed_onestop_id": "f-bctransit~mount~waddington~rt"
         },
         {
           "feed_onestop_id": "f-bctransit~north~okanagan~region"
@@ -700,6 +912,9 @@
         },
         {
           "feed_onestop_id": "f-bctransit~pemberton~valley"
+        },
+        {
+          "feed_onestop_id": "f-bctransit~pemberton~valley~rt"
         },
         {
           "feed_onestop_id": "f-bctransit~port~alberni"
@@ -723,13 +938,25 @@
           "feed_onestop_id": "f-bctransit~quesnel"
         },
         {
+          "feed_onestop_id": "f-bctransit~quesnel~rt"
+        },
+        {
           "feed_onestop_id": "f-bctransit~revelstoke"
+        },
+        {
+          "feed_onestop_id": "f-bctransit~revelstoke~rt"
         },
         {
           "feed_onestop_id": "f-bctransit~salt~spring~island"
         },
         {
+          "feed_onestop_id": "f-bctransit~salt~spring~island~rt"
+        },
+        {
           "feed_onestop_id": "f-bctransit~smithers"
+        },
+        {
+          "feed_onestop_id": "f-bctransit~smithers~rt"
         },
         {
           "feed_onestop_id": "f-bctransit~south~okanagan~similkameen"
@@ -738,7 +965,16 @@
           "feed_onestop_id": "f-bctransit~south~okanagan~similkameen~rt"
         },
         {
+          "feed_onestop_id": "f-bctransit~west~coast"
+        },
+        {
+          "feed_onestop_id": "f-bctransit~west~coast~rt"
+        },
+        {
           "feed_onestop_id": "f-bctransit~williams~lake"
+        },
+        {
+          "feed_onestop_id": "f-bctransit~williams~lake~rt"
         },
         {
           "feed_onestop_id": "f-c0yu-bctransit~campbellrivertransitsystem"

--- a/feeds/hullo.com.dmfr.json
+++ b/feeds/hullo.com.dmfr.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.6.0.json",
+  "feeds": [
+    {
+      "id": "f-c0-hullo~bc~ca",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://hullo.com/gtfs/gtfs-hullo.zip"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
British Columbia additions and maintenance. Follow-up to #2130 — reviewing that PR turned up gaps across the rest of BC, and chasing those turned up several feeds that were quietly serving dead data.

## BC Transit: parity with the published list

BC Transit publishes static + realtime for **35 systems** at [bctransit.com/open-data](https://www.bctransit.com/open-data/). Atlas carried 34 static and 22 realtime.

- **Realtime added for 12 systems** that had static only: 100 Mile House, Ashcroft-Cache-Creek-Clinton, Clearwater, Hazeltons, Merritt, Mount Waddington, Pemberton Valley, Quesnel, Revelstoke, Salt Spring Island, Smithers, Williams Lake.
- **West Coast Transit** (Tofino/Ucluelet, `operatorIds=51`) was missing entirely — added static + realtime as `f-bctransit~west~coast`.

Atlas now matches exactly: **35 static, 35 realtime, no extras.** All 35 RT/static operatorId pairings re-derived from the finished file and verified consistent.

## Four community feeds were serving expired data

The `bctracker.ca` URLs for Denman, Gabriola (GERTIE), Hornby and West Coast Trail Express all return **200 and parse cleanly** — nothing in CI can flag them — but describe service that ended between Sep 2024 and Sep 2025. BCTracker itself now reads these from the upstream repo that produces them.

| feed | was | now |
|---|---|---|
| denman | 2024-08-01 → 2025-05-30 | 2026-01-01 → 2027-04-30 |
| gabriola (GERTIE) | 2024-06-17 → 2025-09-30 | 2026-06-08 → 2026-12-31 |
| hornby | 2024-01-01 → 2025-05-01 | 2026-06-27 → 2027-06-30 |
| trailbus | 2024-05-01 → 2024-09-30 | 2025-10-01 → 2026-09-30 |

`checksum --raw-dir-sha1` confirmed mirror and upstream are genuinely different feeds rather than recompressions. Old URLs retained in `static_historic`.

## Five operators added

| operator | Onestop ID |
|---|---|
| Hullo (Nanaimo ↔ Vancouver fast ferry) | `f-c0-hullo~bc~ca` |
| Aquabus (False Creek, Vancouver) | `f-c2b2-aquabus~bc~ca` |
| Tofino Free Shuttle | `f-tofino~shuttle~bc~ca` |
| Protection Island Ferry (Nanaimo) | `f-protection~island~bc~ca` |
| Mountain Man Mike's Bus | `f-mountain~man~mikes~bc~ca` |

Saskatoon's operator `website` also updated — the old `http://transit.saskatoon.ca` was redirecting.

## Verification

Every URL fetched and validated with `scripts/validate-changed-feed-urls.py`; `dmfr lint`, the v0.6.0 schema check and `validate-feeds.py` all pass. New Onestop IDs verified globally unique across all feeds in Atlas.

## Checked and deliberately not changed

- **Fraser Valley Express** — MobilityData lists it as a standalone feed, but it's route `66-CFV` inside `operatorIds=13` (162 trips, full Chilliwack↔Lougheed corridor). The standalone URL is also 404. No duplicate needed.
- **Legacy `bctransit.com/data/gtfs/*.zip`** — all 404. Confirms tmix is the only live source.
- **TransLink** — static fresh (239 routes, `feed_version 26SEP_20260909`), single agency covering SkyTrain/SeaBus/West Coast Express. RT correctly 403s without a key, matching its declared `authorization`. No change.
- **No operator records for the new feeds** — none has realtime, an NTD id, or a Wikidata entity, so virtual operators are correct. Wikidata's "False Creek Ferries" (Q5432638) is Aquabus's *competitor*, not Aquabus.

## Notes for review

- New BC Transit records carry the standard license block; **the 12 statics they pair with don't** — a pre-existing gap left alone rather than widening the diff. Happy to backfill.
- `bctracker.ca.dmfr.json` is now named for a host none of its feeds use. Left as-is since the Onestop IDs are what matter and moving records makes an unreadable diff.
- Mountain Man Mike's has a `RequiredFieldError` in `feed_info.txt` — informational, upstream's to fix.
- Dawson Creek (`operatorIds=27`) returns 0 vehicle positions with live trip updates; agency-side, predates this PR.
- **Careful with the labels on bctransit.com/open-data** — they name one community per regional system, so several look like they contradict our feed ids. `operatorIds=22` is labeled "Bulkley-Nechako" but is Prince George; `13` is "Agassiz-Harrison" but is all 38 routes of Central Fraser Valley. All 35 were checked by route-code suffix and stop centroid; every existing Atlas name is correct. Please don't "fix" them to match the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sVpbpqKhw5XnZTtbuhikr
