### PR TITLE
Add EMEL Limassol GTFS-Realtime feed

### DIFF
--- a/feeds/motionbuscard.org.cy.dmfr.json
+++ b/feeds/motionbuscard.org.cy.dmfr.json
@@ -17,10 +17,10 @@
     {
       "id": "f-emel~limassol~cy~rt",
       "spec": "gtfs-rt",
-      "urls": {
-        "realtime_trip_updates": "http://20.19.98.194:8328/Api/api/gtfs-realtime/6",
-        "realtime_vehicle_positions": "http://20.19.98.194:8328/Api/api/gtfs-realtime/6"
-      },
+"urls": {
+  "realtime_vehicle_positions": "http://20.19.98.194:8328/Api/api/gtfs-realtime/6",
+  "realtime_trip_updates": "http://20.19.98.194:8328/Api/api/gtfs-realtime/6"
+},
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "url": "https://www.traffic4cyprus.org.cy/dataset/publictransportrealtime_gtfs_rt",

--- a/feeds/motionbuscard.org.cy.dmfr.json
+++ b/feeds/motionbuscard.org.cy.dmfr.json
@@ -15,6 +15,20 @@
       }
     },
     {
+      "id": "f-emel~limassol~cy~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_trip_updates": "http://20.19.98.194:8328/Api/api/gtfs-realtime/6",
+        "realtime_vehicle_positions": "http://20.19.98.194:8328/Api/api/gtfs-realtime/6"
+      },
+      "license": {
+        "spdx_identifier": "CC-BY-4.0",
+        "url": "https://www.traffic4cyprus.org.cy/dataset/publictransportrealtime_gtfs_rt",
+        "use_without_attribution": "no",
+        "create_derived_product": "yes"
+      }
+    },
+    {
       "id": "f-intercity~buses~cy",
       "spec": "gtfs",
       "urls": {
@@ -89,6 +103,9 @@
       "associated_feeds": [
         {
           "feed_onestop_id": "f-emel~limassol~cy"
+        },
+        {
+          "feed_onestop_id": "f-emel~limassol~cy~rt"
         }
       ]
     },

--- a/feeds/motionbuscard.org.cy.dmfr.json
+++ b/feeds/motionbuscard.org.cy.dmfr.json
@@ -17,10 +17,10 @@
     {
       "id": "f-emel~limassol~cy~rt",
       "spec": "gtfs-rt",
-"urls": {
-  "realtime_vehicle_positions": "http://20.19.98.194:8328/Api/api/gtfs-realtime/6",
-  "realtime_trip_updates": "http://20.19.98.194:8328/Api/api/gtfs-realtime/6"
-},
+      "urls": {
+        "realtime_vehicle_positions": "http://20.19.98.194:8328/Api/api/gtfs-realtime/6",
+        "realtime_trip_updates": "http://20.19.98.194:8328/Api/api/gtfs-realtime/6"
+      },
       "license": {
         "spdx_identifier": "CC-BY-4.0",
         "url": "https://www.traffic4cyprus.org.cy/dataset/publictransportrealtime_gtfs_rt",


### PR DESCRIPTION
Adds the official GTFS-Realtime feed for EMEL (Limassol), Cyprus.

Realtime source:
http://20.19.98.194:8328/Api/api/gtfs-realtime/6

Dataset:
https://www.traffic4cyprus.org.cy/dataset/publictransportrealtime_gtfs_rt

The Cyprus MOTION Open Data documentation states that the GTFS-Realtime API supports an optional operator ID path parameter. EMEL is operator/agency ID 6 in the existing static GTFS feed.

The realtime feed is associated with the existing operator:
o-emel~limassol~cy

License: CC BY 4.0